### PR TITLE
Update onboarding to nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
           fetch-depth: 0 # Fetch all history for cargo-release
           token: ${{ secrets.GITHUB_TOKEN }} # Use GITHUB_TOKEN for pushing commits/tags
 
-      - name: Install Rust toolchain (stable)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain (nightly)
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-release
         run: cargo install cargo-release

--- a/README.md
+++ b/README.md
@@ -21,8 +21,19 @@ The project has achieved a significant milestone, delivering an MVP with a funct
 *   **Stubbed Networking Layer:** `icn-network` defines a `NetworkService` trait, `NetworkMessage` enum (now serializable), and a `StubNetworkService` for simulated P2P interactions.
 *   **Refined Error Handling:** Comprehensive error handling is implemented across all layers. Functions return `Result<T, CommonError>`, using specific error variants defined in `icn-common`. The CLI and Node applications now handle these errors more gracefully, providing better user feedback and exiting with appropriate status codes.
 *   **Repository Hygiene:** Includes `LICENSE` (Apache 2.0), `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `.editorconfig`, `rust-toolchain.toml`, issue templates, and a `CHANGELOG.md`.
+
 *   **CI & Dependabot:** Basic CI pipeline (`ci.yml`) for formatting, linting, testing, and docs. Dependabot is set up for Cargo dependency updates.
 *   **Basic Documentation:** READMEs for each crate, module-level documentation, and an initial `docs/ONBOARDING.md`.
+
+### Rust Toolchain
+
+This repository is pinned to the nightly Rust toolchain via `rust-toolchain.toml`.
+Install it with:
+
+```bash
+rustup toolchain install nightly
+rustup override set nightly
+```
 
 ## Getting Started
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -4,9 +4,10 @@ Welcome to the InterCooperative Network (ICN) Core project! This guide will help
 
 ## 1. Prerequisites
 
-*   **Rust:** Install the latest stable Rust toolchain. You can get it from [rustup.rs](https://rustup.rs/).
-    *   Run `rustup update stable` to ensure you have the most recent version.
-    *   The project uses the `stable` channel, as defined in `rust-toolchain.toml`.
+*   **Rust:** Install the nightly Rust toolchain using [rustup.rs](https://rustup.rs/).
+    *   Run `rustup toolchain install nightly` if you don't already have it.
+    *   Set the override for this repository with `rustup override set nightly`.
+    *   The project requires the `nightly` channel, as defined in `rust-toolchain.toml`.
 *   **Git:** For version control.
 *   **EditorConfig Plugin:** (Recommended) For your IDE/editor to maintain consistent coding styles across the project (uses `.editorconfig`).
 *   **Basic Familiarity:** With Rust programming, `cargo`, and decentralized systems concepts (DIDs, CIDs, P2P) will be helpful.


### PR DESCRIPTION
## Summary
- fix docs to use nightly toolchain
- document nightly toolchain requirement in README
- align release workflow with nightly toolchain

## Testing
- `cargo fmt --all -- --check` *(fails: could not download nightly toolchain)*
- `cargo test --all-features --workspace` *(fails: could not download nightly toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683f6acffa908324b2aa8b8b2d045f34