### PR TITLE
Add icn-ccl README and link from crate overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This workspace is organized into several crates, each with a specific focus:
 
 *   `icn-api`: Provides the primary API endpoints for interacting with ICN nodes, likely via JSON-RPC or gRPC.
 *   `icn-cli`: A command-line interface for users and administrators to manage and interact with ICN nodes and the network.
+*   [`icn-ccl`](icn-ccl/README.md): Implements the Cooperative Contract Language compiler, producing WASM modules for the runtime.
 *   `icn-common`: Contains common data structures, types, utilities, and error definitions shared across multiple ICN crates.
 *   `icn-dag`: Implements or defines interfaces for content-addressed Directed Acyclic Graph (DAG) storage and manipulation, crucial for ICN's data model.
 *   `icn-economics`: Handles the economic protocols of the ICN, including token models (e.g., Mana), ledger management, and transaction logic.

--- a/icn-ccl/README.md
+++ b/icn-ccl/README.md
@@ -1,0 +1,39 @@
+# ICN CCL Crate
+
+This crate provides the compiler for the Cooperative Contract Language (CCL) used in the InterCooperative Network (ICN). It translates CCL source into WebAssembly (WASM) modules and produces metadata describing the contract.
+
+## Purpose
+
+The `icn-ccl` crate is responsible for:
+
+* Parsing and semantically analyzing CCL source files.
+* Optimizing the contract's abstract syntax tree.
+* Generating WASM bytecode and accompanying metadata.
+* Offering helper functions consumed by CLI tools and other crates.
+
+## Basic Usage
+
+Programmatic compilation is available via `compile_ccl_source_to_wasm`:
+
+```rust
+use icn_ccl::compile_ccl_source_to_wasm;
+
+let source = "fn get_cost() -> Mana { return 10; }";
+let (wasm, meta) = compile_ccl_source_to_wasm(source)?;
+```
+
+CLI-oriented helpers live in the `cli` module for tools like `icn-cli` to compile `.ccl` files from disk.
+
+## Integration with Other Crates
+
+* Compiled WASM is executed inside [`icn-runtime`](../crates/icn-runtime/README.md).
+* Contract metadata relies on types from [`icn-common`](../crates/icn-common/README.md).
+* Higher level protocols in [`icn-protocol`](../crates/icn-protocol/README.md) may reference CCL contracts.
+
+## Contributing
+
+Contributions are welcome! Please see the root [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
+
+## License
+
+Licensed under the Apache License, Version 2.0. See [LICENSE](../LICENSE).


### PR DESCRIPTION
## Summary
- document the Cooperative Contract Language compiler in `icn-ccl/README.md`
- link the new README from the crate overview list in the root README

## Testing
- `cargo fmt --all -- --check` *(fails: could not download toolchain)*
- `cargo test --all-features --workspace` *(fails: could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683f6bd045308324a1b356aeea19e418