### PR TITLE
[cleanup] remove unused imports and dead_code attributes

### DIFF
--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -18,7 +18,6 @@ use downcast_rs::{impl_downcast, DowncastSync};
 use std::any::Any;
 use std::time::Duration;
 use std::collections::HashMap;
-use bincode;
 use log::{info, warn};
 // Removed unused imports for testing Kademlia disabled build
 

--- a/crates/icn-node/src/main.rs
+++ b/crates/icn-node/src/main.rs
@@ -143,7 +143,6 @@ pub async fn app_router() -> Router { // Renamed to app_router and made async fo
 
 // --- Main Application Logic ---
 #[tokio::main]
-#[allow(dead_code)]
 async fn main() {
     env_logger::init(); // Initialize logger
     let cli = Cli::parse();

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -11,7 +11,6 @@ use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use log::{info, debug}; // Added for potential future use, using println! for now
 
 // Helper to create a test ActualMeshJob with all required fields
 fn create_test_mesh_job(manifest_cid: Cid, cost_mana: u64, creator_did: Did) -> ActualMeshJob {


### PR DESCRIPTION
## Summary
- drop unused log import in `icn-runtime` test
- remove redundant `bincode` import
- remove `#[allow(dead_code)]` from main

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unimproved clippy warnings)*
- `cargo test --all-features --workspace` *(fails to compile tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847ea6fc1048324a7696f57f4d95f0f