### PR TITLE
Fix branch instruction mismatch in onboarding docs

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -271,7 +271,7 @@ This makes the system more predictable and easier to debug.
 6.  **Format & Lint:** Run `cargo fmt --all` and `cargo clippy --all -- -D warnings`.
 7.  **Commit Changes:** Use conventional commit messages.
 8.  **Push to Your Fork/Branch.**
-9.  **Create a Pull Request:** Target the `main` branch of the upstream repository. Clearly describe your changes and link the relevant issue.
+9.  **Create a Pull Request:** Target the `develop` branch of the upstream repository. Rebase your feature branch onto `develop` before opening the PR and clearly describe your changes with links to any relevant issues.
 
 ## 7. Next Steps for the Project (and areas for contribution)
 


### PR DESCRIPTION
## Summary
- fix onboarding doc to instruct opening PRs against `develop`

## Testing
- `cargo fmt --all -- --check` *(fails: unsuccessful tunnel)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unsuccessful tunnel)*
- `cargo test --all-features --workspace` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_683f7c99e3f88324808a22e64bfa25e8