### PR TITLE
Clean unused imports and variables

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -13,7 +13,7 @@ icn-common = { path = "../icn-common" }
 
 # --- crypto ---
 ed25519-dalek = { version = "2.0.0-pre.3", features = ["rand_core"] }
-rand_core      = "0.6"          # used by dalek's OsRng
+rand_core      = { version = "0.6", features = ["getrandom"] } # used by dalek's OsRng
 # --- DID:key helpers ---
 multibase      = "0.9"          # base-58btc ("z...") encoder/decoder
 # tiny crate that just exposes the unsigned-varint impl used by multicodec

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -16,12 +16,11 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use downcast_rs::{impl_downcast, DowncastSync};
 use std::any::Any;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::collections::HashMap;
 use bincode;
 use log::{info, warn};
 // Removed unused imports for testing Kademlia disabled build
-use libp2p::{PeerId as Libp2pPeerId, Multiaddr};
 
 // --- Core Types ---
 
@@ -183,17 +182,14 @@ pub mod libp2p_service {
         core::upgrade, gossipsub, identity, noise, ping,
         swarm::{NetworkBehaviour, Swarm, SwarmEvent, Config as SwarmConfig},
         tcp, yamux, PeerId as Libp2pPeerId, Transport, dns,
-        kad::{Record as KademliaRecord, RecordKey as KademliaKey, GetRecordOk, 
-              store::MemoryStore, Behaviour as KademliaBehaviour, Config as KademliaConfig, 
-              Event as KademliaEvent, QueryResult as KademliaQueryResult, Quorum, QueryId},
-        request_response::{Behaviour as RequestResponseBehaviour, Codec as RequestResponseCodec, 
-                          Event as RequestResponseEvent, ProtocolSupport},
+        kad::{Record as KademliaRecord, RecordKey as KademliaKey},
+        request_response::{Behaviour as RequestResponseBehaviour, Codec as RequestResponseCodec, ProtocolSupport},
         Multiaddr,
     };
     use tokio::{sync::{mpsc, oneshot}, task};
     use std::sync::{Arc, Mutex};
     use std::str::FromStr;
-    use std::num::NonZero;
+    
 
     // --- Enhanced Statistics and Configuration ---
     
@@ -235,14 +231,12 @@ pub mod libp2p_service {
         messages_received: u64,
         failed_connections: u64,
         message_counts: HashMap<String, MessageTypeStats>,
-        last_bootstrap: Option<Instant>,
         kademlia_peers: usize,
     }
 
     impl EnhancedNetworkStats {
         fn new() -> Self {
             Self {
-                last_bootstrap: Some(Instant::now()),
                 ..Default::default()
             }
         }
@@ -284,6 +278,7 @@ pub mod libp2p_service {
     }
 
     #[derive(Debug)]
+    #[allow(dead_code)]
     enum Command {
         DiscoverPeers {
             target: Option<Libp2pPeerId>,
@@ -502,7 +497,7 @@ pub mod libp2p_service {
                         Some(command) = cmd_rx.recv() => {
                             log::debug!("🔧 [LIBP2P] Received command: {:?}", std::mem::discriminant(&command));
                             match command {
-                                Command::DiscoverPeers { target, rsp } => {
+                                Command::DiscoverPeers { target: _target, rsp } => {
                                     log::debug!("Peer discovery disabled (Kademlia disabled for testing)");
                                     // Return empty peer list since Kademlia is disabled
                                     let peers: Vec<super::PeerId> = Vec::new();

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -532,7 +532,7 @@ impl RuntimeContext {
                     let current_job_id = job.id.clone(); // Clone for use in logs and map keys
 
                     // Get current state from the central job_states map
-                    let mut job_states_guard = self_clone.job_states.lock().await;
+                    let job_states_guard = self_clone.job_states.lock().await;
                     let current_job_state = job_states_guard.get(&current_job_id).cloned();
                     drop(job_states_guard); // Release lock quickly
 

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -1,12 +1,10 @@
 //! This module provides executor-side functionality for running mesh jobs.
 
-use std::collections::HashMap;
 use icn_common::{Did, Cid, CommonError};
 use icn_identity::{ExecutionReceipt as IdentityExecutionReceipt, SigningKey, SignatureBytes /* Removed , generate_ed25519_keypair */};
-use icn_mesh::{JobId, ActualMeshJob, JobSpec, /* ... other mesh types ... */};
+use icn_mesh::{ActualMeshJob, JobSpec /* ... other mesh types ... */};
 use log::{info}; // Removed error
 use std::time::SystemTime;
-use serde_json::Value; // Added for handle_*_job functions
 
 /// Trait for a job executor.
 #[async_trait::async_trait]

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -21,10 +21,9 @@ use icn_common::{Did, NodeInfo, Cid, CommonError};
 use icn_identity;
 use futures;
 use log::{info, debug};
+#[cfg(test)]
 use std::sync::Arc;
 use std::str::FromStr;
-use icn_mesh::ActualMeshJob;
-use context::StubMeshNetworkService;
 
 /// Placeholder function demonstrating use of common types for runtime operations.
 /// This function is not directly part of the Host ABI layer discussed below but serves as an example.
@@ -327,8 +326,8 @@ mod tests {
         let job_json1 = serde_json::to_string(&test_job1).unwrap();
         let job_json2 = serde_json::to_string(&test_job2).unwrap();
 
-        let job_id1 = host_submit_mesh_job(&ctx, &job_json1).await.unwrap();
-        let job_id2 = host_submit_mesh_job(&ctx, &job_json2).await.unwrap();
+        let _job_id1 = host_submit_mesh_job(&ctx, &job_json1).await.unwrap();
+        let _job_id2 = host_submit_mesh_job(&ctx, &job_json2).await.unwrap();
 
         let pending_jobs = host_get_pending_mesh_jobs(&ctx).unwrap();
         assert_eq!(pending_jobs.len(), 2);


### PR DESCRIPTION
## Summary
- enable getrandom feature for rand_core
- quiet unused imports for runtime and node crates
- prefix unused state parameters
- drop unused field from network stats and silence dead code
- tweak variable names and imports to reduce warnings

## Testing
- `cargo check --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_68469dc9b0a08324999854145b665e30