### PR TITLE
[icn-node] add api key auth and rate limiting

### DIFF
--- a/configs/single_node.toml
+++ b/configs/single_node.toml
@@ -1,0 +1,5 @@
+# Example single node configuration
+http_listen_addr = "127.0.0.1:7845"
+storage_backend = "memory"
+api_key = "CHANGE_ME"
+open_rate_limit = 60

--- a/configs/small_federation.toml
+++ b/configs/small_federation.toml
@@ -1,0 +1,7 @@
+# Example node configuration for a small federation
+http_listen_addr = "0.0.0.0:7845"
+storage_backend = "sqlite"
+storage_path = "./icn_data/node1.sqlite"
+bootstrap_peers = ["/ip4/1.2.3.4/tcp/7000/p2p/QmPeer"]
+api_key = "node1secret"
+open_rate_limit = 0

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -1,0 +1,27 @@
+# ICN Deployment Guide
+
+This guide provides minimal examples for launching `icn-node` in common scenarios.
+
+## Single Node Local
+
+This mode runs a standalone node for development or testing.
+
+```bash
+icn-node --storage-backend memory --http-listen-addr 127.0.0.1:7845 \
+         --api-key mylocalkey
+```
+
+A sample TOML configuration is in `configs/single_node.toml`.
+
+## Small Federation
+
+For a small group of cooperating nodes, each node may use a persistent store and
+bootstrap to known peers.
+
+```bash
+icn-node --storage-backend sqlite --storage-path ./icn_data/node1.sqlite \
+         --bootstrap-peers /ip4/1.2.3.4/tcp/7000/p2p/QmPeer \
+         --api-key node1secret --open-rate-limit 0
+```
+
+See `configs/small_federation.toml` for an example configuration file.


### PR DESCRIPTION
## Summary
- add CLI options for API key and open rate limit
- implement API key middleware and optional simple rate limiter
- provide sample deployment configs and a basic deployment guide

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68490de6413483248c04421d932962f7