### PR TITLE
Add basic network stats

### DIFF
--- a/crates/icn-network/tests/network_stats.rs
+++ b/crates/icn-network/tests/network_stats.rs
@@ -1,0 +1,45 @@
+#[cfg(feature = "experimental-libp2p")]
+mod network_stats {
+    use icn_network::libp2p_service::Libp2pNetworkService;
+    use icn_network::{NetworkMessage, NetworkService};
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn test_network_stats_basic() {
+        let node1 = Libp2pNetworkService::new(None)
+            .await
+            .expect("node1 start");
+        let node1_peer = node1.local_peer_id().clone();
+        sleep(Duration::from_secs(1)).await;
+        let addr = node1
+            .listening_addresses()
+            .into_iter()
+            .next()
+            .expect("node1 addr");
+
+        let node2 = Libp2pNetworkService::new(Some(vec![(node1_peer, addr)]))
+            .await
+            .expect("node2 start");
+
+        sleep(Duration::from_secs(2)).await;
+
+        node2
+            .broadcast_message(NetworkMessage::GossipSub(
+                "test".to_string(),
+                b"hello".to_vec(),
+            ))
+            .await
+            .expect("broadcast");
+
+        sleep(Duration::from_secs(2)).await;
+
+        let stats1 = node1.get_network_stats().await.expect("stats1");
+        let stats2 = node2.get_network_stats().await.expect("stats2");
+
+        assert!(stats1.peer_count >= 1, "node1 peers");
+        assert!(stats2.peer_count >= 1, "node2 peers");
+        assert!(stats2.bytes_sent > 0, "node2 bytes sent");
+        assert!(stats1.bytes_received > 0, "node1 bytes received");
+    }
+}


### PR DESCRIPTION
## Summary
- implement network stat counters in the Libp2p service
- expose a `get_network_stats` API
- add a new integration test using two libp2p nodes
- fix feature gating and request-response initialization

## Testing
- `cargo fmt` *(failed: could not download toolchain)*
- `cargo test --all-features` *(failed: could not download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683fe15b4dc0832484a7e1187d99c91a