### PR TITLE
[ccl] expand parser functionality

### DIFF
--- a/icn-ccl/Cargo.toml
+++ b/icn-ccl/Cargo.toml
@@ -2,8 +2,8 @@
 name = "icn-ccl"
 version = "0.1.0"
 edition = "2021" # Assuming 2021 edition, adjust if needed
-authors.workspace = true
-license.workspace = true
+authors = ["InterCooperative Network <dev@intercooperative.network>"]
+license = "Apache-2.0"
 # description = "Compiler for the Cooperative Contract Language (CCL) to WASM"
 
 [dependencies]
@@ -22,3 +22,5 @@ icn-common = { path = "../crates/icn-common" } # Adjust path as necessary
 [dev-dependencies]
 tempfile = "3.10"
 # Add test dependencies 
+[workspace]
+

--- a/icn-ccl/src/ast.rs
+++ b/icn-ccl/src/ast.rs
@@ -1,5 +1,5 @@
 // icn-ccl/src/ast.rs
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 // Potentially use types from icn_common like Did if they appear in AST
 // use icn_common::Did;
 
@@ -56,7 +56,12 @@ pub enum StatementNode {
     },
     ExpressionStatement(ExpressionNode),
     Return(ExpressionNode),
-    // ... other statement types (if, loop, etc.)
+    If {
+        condition: ExpressionNode,
+        then_block: BlockNode,
+        else_block: Option<BlockNode>,
+    },
+    // ... other statement types (loop, etc.)
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -79,9 +84,18 @@ pub enum ExpressionNode {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum BinaryOperator {
-    Add, Sub, Mul, Div,
-    Eq, Neq, Lt, Gt, Lte, Gte,
-    And, Or,
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Eq,
+    Neq,
+    Lt,
+    Gt,
+    Lte,
+    Gte,
+    And,
+    Or,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -89,7 +103,7 @@ pub enum ActionNode {
     Allow,
     Deny,
     Charge(ExpressionNode), // e.g., charge actor.mana(amount_expr)
-    // ... other policy-specific actions
+                            // ... other policy-specific actions
 }
 
 // Helper function to convert Pest pairs to AST (simplified example)
@@ -98,4 +112,4 @@ pub enum ActionNode {
 //         // ... conversion logic ...
 //         _ => unimplemented!("Rule not implemented in AST conversion: {:?}", pair.as_rule()),
 //     }
-// } 
+// }

--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -8,6 +8,7 @@ COMMENT = _{ "//" ~ (!NEWLINE ~ ANY)* }
 identifier = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 integer_literal = @{ ASCII_DIGIT+ }
 string_literal = @{ "\"" ~ (ASCII_ALPHANUMERIC | " ")* ~ "\"" } // Simplified
+boolean_literal = { "true" | "false" }
 
 // Top-level: A CCL policy is a sequence of statements or definitions
 policy = { SOI ~ (function_definition | policy_statement)* ~ EOI }
@@ -24,20 +25,41 @@ import_statement = { "import" ~ string_literal ~ "as" ~ identifier ~ ";" }
 
 // Example: Block of statements
 block = { "{" ~ statement* ~ "}" }
-statement = { let_statement | expression_statement | return_statement }
+statement = { let_statement | expression_statement | return_statement | if_statement }
 let_statement = { "let" ~ identifier ~ "=" ~ expression ~ ";" }
 expression_statement = { expression ~ ";" }
 return_statement = { "return" ~ expression ~ ";" }
+if_statement = { "if" ~ expression ~ block ~ ("else" ~ block)? }
 
 // Example: Expressions (highly simplified)
-expression = { term ~ (("==" | "!=" | "<" | ">" | "+" | "-") ~ term)* }
-term = { factor ~ (("*" | "/") ~ factor)* }
-factor = { integer_literal | boolean_literal | string_literal | identifier | "(" ~ expression ~ ")" | function_call }
-boolean_literal = { "true" | "false" }
+expression = { logical_or }
+logical_or = { logical_and ~ (OR_OP ~ logical_and)* }
+logical_and = { equality ~ (AND_OP ~ equality)* }
+equality = { comparison ~ ((EQ_OP | NEQ_OP) ~ comparison)* }
+comparison = { addition ~ ((LT_OP | LTE_OP | GT_OP | GTE_OP) ~ addition)* }
+addition = { multiplication ~ ((ADD_OP | SUB_OP) ~ multiplication)* }
+multiplication = { primary ~ ((MUL_OP | DIV_OP) ~ primary)* }
+primary = { integer_literal | boolean_literal | string_literal | function_call | identifier | "(" ~ expression ~ ")" }
 function_call = { identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 
+ADD_OP = { "+" }
+SUB_OP = { "-" }
+MUL_OP = { "*" }
+DIV_OP = { "/" }
+EQ_OP  = { "==" }
+NEQ_OP = { "!=" }
+LT_OP  = { "<" }
+LTE_OP = { "<=" }
+GT_OP  = { ">" }
+GTE_OP = { ">=" }
+AND_OP = { "&&" }
+OR_OP  = { "||" }
+
 // Example: Actions (specific to policy rules)
-action = { "allow" | "deny" | "charge" ~ expression }
+action = { ALLOW | DENY | CHARGE ~ expression }
+ALLOW = { "allow" }
+DENY = { "deny" }
+CHARGE = { "charge" }
 
 // Catch-all for errors or further development
 // UNEXPECTED = _{ ANY } // Uncomment for debugging grammar issues 

--- a/icn-ccl/src/parser.rs
+++ b/icn-ccl/src/parser.rs
@@ -1,87 +1,217 @@
 // icn-ccl/src/parser.rs
+use crate::ast::{
+    AstNode, BlockNode, ExpressionNode, PolicyStatementNode, StatementNode, TypeAnnotationNode,
+};
+use crate::error::CclError;
 use pest::iterators::Pair;
 use pest::Parser;
 use pest_derive::Parser;
-use crate::ast::{AstNode, BlockNode, ExpressionNode, PolicyStatementNode, StatementNode, TypeAnnotationNode};
-use crate::error::CclError;
 
 #[derive(Parser)]
 #[grammar = "grammar/ccl.pest"] // Path to your Pest grammar file
 pub struct CclParser;
 
-// New helper function to handle the leaf nodes of an expression
+// Parse a simple literal or identifier expression
 fn parse_literal_expression(pair: Pair<Rule>) -> Result<ExpressionNode, CclError> {
     match pair.as_rule() {
         Rule::integer_literal => {
-            let value = pair.as_str().parse::<i64>()
+            let value = pair
+                .as_str()
+                .parse::<i64>()
                 .map_err(|e| CclError::ParsingError(format!("Invalid integer: {}", e)))?;
             Ok(ExpressionNode::IntegerLiteral(value))
         }
-        Rule::boolean_literal => {
-            match pair.as_str() {
-                "true" => Ok(ExpressionNode::BooleanLiteral(true)),
-                "false" => Ok(ExpressionNode::BooleanLiteral(false)),
-                _ => Err(CclError::ParsingError("Invalid boolean literal".to_string())),
-            }
-        }
+        Rule::boolean_literal => match pair.as_str() {
+            "true" => Ok(ExpressionNode::BooleanLiteral(true)),
+            "false" => Ok(ExpressionNode::BooleanLiteral(false)),
+            _ => Err(CclError::ParsingError(
+                "Invalid boolean literal".to_string(),
+            )),
+        },
         Rule::string_literal => {
             // Need to strip quotes from string_literal if they are part of the pair's string value
             let s = pair.as_str();
             if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-                Ok(ExpressionNode::StringLiteral(s[1..s.len()-1].to_string()))
+                Ok(ExpressionNode::StringLiteral(s[1..s.len() - 1].to_string()))
             } else {
                 // This case should ideally not be hit if Pest grammar for string_literal is correct e.g. `"\"" ~ inner_chars ~ "\""`
                 // If `string_literal = @{ "\"" ~ inner ~ "\"" }` then `as_str()` includes quotes.
                 Ok(ExpressionNode::StringLiteral(s.to_string())) // Fallback, or error
             }
         }
-        Rule::identifier => {
-            Ok(ExpressionNode::Identifier(pair.as_str().to_string()))
+        Rule::identifier => Ok(ExpressionNode::Identifier(pair.as_str().to_string())),
+        _ => Err(CclError::ParsingError(format!(
+            "Unsupported literal expression type: {:?}",
+            pair.as_rule()
+        ))),
+    }
+}
+
+fn parse_function_call(pair: Pair<Rule>) -> Result<ExpressionNode, CclError> {
+    let mut inner = pair.into_inner();
+    let name_pair = inner
+        .next()
+        .ok_or_else(|| CclError::ParsingError("Function call missing name".to_string()))?;
+    let name = name_pair.as_str().to_string();
+    let mut args = Vec::new();
+    for arg_pair in inner {
+        if arg_pair.as_rule() == Rule::expression {
+            args.push(parse_expression(arg_pair)?);
         }
-        // TODO: Rule::function_call, Rule::parenthesized_expression, etc.
-        _ => Err(CclError::ParsingError(format!("Unsupported literal/factor expression type: {:?}", pair.as_rule()))),
+    }
+    Ok(ExpressionNode::FunctionCall {
+        name,
+        arguments: args,
+    })
+}
+
+fn parse_primary(pair: Pair<Rule>) -> Result<ExpressionNode, CclError> {
+    match pair.as_rule() {
+        Rule::integer_literal | Rule::boolean_literal | Rule::string_literal | Rule::identifier => {
+            parse_literal_expression(pair)
+        }
+        Rule::function_call => parse_function_call(pair),
+        Rule::expression => parse_expression(pair),
+        Rule::primary => {
+            let inner = pair.into_inner().next().ok_or_else(|| {
+                CclError::ParsingError("Primary expression missing inner".to_string())
+            })?;
+            parse_primary(inner)
+        }
+        _ => Err(CclError::ParsingError(format!(
+            "Unsupported primary expression: {:?}",
+            pair.as_rule()
+        ))),
     }
 }
 
 fn parse_expression(pair: Pair<Rule>) -> Result<ExpressionNode, CclError> {
-    // expression = { term ~ (binary_operator ~ term)* }
-    // term       = { factor ~ (multiplicative_operator ~ factor)* }
-    // factor     = { primary_expression | unary_operator ~ primary_expression }
-    // primary_expression = { literal | identifier | parenthesized_expression | function_call }
-    // literal    = { integer_literal | boolean_literal | string_literal }
-
     match pair.as_rule() {
         Rule::expression => {
-            // For this minimal implementation, we assume the expression is just a single literal without operators.
-            // expression -> term -> factor -> literal_pair
-            let mut inner_rules = pair.into_inner(); // consumes the expression pair
-            let term_pair = inner_rules.next()
-                .ok_or_else(|| CclError::ParsingError("Expression missing term".to_string()))?;
-            
-            // TODO: Handle binary operators if inner_rules.next() is not None here
-
-            // Now parse the term_pair
-            // term = { factor ~ (("*" | "/") ~ factor)* }
-            let mut term_inner_rules = term_pair.into_inner();
-            let factor_pair = term_inner_rules.next()
-                .ok_or_else(|| CclError::ParsingError("Term missing factor".to_string()))?;
-
-            // TODO: Handle multiplicative operators if term_inner_rules.next() is not None here
-
-            // Now parse the factor_pair
-            // factor = { integer_literal | boolean_literal | string_literal | identifier | "(" ~ expression ~ ")" | function_call }
-            // For the simple case `return 42;`, factor_pair directly contains integer_literal.
-            let literal_or_primary_pair = factor_pair.into_inner().next()
-                 .ok_or_else(|| CclError::ParsingError("Factor missing primary expression".to_string()))?;
-
-            parse_literal_expression(literal_or_primary_pair)
+            let inner = pair
+                .into_inner()
+                .next()
+                .ok_or_else(|| CclError::ParsingError("Expression missing inner".to_string()))?;
+            parse_expression(inner)
         }
-        // This case allows calling parse_expression with a rule that is already a literal (e.g. from other parser functions if needed)
-        // However, the main call from `parse_block` will pass `Rule::expression`.
-        Rule::integer_literal | Rule::boolean_literal | Rule::string_literal | Rule::identifier => {
-            parse_literal_expression(pair)
+        Rule::logical_or => {
+            let mut inner = pair.into_inner();
+            let mut expr = parse_expression(inner.next().unwrap())?;
+            while let Some(op) = inner.next() {
+                let right = parse_expression(inner.next().unwrap())?;
+                let op = match op.as_rule() {
+                    Rule::OR_OP => BinaryOperator::Or,
+                    _ => unreachable!(),
+                };
+                expr = ExpressionNode::BinaryOp {
+                    left: Box::new(expr),
+                    operator: op,
+                    right: Box::new(right),
+                };
+            }
+            Ok(expr)
         }
-        _ => Err(CclError::ParsingError(format!("Unsupported top-level rule for expression parsing: {:?}", pair.as_rule()))),
+        Rule::logical_and => {
+            let mut inner = pair.into_inner();
+            let mut expr = parse_expression(inner.next().unwrap())?;
+            while let Some(op) = inner.next() {
+                let right = parse_expression(inner.next().unwrap())?;
+                let op = match op.as_rule() {
+                    Rule::AND_OP => BinaryOperator::And,
+                    _ => unreachable!(),
+                };
+                expr = ExpressionNode::BinaryOp {
+                    left: Box::new(expr),
+                    operator: op,
+                    right: Box::new(right),
+                };
+            }
+            Ok(expr)
+        }
+        Rule::equality => {
+            let mut inner = pair.into_inner();
+            let mut expr = parse_expression(inner.next().unwrap())?;
+            while let Some(op) = inner.next() {
+                let right = parse_expression(inner.next().unwrap())?;
+                let op = match op.as_rule() {
+                    Rule::EQ_OP => BinaryOperator::Eq,
+                    Rule::NEQ_OP => BinaryOperator::Neq,
+                    _ => unreachable!(),
+                };
+                expr = ExpressionNode::BinaryOp {
+                    left: Box::new(expr),
+                    operator: op,
+                    right: Box::new(right),
+                };
+            }
+            Ok(expr)
+        }
+        Rule::comparison => {
+            let mut inner = pair.into_inner();
+            let mut expr = parse_expression(inner.next().unwrap())?;
+            while let Some(op) = inner.next() {
+                let right = parse_expression(inner.next().unwrap())?;
+                let op = match op.as_rule() {
+                    Rule::LT_OP => BinaryOperator::Lt,
+                    Rule::LTE_OP => BinaryOperator::Lte,
+                    Rule::GT_OP => BinaryOperator::Gt,
+                    Rule::GTE_OP => BinaryOperator::Gte,
+                    _ => unreachable!(),
+                };
+                expr = ExpressionNode::BinaryOp {
+                    left: Box::new(expr),
+                    operator: op,
+                    right: Box::new(right),
+                };
+            }
+            Ok(expr)
+        }
+        Rule::addition => {
+            let mut inner = pair.into_inner();
+            let mut expr = parse_expression(inner.next().unwrap())?;
+            while let Some(op) = inner.next() {
+                let right = parse_expression(inner.next().unwrap())?;
+                let op = match op.as_rule() {
+                    Rule::ADD_OP => BinaryOperator::Add,
+                    Rule::SUB_OP => BinaryOperator::Sub,
+                    _ => unreachable!(),
+                };
+                expr = ExpressionNode::BinaryOp {
+                    left: Box::new(expr),
+                    operator: op,
+                    right: Box::new(right),
+                };
+            }
+            Ok(expr)
+        }
+        Rule::multiplication => {
+            let mut inner = pair.into_inner();
+            let mut expr = parse_expression(inner.next().unwrap())?;
+            while let Some(op) = inner.next() {
+                let right = parse_expression(inner.next().unwrap())?;
+                let op = match op.as_rule() {
+                    Rule::MUL_OP => BinaryOperator::Mul,
+                    Rule::DIV_OP => BinaryOperator::Div,
+                    _ => unreachable!(),
+                };
+                expr = ExpressionNode::BinaryOp {
+                    left: Box::new(expr),
+                    operator: op,
+                    right: Box::new(right),
+                };
+            }
+            Ok(expr)
+        }
+        Rule::primary => parse_primary(pair),
+        Rule::function_call
+        | Rule::integer_literal
+        | Rule::boolean_literal
+        | Rule::string_literal
+        | Rule::identifier => parse_primary(pair),
+        _ => Err(CclError::ParsingError(format!(
+            "Unsupported expression rule: {:?}",
+            pair.as_rule()
+        ))),
     }
 }
 
@@ -89,25 +219,79 @@ fn parse_block(pair: Pair<Rule>) -> Result<BlockNode, CclError> {
     let mut statements = vec![];
     // block = { "{" ~ statement* ~ "}" }
     // We expect the block's inner rules to be `statement` rules.
-    for statement_rule_pair in pair.into_inner() { // This `pair` is the `block`
+    for statement_rule_pair in pair.into_inner() {
+        // This `pair` is the `block`
         if statement_rule_pair.as_rule() == Rule::statement {
             // A `statement` rule can be `let_statement | expression_statement | return_statement`
             // We take the first (and only, for now) inner rule of the `statement`.
-            let actual_statement_pair = statement_rule_pair.into_inner().next()
+            let actual_statement_pair = statement_rule_pair
+                .into_inner()
+                .next()
                 .ok_or_else(|| CclError::ParsingError("Empty statement rule".to_string()))?;
 
             match actual_statement_pair.as_rule() {
                 Rule::return_statement => {
                     let mut inner_return_rules = actual_statement_pair.into_inner();
-                    let expression_rule = inner_return_rules.next()
-                        .ok_or_else(|| CclError::ParsingError("Return statement missing expression".to_string()))?;
+                    let expression_rule = inner_return_rules.next().ok_or_else(|| {
+                        CclError::ParsingError("Return statement missing expression".to_string())
+                    })?;
                     statements.push(StatementNode::Return(parse_expression(expression_rule)?));
                 }
-                // TODO: Add Rule::let_statement, Rule::expression_statement
-                _ => return Err(CclError::ParsingError(format!("Unsupported statement type: {:?}", actual_statement_pair.as_rule()))),
+                Rule::let_statement => {
+                    let mut inner = actual_statement_pair.into_inner();
+                    let name_pair = inner.next().ok_or_else(|| {
+                        CclError::ParsingError("Let statement missing identifier".to_string())
+                    })?;
+                    let expr_pair = inner.next().ok_or_else(|| {
+                        CclError::ParsingError("Let statement missing expression".to_string())
+                    })?;
+                    statements.push(StatementNode::Let {
+                        name: name_pair.as_str().to_string(),
+                        value: parse_expression(expr_pair)?,
+                    });
+                }
+                Rule::expression_statement => {
+                    let expr_pair = actual_statement_pair.into_inner().next().ok_or_else(|| {
+                        CclError::ParsingError(
+                            "Expression statement missing expression".to_string(),
+                        )
+                    })?;
+                    statements.push(StatementNode::ExpressionStatement(parse_expression(
+                        expr_pair,
+                    )?));
+                }
+                Rule::if_statement => {
+                    let mut inner = actual_statement_pair.into_inner();
+                    let cond_pair = inner.next().ok_or_else(|| {
+                        CclError::ParsingError("If statement missing condition".to_string())
+                    })?;
+                    let then_block_pair = inner.next().ok_or_else(|| {
+                        CclError::ParsingError("If statement missing then block".to_string())
+                    })?;
+                    let else_block_pair = inner.next();
+                    let else_block = if let Some(p) = else_block_pair {
+                        Some(parse_block(p)?)
+                    } else {
+                        None
+                    };
+                    statements.push(StatementNode::If {
+                        condition: parse_expression(cond_pair)?,
+                        then_block: parse_block(then_block_pair)?,
+                        else_block,
+                    });
+                }
+                _ => {
+                    return Err(CclError::ParsingError(format!(
+                        "Unsupported statement type: {:?}",
+                        actual_statement_pair.as_rule()
+                    )));
+                }
             }
         } else {
-            return Err(CclError::ParsingError(format!("Unexpected rule directly in block: {:?}, expected a statement", statement_rule_pair.as_rule())));
+            return Err(CclError::ParsingError(format!(
+                "Unexpected rule directly in block: {:?}, expected a statement",
+                statement_rule_pair.as_rule()
+            )));
         }
     }
     Ok(BlockNode { statements })
@@ -118,14 +302,20 @@ fn parse_type_annotation(pair: Pair<Rule>) -> Result<TypeAnnotationNode, CclErro
     // So, the `pair` passed here should have `pair.as_rule() == Rule::identifier` if Pest rule `type_annotation = { identifier }` was used directly in `function_definition`.
     // However, the `function_definition` rule is `... ~ type_annotation ~ ...`
     // So the `pair` here *is* the `type_annotation` rule itself. Its inner rule should be `identifier`.
-    let type_identifier_pair = pair.into_inner().next()
+    let type_identifier_pair = pair
+        .into_inner()
+        .next()
         .ok_or_else(|| CclError::ParsingError("Type annotation missing identifier".to_string()))?;
-    
+
     if type_identifier_pair.as_rule() != Rule::identifier {
-        return Err(CclError::ParsingError(format!("Expected identifier for type annotation, got {:?}", type_identifier_pair.as_rule())));
+        return Err(CclError::ParsingError(format!(
+            "Expected identifier for type annotation, got {:?}",
+            type_identifier_pair.as_rule()
+        )));
     }
 
-    match type_identifier_pair.as_str() { // The matched identifier string
+    match type_identifier_pair.as_str() {
+        // The matched identifier string
         "Integer" => Ok(TypeAnnotationNode::Integer),
         "Bool" => Ok(TypeAnnotationNode::Bool),
         "String" => Ok(TypeAnnotationNode::String),
@@ -139,16 +329,22 @@ fn parse_function_definition(pair: Pair<Rule>) -> Result<AstNode, CclError> {
     // function_definition = { "fn" ~ identifier ~ "(" ~ (parameter ~ ("," ~ parameter)*)? ~ ")" ~ "->" ~ type_annotation ~ block }
     let mut inner_rules = pair.into_inner(); // Consumes the function_definition pair
 
-    let name_token = inner_rules.next().ok_or_else(|| CclError::ParsingError("Function definition missing name".to_string()))?;
+    let name_token = inner_rules
+        .next()
+        .ok_or_else(|| CclError::ParsingError("Function definition missing name".to_string()))?;
     assert_eq!(name_token.as_rule(), Rule::identifier);
     let name = name_token.as_str().to_string();
-    
-    let return_type_pair = inner_rules.next().ok_or_else(|| CclError::ParsingError("Function definition missing return type".to_string()))?;
+
+    let return_type_pair = inner_rules.next().ok_or_else(|| {
+        CclError::ParsingError("Function definition missing return type".to_string())
+    })?;
     let return_type = parse_type_annotation(return_type_pair)?;
-    
-    let block_pair = inner_rules.next().ok_or_else(|| CclError::ParsingError("Function definition missing body".to_string()))?;
+
+    let block_pair = inner_rules
+        .next()
+        .ok_or_else(|| CclError::ParsingError("Function definition missing body".to_string()))?;
     let body = parse_block(block_pair)?;
-    
+
     Ok(AstNode::FunctionDefinition {
         name,
         parameters: vec![], // Minimal example has no parameters
@@ -157,40 +353,121 @@ fn parse_function_definition(pair: Pair<Rule>) -> Result<AstNode, CclError> {
     })
 }
 
+fn parse_action(pair: Pair<Rule>) -> Result<ActionNode, CclError> {
+    let mut inner = pair.into_inner();
+    let first = inner
+        .next()
+        .ok_or_else(|| CclError::ParsingError("Empty action".to_string()))?;
+    match first.as_rule() {
+        Rule::ALLOW => Ok(ActionNode::Allow),
+        Rule::DENY => Ok(ActionNode::Deny),
+        Rule::CHARGE => {
+            let expr_pair = inner.next().ok_or_else(|| {
+                CclError::ParsingError("Charge action missing expression".to_string())
+            })?;
+            Ok(ActionNode::Charge(parse_expression(expr_pair)?))
+        }
+        _ => Err(CclError::ParsingError(format!(
+            "Unknown action component: {:?}",
+            first.as_rule()
+        ))),
+    }
+}
+
+fn parse_rule_definition(pair: Pair<Rule>) -> Result<AstNode, CclError> {
+    let mut inner = pair.into_inner();
+    let name_pair = inner
+        .next()
+        .ok_or_else(|| CclError::ParsingError("Rule missing name".to_string()))?;
+    let condition_pair = inner
+        .next()
+        .ok_or_else(|| CclError::ParsingError("Rule missing condition".to_string()))?;
+    let action_pair = inner
+        .next()
+        .ok_or_else(|| CclError::ParsingError("Rule missing action".to_string()))?;
+
+    Ok(AstNode::RuleDefinition {
+        name: name_pair.as_str().to_string(),
+        condition: parse_expression(condition_pair)?,
+        action: parse_action(action_pair)?,
+    })
+}
+
 pub fn parse_ccl_source(source: &str) -> Result<AstNode, CclError> {
     match CclParser::parse(Rule::policy, source) {
         Ok(mut pairs) => {
-            let policy_content = pairs.next().ok_or_else(|| CclError::ParsingError("Empty policy source".to_string()))?;
-            
+            let policy_content = pairs
+                .next()
+                .ok_or_else(|| CclError::ParsingError("Empty policy source".to_string()))?;
+
             let mut ast_nodes_for_policy = vec![];
 
             for pair_in_policy in policy_content.into_inner() {
                 match pair_in_policy.as_rule() {
                     Rule::function_definition => {
-                        ast_nodes_for_policy.push(PolicyStatementNode::FunctionDef(parse_function_definition(pair_in_policy)?));
+                        ast_nodes_for_policy.push(PolicyStatementNode::FunctionDef(
+                            parse_function_definition(pair_in_policy)?,
+                        ));
                     }
-                    Rule::EOI => (), 
-                    _ => return Err(CclError::ParsingError(format!("Unexpected rule in policy: {:?}", pair_in_policy.as_rule()))),
+                    Rule::policy_statement => {
+                        let mut inner = pair_in_policy.into_inner();
+                        let stmt_pair = inner.next().ok_or_else(|| {
+                            CclError::ParsingError("Empty policy statement".to_string())
+                        })?;
+                        match stmt_pair.as_rule() {
+                            Rule::rule_definition => {
+                                ast_nodes_for_policy.push(PolicyStatementNode::RuleDef(
+                                    parse_rule_definition(stmt_pair)?,
+                                ));
+                            }
+                            Rule::import_statement => {
+                                let mut i = stmt_pair.into_inner();
+                                let path_pair = i.next().ok_or_else(|| {
+                                    CclError::ParsingError("Import missing path".to_string())
+                                })?;
+                                let alias_pair = i.next().ok_or_else(|| {
+                                    CclError::ParsingError("Import missing alias".to_string())
+                                })?;
+                                let path = path_pair.as_str().trim_matches('"').to_string();
+                                let alias = alias_pair.as_str().to_string();
+                                ast_nodes_for_policy
+                                    .push(PolicyStatementNode::Import { path, alias });
+                            }
+                            _ => {
+                                return Err(CclError::ParsingError(format!(
+                                    "Unknown policy statement: {:?}",
+                                    stmt_pair.as_rule()
+                                )));
+                            }
+                        }
+                    }
+                    Rule::EOI => (),
+                    _ => {
+                        return Err(CclError::ParsingError(format!(
+                            "Unexpected rule in policy: {:?}",
+                            pair_in_policy.as_rule()
+                        )));
+                    }
                 }
             }
             if ast_nodes_for_policy.is_empty() {
-                 return Err(CclError::ParsingError("No function definitions found in policy".to_string()));
+                return Err(CclError::ParsingError(
+                    "Policy contained no items".to_string(),
+                ));
             }
             Ok(AstNode::Policy(ast_nodes_for_policy))
-
         }
-        Err(e) => {
-            Err(CclError::ParsingError(format!("Pest parsing error: {}", e)))
-        }
+        Err(e) => Err(CclError::ParsingError(format!("Pest parsing error: {}", e))),
     }
 }
-
 
 // Example test for the parser
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{AstNode, BlockNode, ExpressionNode, PolicyStatementNode, StatementNode, TypeAnnotationNode};
+    use crate::ast::{
+        AstNode, BlockNode, ExpressionNode, PolicyStatementNode, StatementNode, TypeAnnotationNode,
+    };
 
     #[test]
     fn test_parse_simple_function_definition() {
@@ -201,20 +478,18 @@ mod tests {
         "#;
         match parse_ccl_source(source) {
             Ok(ast) => {
-                let expected_ast = AstNode::Policy(vec![
-                    PolicyStatementNode::FunctionDef(
-                        AstNode::FunctionDefinition {
-                            name: "get_value".to_string(),
-                            parameters: vec![],
-                            return_type: TypeAnnotationNode::Integer,
-                            body: BlockNode {
-                                statements: vec![
-                                    StatementNode::Return(ExpressionNode::IntegerLiteral(42))
-                                ],
-                            },
-                        }
-                    )
-                ]);
+                let expected_ast = AstNode::Policy(vec![PolicyStatementNode::FunctionDef(
+                    AstNode::FunctionDefinition {
+                        name: "get_value".to_string(),
+                        parameters: vec![],
+                        return_type: TypeAnnotationNode::Integer,
+                        body: BlockNode {
+                            statements: vec![StatementNode::Return(
+                                ExpressionNode::IntegerLiteral(42),
+                            )],
+                        },
+                    },
+                )]);
                 assert_eq!(ast, expected_ast);
             }
             Err(e) => panic!("Parsing failed: {}", e),
@@ -223,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_parse_invalid_syntax() {
-        let source = "fn broken { return 1 }"; 
+        let source = "fn broken { return 1 }";
         let result = parse_ccl_source(source);
         assert!(matches!(result, Err(CclError::ParsingError(_))));
     }
@@ -241,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_parse_block_missing_return_expression() {
-         let source = r#"
+        let source = r#"
             fn test_func() -> Integer {
                 return ; 
             }
@@ -249,7 +524,7 @@ mod tests {
         let result = parse_ccl_source(source);
         assert!(matches!(result, Err(CclError::ParsingError(_))));
     }
-     #[test]
+    #[test]
     fn test_malformed_function_no_body() {
         let source = "fn no_body() -> Integer";
         let result = parse_ccl_source(source);
@@ -262,4 +537,37 @@ mod tests {
         let result = parse_ccl_source(source);
         assert!(matches!(result, Err(CclError::ParsingError(_))));
     }
-} 
+
+    #[test]
+    fn test_parse_if_and_let() {
+        let source = r#"
+            fn check() -> Bool {
+                let x = 1 + 2 * 3;
+                if x > 5 {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        "#;
+        let parsed = parse_ccl_source(source).expect("should parse");
+        if let AstNode::Policy(items) = parsed {
+            assert!(!items.is_empty());
+        } else {
+            panic!("Expected policy AST");
+        }
+    }
+
+    #[test]
+    fn test_parse_rule_definition() {
+        let source = r#"
+            rule allow_all when true then allow
+        "#;
+        let parsed = parse_ccl_source(source).expect("should parse rule");
+        if let AstNode::Policy(items) = parsed {
+            assert!(matches!(items[0], PolicyStatementNode::RuleDef(_)));
+        } else {
+            panic!("Expected policy AST");
+        }
+    }
+}

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -21,15 +21,30 @@ fn test_compile_simple_policy_end_to_end() {
 
     match compile_ccl_source_to_wasm(ccl_source) {
         Ok((wasm_bytecode, metadata)) => {
-            assert!(!wasm_bytecode.is_empty(), "WASM bytecode should not be empty");
-            assert!(wasm_bytecode.starts_with(b"\0asm"), "Output should be valid WASM");
+            assert!(
+                !wasm_bytecode.is_empty(),
+                "WASM bytecode should not be empty"
+            );
+            assert!(
+                wasm_bytecode.starts_with(b"\0asm"),
+                "Output should be valid WASM"
+            );
 
-            println!("Generated WASM (first 16 bytes): {:?}", &wasm_bytecode[0..std::cmp::min(16, wasm_bytecode.len())]);
+            println!(
+                "Generated WASM (first 16 bytes): {:?}",
+                &wasm_bytecode[0..std::cmp::min(16, wasm_bytecode.len())]
+            );
             println!("Generated Metadata: {:?}", metadata);
 
-            assert!(metadata.cid.contains("bafy2bzace"), "Metadata CID placeholder missing"); // Check placeholder
-            assert_eq!(metadata.exports, vec!["mana_cost".to_string(), "can_bid".to_string()]); // From stub
-            // TODO: Update assertions once actual exports are derived from the AST
+            assert!(
+                metadata.cid.contains("bafy2bzace"),
+                "Metadata CID placeholder missing"
+            ); // Check placeholder
+            assert_eq!(
+                metadata.exports,
+                vec!["mana_cost".to_string(), "can_bid".to_string()]
+            ); // From stub
+               // TODO: Update assertions once actual exports are derived from the AST
         }
         Err(e) => {
             panic!("CCL compilation failed: {:?}", e);
@@ -42,34 +57,57 @@ fn test_compile_ccl_file_cli_function() {
     let dir = tempdir().expect("Failed to create temp dir");
     let source_content = "fn main() -> Bool { return true; }"; // Simplified
     let source_path = create_dummy_ccl_file(dir.path(), "test_policy.ccl", source_content);
-    
+
     let output_wasm_path = dir.path().join("test_policy.wasm");
     let output_meta_path = dir.path().join("test_policy.json");
 
     match icn_ccl::cli::compile_ccl_file(&source_path, &output_wasm_path, &output_meta_path) {
         Ok(metadata) => {
             assert!(output_wasm_path.exists(), ".wasm file should be created");
-            assert!(output_meta_path.exists(), ".json metadata file should be created");
-            
+            assert!(
+                output_meta_path.exists(),
+                ".json metadata file should be created"
+            );
+
             let wasm_bytes = fs::read(&output_wasm_path).unwrap();
             assert!(wasm_bytes.starts_with(b"\0asm"));
 
             let meta_content = fs::read_to_string(&output_meta_path).unwrap();
             let parsed_meta: ContractMetadata = serde_json::from_str(&meta_content).unwrap();
             assert_eq!(parsed_meta.cid, metadata.cid); // Check consistency
-            
-            println!("CLI compile_ccl_file test successful. Metadata: {:?}", metadata);
+
+            println!(
+                "CLI compile_ccl_file test successful. Metadata: {:?}",
+                metadata
+            );
         }
         Err(e) => panic!("compile_ccl_file failed: {:?}", e),
     }
 }
 
-
 #[test]
 fn test_compile_invalid_ccl() {
     let invalid_ccl_source = "fn broken syntax here {";
     let result = compile_ccl_source_to_wasm(invalid_ccl_source);
-    assert!(matches!(result, Err(CclError::ParsingError(_))), "Expected parsing error for invalid syntax");
+    assert!(
+        matches!(result, Err(CclError::ParsingError(_))),
+        "Expected parsing error for invalid syntax"
+    );
+}
+
+#[test]
+fn test_compile_with_rule_and_if() {
+    let source = r#"
+        fn main() -> Bool {
+            let a = 5;
+            if a > 1 { return true; } else { return false; }
+        }
+
+        rule basic when true then allow
+    "#;
+
+    let res = compile_ccl_source_to_wasm(source);
+    assert!(res.is_ok(), "Compilation should succeed");
 }
 
 // TODO: Add more integration tests:
@@ -77,4 +115,4 @@ fn test_compile_invalid_ccl() {
 // - Correct metadata generation (exports, inputs based on CCL code)
 // - Test CLI check function
 // - Test CLI format function (once implemented)
-// - Test CLI explain function (once implemented) 
+// - Test CLI explain function (once implemented)


### PR DESCRIPTION
## Summary
- extend `StatementNode` with `If` support
- update CCL grammar for expressions, if/else, and rule actions
- implement expression parsing with precedence and new statements
- parse rule definitions and imports when loading policies
- test additional parsing cases and compilation end-to-end
- adjust `Cargo.toml` for standalone build

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile workspace crates)*
- `cargo test --all-features --workspace` *(fails to compile workspace tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847f8422d148324bb7d5de6ce90e921