### PR TITLE
[icn-runtime] add basic wasmtime executor

### DIFF
--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -24,9 +24,11 @@ thiserror = "1.0"
 libp2p = { version = "0.53.2", optional = true }
 downcast-rs = "1.2.0"
 futures = "0.3"
+wasmtime = { version = "15", features = ["async"] }
 
 [dev-dependencies]
 anyhow = "1.0.75"
+wat = "1.0"
 # temp-dir = "0.1"
 
 [features]

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -1,0 +1,36 @@
+use icn_runtime::context::RuntimeContext;
+use icn_runtime::executor::{JobExecutor, WasmExecutor};
+use icn_common::Cid;
+use icn_mesh::{ActualMeshJob, JobSpec};
+use icn_identity::{generate_ed25519_keypair, did_key_from_verifying_key, SignatureBytes};
+use std::str::FromStr;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_executor_runs_wasm() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 42);
+    let (sk, vk) = generate_ed25519_keypair();
+    let node_did = did_key_from_verifying_key(&vk);
+    let node_did = icn_common::Did::from_str(&node_did).unwrap();
+
+    let wasm = r#"(module
+        (import "icn" "host_account_get_mana" (func $get (result i64)))
+        (func (export "run") (result i64)
+            call $get
+        )
+    )"#;
+    let wasm_bytes = wat::parse_str(wasm).unwrap();
+    let cid = ctx.dag_store.put(&wasm_bytes).await.unwrap();
+
+    let job = ActualMeshJob {
+        id: Cid::new_v1_dummy(0x55, 0x11, b"job"),
+        manifest_cid: cid,
+        spec: JobSpec::GenericPlaceholder,
+        creator_did: node_did.clone(),
+        cost_mana: 0,
+        signature: SignatureBytes(vec![]),
+    };
+
+    let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
+    let receipt = exec.execute_job(&job).await.unwrap();
+    assert_eq!(receipt.executor_did, node_did);
+}


### PR DESCRIPTION
## Summary
- integrate `wasmtime` runtime in `icn-runtime`
- implement `WasmExecutor` able to load modules from the DAG and expose `host_account_get_mana`
- add `wasm_executor` integration test

## Testing
- `cargo fmt --all -- --check` *(fails: `cargo: command not found`)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: `cargo: command not found`)*
- `cargo test --all-features --workspace` *(fails: `cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848121a7f988324ad2691e1a94a5809