### PR TITLE
Switch workspace to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "3"
 
 # Optional: centralize workspace-wide settings
 [workspace.package]
-edition = "2024"
+edition = "2021"
 version = "0.1.0"
 authors = ["InterCooperative Network <dev@intercooperative.network>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- use Rust 2021 edition for the workspace

## Testing
- `cargo check -q`


------
https://chatgpt.com/codex/tasks/task_e_684694d098308324afdc8c8d97b2256f