### PR TITLE
[governance] add proposal announcement messaging

### DIFF
--- a/crates/icn-governance/tests/external.rs
+++ b/crates/icn-governance/tests/external.rs
@@ -1,0 +1,23 @@
+use icn_common::Did;
+use icn_governance::{GovernanceModule, ProposalType};
+use std::str::FromStr;
+
+#[test]
+fn insert_external_proposal_round_trip() {
+    let mut gov1 = GovernanceModule::new();
+    let pid = gov1
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("hi".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap();
+    let proposal = gov1.get_proposal(&pid).unwrap().unwrap();
+
+    let mut gov2 = GovernanceModule::new();
+    gov2.insert_external_proposal(proposal.clone()).unwrap();
+    let prop2 = gov2.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop2.id, pid);
+    assert_eq!(prop2.description, proposal.description);
+}

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -67,6 +67,7 @@ pub enum NetworkMessage {
     BidSubmission(Bid),
     JobAssignmentNotification(JobId, Did),
     SubmitReceipt(ExecutionReceipt),
+    ProposalAnnouncement(Vec<u8>),
 }
 
 impl NetworkMessage {
@@ -80,6 +81,7 @@ impl NetworkMessage {
             NetworkMessage::BidSubmission(_) => "BidSubmission",
             NetworkMessage::JobAssignmentNotification(_, _) => "JobAssignmentNotification",
             NetworkMessage::SubmitReceipt(_) => "SubmitReceipt",
+            NetworkMessage::ProposalAnnouncement(_) => "ProposalAnnouncement",
         }
     }
 }

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -26,6 +26,7 @@ libp2p = { version = "0.53.2", optional = true }
 downcast-rs = "1.2.0"
 futures = "0.3"
 wasmtime = { version = "15", features = ["async"] }
+bincode = "1.3"
 
 [dev-dependencies]
 anyhow = "1.0.75"


### PR DESCRIPTION
## Summary
- allow broadcasting proposals as a new `NetworkMessage` variant
- add `insert_external_proposal` helper
- broadcast proposals on submission
- enable runtime to ingest announced proposals
- test external proposal insertion

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68490ce6326c8324bc483a54c7a1f515