### PR TITLE
[docs] network dht and mesh scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repository hygiene files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, .editorconfig).
 - Workspace consistency for Cargo.toml files.
 - Optional improvements: rust-toolchain.toml, dependabot.yml, issue templates, CHANGELOG.md.
+- Kademlia DHT record storage and peer discovery behind `experimental-libp2p`.
+- New scoring algorithm in `icn-mesh` with reputation-based `select_executor`.
 
 ### Changed
 

--- a/crates/icn-mesh/README.md
+++ b/crates/icn-mesh/README.md
@@ -23,6 +23,18 @@ The API style emphasizes:
 *   **Efficiency:** Optimal use of network resources for job execution.
 *   **Extensibility:** Allowing different types of jobs and scheduling algorithms to be supported.
 
+## Scoring Algorithm & Reputation
+
+Job bids are evaluated by `select_executor`, which calls `score_bid` for each
+bid. The score is a weighted combination of the bid price, the executor's
+advertised performance, and a reputation value supplied by the reputation
+module. The bid with the highest score is chosen as the executor.
+
+The reputation module monitors execution receipts and updates each executor's
+score over time. `select_executor` queries this module (via the
+`ReputationExecutorSelector` helper) so that nodes with proven reliability are
+favored in future selections.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -34,6 +34,24 @@ The `StubNetworkService` also simulates these errors to help test error handling
 
 This crate includes an optional `experimental-libp2p` feature. Enabling it pulls in the optional `libp2p` and `libp2p-request-response` dependencies, allowing for the implementation of a `NetworkService` backed by a real libp2p stack.
 
+## Kademlia DHT
+
+When compiled with the `experimental-libp2p` feature, the network layer exposes
+basic Kademlia distributed hash table (DHT) functionality. This allows nodes to
+store small records in the DHT and to discover peers through the standard
+libp2p Kademlia protocol.
+
+Kademlia commands are disabled in the stub service and only become available in
+the `Libp2pNetworkService` when the feature flag is enabled. Be sure to compile
+with:
+
+```bash
+cargo build --features experimental-libp2p
+```
+
+to use the `get_kademlia_record` and `put_kademlia_record` APIs as well as peer
+discovery via the DHT.
+
 ## Public API Style
 
 This crate provides: 


### PR DESCRIPTION
## Summary
- document Kademlia DHT usage and feature flag in `icn-network` README
- explain mesh executor scoring and reputation interplay
- note the new docs in CHANGELOG

## Testing
- `cargo fmt --all -- --check` *(fails: shows diff)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy errors)*
- `cargo test --all-features --workspace` *(fails: compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848bc31adbc8324a22e6a58dd1bc237