### PR TITLE
Update libp2p feature name in network crate

### DIFF
--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -30,9 +30,9 @@ Functions and methods within this crate return `Result<T, CommonError>`, utilizi
 
 The `StubNetworkService` also simulates these errors to help test error handling in dependent crates.
 
-## `with-libp2p` Feature
+## `experimental-libp2p` Feature
 
-This crate includes an optional `with-libp2p` feature. When enabled, it will pull in `libp2p` as a dependency, allowing for the implementation of a `NetworkService` backed by a real libp2p stack.
+This crate includes an optional `experimental-libp2p` feature. Enabling it pulls in the optional `libp2p` and `libp2p-request-response` dependencies, allowing for the implementation of a `NetworkService` backed by a real libp2p stack.
 
 ## Public API Style
 
@@ -48,7 +48,7 @@ The API aims for modularity, allowing different P2P backends to be integrated by
 Please refer to the main `CONTRIBUTING.md` in the root of the `icn-core` repository.
 
 Key areas for future contributions:
-*   Implementing a `Libp2pNetworkService` that utilizes the `libp2p` stack (under the `with-libp2p` feature).
+*   Implementing a `Libp2pNetworkService` that utilizes the `libp2p` stack (under the `experimental-libp2p` feature).
 *   Defining and implementing robust peer discovery mechanisms.
 *   Implementing secure and efficient message serialization and transport.
 *   Adding support for various transport protocols.

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -74,7 +74,7 @@ impl_downcast!(sync NetworkService);
 pub struct StubNetworkService;
 
 // TODO (#issue_url_for_libp2p_integration): Implement `Libp2pNetworkService` that uses a real libp2p stack.
-// This service should be conditionally compiled when the `with-libp2p` feature is enabled.
+// This service should be conditionally compiled when the `experimental-libp2p` feature is enabled.
 // It will involve managing Swarm, Behaviours (e.g., Kademlia, Gossipsub), and transport configurations.
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- reference `experimental-libp2p` feature in icn-network README
- update todo comment in `src/lib.rs`

## Testing
- `cargo test --workspace --all-features` *(fails: unsuccessful tunnel)*
- `cargo test --workspace` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_683ff7506854832499794ce982fa1dfc