### PR TITLE
[icn-network] add DHT key prefixes

### DIFF
--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -58,6 +58,7 @@ This crate provides:
 *   Data structures (`PeerId`, `NetworkMessage`).
 *   A core trait (`NetworkService`) for P2P interactions.
 *   A concrete stub implementation (`StubNetworkService`) for testing and initial development.
+*   With the `experimental-libp2p` feature enabled, DHT record APIs (`get_kademlia_record` and `put_kademlia_record`) for storing service advertisements and DID documents.
 
 The API aims for modularity, allowing different P2P backends to be integrated by implementing the `NetworkService` trait.
 

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -28,6 +28,21 @@ use std::time::Duration;
 use tokio::sync::mpsc::Receiver;
 // Removed unused imports for testing Kademlia disabled build
 
+/// Prefix for service advertisement records stored in the DHT.
+///
+/// Keys are constructed as `format!("{SERVICE_AD_PREFIX}{did}")` where `did`
+/// is the DID of the advertising node. For example, a node with the DID
+/// `did:web:example.com` should advertise under the key
+/// `/icn/service/did:web:example.com`.
+pub const SERVICE_AD_PREFIX: &str = "/icn/service/";
+
+/// Prefix for DID document records stored in the DHT.
+///
+/// Keys are constructed as `format!("{DID_DOC_PREFIX}{did}")`. A DID
+/// document for `did:web:example.com` would therefore be stored under
+/// `/icn/did/did:web:example.com`.
+pub const DID_DOC_PREFIX: &str = "/icn/did/";
+
 // --- Core Types ---
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Summary
- define `SERVICE_AD_PREFIX` and `DID_DOC_PREFIX` constants
- explain how to build DHT keys
- document that DHT record APIs exist when enabling `experimental-libp2p`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-network --all-targets --all-features -- -D warnings` *(fails: unused imports in tests)*
- `cargo test --all-features --workspace` *(fails to compile network and runtime tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848c30795908324a25a8bf92c7483f9