### PR TITLE
[icn-dag] add sled persistence backend

### DIFF
--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -201,19 +201,19 @@ pub fn parse_cid_from_string(cid_str: &str) -> Result<Cid, CommonError> {
         .ok_or_else(|| CommonError::InvalidInputError("Missing 'cidv' prefix".to_string()))?;
     let version: u64 = version_str
         .parse()
-        .map_err(|e| CommonError::InvalidInputError(format!("Invalid version: {}", e)))?;
+        .map_err(|e| CommonError::InvalidInputError(format!("Invalid version: {e}")))?;
 
     let codec: u64 = parts[1]
         .parse()
-        .map_err(|e| CommonError::InvalidInputError(format!("Invalid codec: {}", e)))?;
+        .map_err(|e| CommonError::InvalidInputError(format!("Invalid codec: {e}")))?;
 
     let hash_alg: u64 = parts[2]
         .parse()
-        .map_err(|e| CommonError::InvalidInputError(format!("Invalid hash_alg: {}", e)))?;
+        .map_err(|e| CommonError::InvalidInputError(format!("Invalid hash_alg: {e}")))?;
 
     let hash_bytes = bs58::decode(parts[3])
         .into_vec()
-        .map_err(|e| CommonError::InvalidInputError(format!("Invalid base58 hash: {}", e)))?;
+        .map_err(|e| CommonError::InvalidInputError(format!("Invalid base58 hash: {e}")))?;
 
     Ok(Cid {
         version,

--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -10,6 +10,14 @@ icn-common = { path = "../icn-common" }
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sled = { version = "0.34", optional = true }
+bincode = { version = "1.3", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"
+sled = { version = "0.34", optional = false }
+bincode = { version = "1.3", optional = false }
+
+[features]
+default = ["persist-sled"]
+persist-sled = ["dep:sled", "dep:bincode"]

--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -20,6 +20,7 @@ The API style prioritizes:
 *   **Composability:** Allowing different DAG-based data structures to be built on top.
 *   **Performance:** Efficient handling of DAG operations, especially for large graphs.
 *   **Flexibility:** Supporting different codecs and storage backends where appropriate.
+*   **Pluggable Persistence:** Includes in-memory, file-based, and optional `sled` backends via the `persist-sled` feature.
 
 ## Contributing
 

--- a/crates/icn-dag/src/sled_store.rs
+++ b/crates/icn-dag/src/sled_store.rs
@@ -1,0 +1,71 @@
+use crate::{DagBlock, Cid, CommonError, StorageService};
+use std::path::PathBuf;
+
+#[cfg(feature = "persist-sled")]
+use bincode;
+#[cfg(feature = "persist-sled")]
+use sled;
+
+#[cfg(feature = "persist-sled")]
+#[derive(Debug)]
+pub struct SledDagStore {
+    db: sled::Db,
+    tree_name: String,
+}
+
+#[cfg(feature = "persist-sled")]
+impl SledDagStore {
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let db = sled::open(path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sled DB: {}", e)))?;
+        Ok(Self { db, tree_name: "dag_blocks_v1".into() })
+    }
+
+    fn tree(&self) -> Result<sled::Tree, CommonError> {
+        self.db
+            .open_tree(&self.tree_name)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open tree: {}", e)))
+    }
+}
+
+#[cfg(feature = "persist-sled")]
+impl StorageService<DagBlock> for SledDagStore {
+    fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
+        let tree = self.tree()?;
+        let encoded = bincode::serialize(block)
+            .map_err(|e| CommonError::SerializationError(format!("Failed to serialize block {}: {}", block.cid, e)))?;
+        tree.insert(block.cid.to_string(), encoded)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to insert block {}: {}", block.cid, e)))?;
+        Ok(())
+    }
+
+    fn get(&self, cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
+        let tree = self.tree()?;
+        match tree.get(cid.to_string())
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to get block {}: {}", cid, e)))? {
+            Some(ivec) => {
+                let block: DagBlock = bincode::deserialize(&ivec)
+                    .map_err(|e| CommonError::DeserializationError(format!("Failed to deserialize block {}: {}", cid, e)))?;
+                if &block.cid != cid {
+                    return Err(CommonError::InvalidInputError(format!("CID mismatch for block read from sled: expected {}, found {}", cid, block.cid)));
+                }
+                Ok(Some(block))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        let tree = self.tree()?;
+        tree.remove(cid.to_string())
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to delete block {}: {}", cid, e)))?;
+        Ok(())
+    }
+
+    fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
+        let tree = self.tree()?;
+        let exists = tree.contains_key(cid.to_string())
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to check block {}: {}", cid, e)))?;
+        Ok(exists)
+    }
+}

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -43,7 +43,7 @@ pub fn did_key_from_verifying_key(pk: &VerifyingKey) -> String {
     let mb = multibase_encode(Base::Base58Btc, prefixed_pk_bytes);
 
     // 4. final did string
-    format!("did:key:{}", mb)
+    format!("did:key:{mb}")
 }
 
 /// Convenience wrapper around signing raw bytes with an Ed25519 SigningKey.


### PR DESCRIPTION
## Summary
- add optional `sled` backend and feature flag
- implement `SledDagStore` for persistent DAG storage
- document pluggable persistence backends
- fix clippy lint warnings in common and identity crates

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`)*

------
https://chatgpt.com/codex/tasks/task_e_6846a4a5e62483249d8861efa8fd78bf