### PR TITLE
[runtime,node] integrate governance module

### DIFF
--- a/crates/icn-node/tests/governance.rs
+++ b/crates/icn-node/tests/governance.rs
@@ -1,0 +1,57 @@
+use icn_node::app_router;
+use tokio::task;
+use reqwest::Client;
+use icn_api::governance_trait::{SubmitProposalRequest, ProposalInputType, CastVoteRequest};
+use serde_json::Value;
+
+#[tokio::test]
+async fn submit_and_vote_proposal() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+
+    let client = Client::new();
+    let submit_req = SubmitProposalRequest {
+        proposer_did: "did:example:alice".to_string(),
+        proposal: ProposalInputType::GenericText { text: "hi".into() },
+        description: "test".into(),
+        duration_secs: 60,
+    };
+    let resp: Value = client
+        .post(&format!("http://{}/governance/submit", addr))
+        .json(&submit_req)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let pid = resp["0"].as_str().unwrap_or_else(|| resp["id"].as_str().unwrap()).to_string();
+
+    let vote_req = CastVoteRequest {
+        voter_did: "did:example:bob".to_string(),
+        proposal_id: pid.clone(),
+        vote_option: "yes".to_string(),
+    };
+    let vote_resp = client
+        .post(&format!("http://{}/governance/vote", addr))
+        .json(&vote_req)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(vote_resp.status(), 200);
+
+    let proposal: Value = client
+        .get(&format!("http://{}/governance/proposal/{}", addr, pid))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(proposal["votes"].as_object().unwrap().len(), 1);
+
+    server.abort();
+}

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -14,6 +14,7 @@ icn-economics = { path = "../icn-economics" }
 icn-mesh = { path = "../icn-mesh" }
 icn-network = { path = "../icn-network", features = ["experimental-libp2p"] }
 icn-dag = { path = "../icn-dag" }
+icn-governance = { path = "../icn-governance", default-features = false }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -35,6 +36,7 @@ wat = "1.0"
 default = []
 # TODO: Define features if needed, e.g., for different execution environments or optional components.
 enable-libp2p = ["dep:libp2p"]
+persist-sled = ["icn-governance/persist-sled"]
 
 # Integration tests for cross-node functionality
 [[test]]

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -22,9 +22,7 @@ pub use context::{HostAbiError, RuntimeContext, Signer, StorageService};
 // Re-export ABI constants
 pub use abi::*;
 
-use futures;
 use icn_common::{Cid, CommonError, Did, NodeInfo};
-use icn_identity;
 use log::{debug, info};
 use std::str::FromStr;
 #[cfg(test)]
@@ -299,6 +297,30 @@ pub async fn host_anchor_receipt(
 
     reputation_updater.submit(&receipt); // This is a stub for now
     Ok(anchored_cid)
+}
+
+/// Creates a governance proposal using the runtime context.
+pub async fn host_create_governance_proposal(ctx: &RuntimeContext, payload_json: &str) -> Result<String, HostAbiError> {
+    let payload: context::CreateProposalPayload = serde_json::from_str(payload_json)
+        .map_err(|e| HostAbiError::InvalidParameters(format!("Failed to parse CreateProposalPayload JSON: {}", e)))?;
+    ctx.create_governance_proposal(payload).await
+}
+
+/// Casts a governance vote using the runtime context.
+pub async fn host_cast_governance_vote(ctx: &RuntimeContext, payload_json: &str) -> Result<(), HostAbiError> {
+    let payload: context::CastVotePayload = serde_json::from_str(payload_json)
+        .map_err(|e| HostAbiError::InvalidParameters(format!("Failed to parse CastVotePayload JSON: {}", e)))?;
+    ctx.cast_governance_vote(payload).await
+}
+
+/// Closes voting on a governance proposal. Currently not implemented.
+pub async fn host_close_governance_proposal_voting(ctx: &RuntimeContext, proposal_id: &str) -> Result<String, HostAbiError> {
+    ctx.close_governance_proposal_voting(proposal_id).await
+}
+
+/// Executes an accepted governance proposal. Currently not implemented.
+pub async fn host_execute_governance_proposal(ctx: &RuntimeContext, proposal_id: &str) -> Result<(), HostAbiError> {
+    ctx.execute_governance_proposal(proposal_id).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- wire `GovernanceModule` into `RuntimeContext`
- expose governance-related host ABI helpers
- implement HTTP handlers for governance
- test submitting and voting on proposals

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: this file contains an unclosed delimiter, unused imports, etc.)*
- `cargo test --all-features --workspace` *(fails: could not compile `icn-runtime` (test "mesh"))*

------
https://chatgpt.com/codex/tasks/task_e_6848be8c6d5c83248b938eaf95e499a6