### PR TITLE
[icn-governance] finalize vote lifecycle

### DIFF
--- a/crates/icn-governance/tests/voting.rs
+++ b/crates/icn-governance/tests/voting.rs
@@ -1,0 +1,75 @@
+use icn_common::Did;
+use icn_governance::{GovernanceModule, ProposalStatus, ProposalType, VoteOption};
+use std::str::FromStr;
+
+#[test]
+fn vote_tally_and_execute() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.add_member(Did::from_str("did:example:charlie").unwrap());
+    gov.set_quorum(2);
+    gov.set_threshold(0.5);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::NewMemberInvitation(Did::from_str("did:example:dave").unwrap()),
+            "add dave".into(),
+            60,
+        )
+        .unwrap();
+
+    gov.cast_vote(
+        Did::from_str("did:example:bob").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:charlie").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+
+    let status = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
+
+    gov.execute_proposal(&pid).unwrap();
+    assert!(gov
+        .members()
+        .contains(&Did::from_str("did:example:dave").unwrap()));
+
+    let prop = gov.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.status, ProposalStatus::Executed);
+}
+
+#[test]
+fn reject_due_to_quorum() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.add_member(Did::from_str("did:example:charlie").unwrap());
+    gov.set_quorum(3);
+    gov.set_threshold(0.5);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("hi".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap();
+
+    gov.cast_vote(
+        Did::from_str("did:example:bob").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+
+    let status = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Rejected);
+}

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -22,9 +22,7 @@ pub use context::{HostAbiError, RuntimeContext, Signer, StorageService};
 // Re-export ABI constants
 pub use abi::*;
 
-use futures;
 use icn_common::{Cid, CommonError, Did, NodeInfo};
-use icn_identity;
 use log::{debug, info};
 use std::str::FromStr;
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- implement vote tallying, closing, and execution logic in governance module
- maintain member lists and quorum settings
- persist proposal status updates when sled persistence is enabled
- add in-memory voting tests and extend sled test coverage

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: use of undeclared type `DefaultMeshNetworkService` in unrelated tests)*
- `cargo test --all-features --workspace` *(fails: use of undeclared type `DefaultMeshNetworkService` in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848be8afc7c8324a7fbaf9e8a4248d9