### PR TITLE
[runtime] consolidate DAG storage trait

### DIFF
--- a/crates/icn-node/src/main.rs
+++ b/crates/icn-node/src/main.rs
@@ -33,7 +33,6 @@ use icn_runtime::context::{
 };
 use icn_runtime::{host_anchor_receipt, host_submit_mesh_job, ReputationUpdater};
 
-use async_trait::async_trait;
 use axum::{
     extract::{Path as AxumPath, State},
     http::StatusCode,
@@ -50,9 +49,9 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::sync::{Mutex as AsyncMutex, Mutex as TokioMutex};
 
 #[cfg(feature = "enable-libp2p")]
 use libp2p::{Multiaddr, PeerId as Libp2pPeerId};
@@ -144,49 +143,6 @@ enum StorageBackendType {
     Sqlite,
 }
 
-#[derive(Debug)]
-struct DagStoreAdapter<S: icn_dag::StorageService<CoreDagBlock> + Send + std::fmt::Debug> {
-    inner: Mutex<S>,
-}
-
-impl<S: icn_dag::StorageService<CoreDagBlock> + Send + std::fmt::Debug> DagStoreAdapter<S> {
-    fn new(inner: S) -> Self {
-        Self {
-            inner: Mutex::new(inner),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl<S> icn_runtime::context::StorageService for DagStoreAdapter<S>
-where
-    S: icn_dag::StorageService<CoreDagBlock> + Send + 'static + std::fmt::Debug,
-{
-    async fn put(&self, data: &[u8]) -> Result<Cid, icn_runtime::context::HostAbiError> {
-        let block = CoreDagBlock {
-            cid: Cid::new_v1_dummy(0x71, 0x12, data),
-            data: data.to_vec(),
-            links: vec![],
-        };
-        let mut store = self.inner.lock().unwrap();
-        store
-            .put(&block)
-            .map_err(icn_runtime::context::HostAbiError::Common)?;
-        Ok(block.cid)
-    }
-
-    async fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>, icn_runtime::context::HostAbiError> {
-        let store = self.inner.lock().unwrap();
-        match store
-            .get(cid)
-            .map_err(icn_runtime::context::HostAbiError::Common)?
-        {
-            Some(block) => Ok(Some(block.data)),
-            None => Ok(None),
-        }
-    }
-}
-
 // --- Supporting Types ---
 
 #[derive(Deserialize)]
@@ -271,7 +227,7 @@ pub async fn app_router_with_options(api_key: Option<String>, rate_limit: Option
     info!("Test/Embedded Node DID: {}", node_did);
 
     let signer = Arc::new(RuntimeStubSigner::new_with_keys(sk, pk));
-    let dag_store_for_rt = Arc::new(RuntimeStubDagStore::new());
+    let dag_store_for_rt = Arc::new(TokioMutex::new(RuntimeStubDagStore::new()));
     let mesh_network_service = Arc::new(StubMeshNetworkService::new());
     // GovernanceModule is initialized inside RuntimeContext::new
 
@@ -437,18 +393,18 @@ async fn main() {
     } else {
         info!("Using stub networking (P2P disabled)");
         let signer = Arc::new(RuntimeStubSigner::new_with_keys(node_sk, node_pk));
-        let dag_store_for_rt: Arc<dyn icn_runtime::context::StorageService> =
+        let dag_store_for_rt: Arc<TokioMutex<dyn icn_dag::StorageService<CoreDagBlock> + Send>> =
             match cli.storage_backend {
-                StorageBackendType::Memory => Arc::new(RuntimeStubDagStore::new()),
+                StorageBackendType::Memory => Arc::new(TokioMutex::new(RuntimeStubDagStore::new())),
                 StorageBackendType::File => {
                     let store = FileDagStore::new(cli.storage_path.clone())
                         .expect("Failed to init file store");
-                    Arc::new(DagStoreAdapter::new(store))
+                    Arc::new(TokioMutex::new(store))
                 }
                 StorageBackendType::Sqlite => {
                     let store = SqliteDagStore::new(cli.storage_path.clone())
                         .expect("Failed to init sqlite store");
-                    Arc::new(DagStoreAdapter::new(store))
+                    Arc::new(TokioMutex::new(store))
                 }
             };
         let mesh_network_service = Arc::new(StubMeshNetworkService::new());
@@ -584,9 +540,14 @@ async fn dag_put_handler(
     Json(block): Json<DagBlockPayload>,
 ) -> impl IntoResponse {
     // Use RuntimeContext's dag_store now
-    match state.runtime_context.dag_store.put(&block.data).await {
-        // Assuming block.data is Vec<u8>
-        Ok(cid) => (StatusCode::CREATED, Json(cid)).into_response(),
+    let dag_block = CoreDagBlock {
+        cid: Cid::new_v1_dummy(0x71, 0x12, &block.data),
+        data: block.data,
+        links: vec![],
+    };
+    let mut store = state.runtime_context.dag_store.lock().await;
+    match store.put(&dag_block) {
+        Ok(()) => (StatusCode::CREATED, Json(dag_block.cid)).into_response(),
         Err(e) => map_rust_error_to_json_response(
             format!("DAG put error: {}", e),
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -602,8 +563,9 @@ async fn dag_get_handler(
 ) -> impl IntoResponse {
     // TODO: Parse cid_request.cid into a real Cid. For now, using a placeholder.
     let cid_to_get = Cid::new_v1_dummy(0, 0, cid_request.cid.as_bytes()); // Placeholder for Cid::from_str
-    match state.runtime_context.dag_store.get(&cid_to_get).await {
-        Ok(Some(data)) => (StatusCode::OK, Json(data)).into_response(), // Assuming data is Vec<u8>
+    let store = state.runtime_context.dag_store.lock().await;
+    match store.get(&cid_to_get) {
+        Ok(Some(block)) => (StatusCode::OK, Json(block.data)).into_response(),
         Ok(None) => map_rust_error_to_json_response("Block not found", StatusCode::NOT_FOUND)
             .into_response(),
         Err(e) => map_rust_error_to_json_response(

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1,6 +1,6 @@
 //! Defines the `RuntimeContext`, `HostEnvironment`, and related types for the ICN runtime.
 
-use icn_common::{Cid, CommonError, Did};
+use icn_common::{Cid, CommonError, DagBlock, Did};
 use icn_identity::ExecutionReceipt as IdentityExecutionReceipt;
 use icn_mesh::{ActualMeshJob, JobId, JobState, MeshJobBid};
 
@@ -56,14 +56,7 @@ pub trait Signer: Send + Sync + std::fmt::Debug {
     fn verifying_key_ref(&self) -> &VerifyingKey;
 }
 
-// Placeholder for icn-dag::StorageService (assuming it should be async)
-// Renamed from DagStore to avoid confusion if DagStore is a concrete type elsewhere.
-#[async_trait]
-pub trait StorageService: Send + Sync + std::fmt::Debug + DowncastSync {
-    async fn put(&self, data: &[u8]) -> Result<Cid, HostAbiError>;
-    async fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>, HostAbiError>;
-}
-impl_downcast!(sync StorageService);
+use icn_dag::StorageService as DagStorageService;
 
 // Placeholder for icn_economics::ManaRepository
 pub trait ManaRepository: Send + Sync + std::fmt::Debug {
@@ -437,7 +430,6 @@ impl From<CommonError> for HostAbiError {
 }
 
 // --- Runtime Context ---
-#[derive(Debug)]
 pub struct RuntimeContext {
     pub current_identity: Did,
     pub mana_ledger: SimpleManaLedger,
@@ -446,7 +438,7 @@ pub struct RuntimeContext {
     pub governance_module: Arc<TokioMutex<GovernanceModule>>,
     pub mesh_network_service: Arc<dyn MeshNetworkService>, // Uses local MeshNetworkService trait
     pub signer: Arc<dyn Signer>,
-    pub dag_store: Arc<dyn StorageService>, // Uses local StorageService trait
+    pub dag_store: Arc<TokioMutex<dyn DagStorageService<DagBlock> + Send>>, // Uses icn_dag::StorageService
 }
 
 impl RuntimeContext {
@@ -454,7 +446,7 @@ impl RuntimeContext {
         current_identity: Did,
         mesh_network_service: Arc<dyn MeshNetworkService>,
         signer: Arc<dyn Signer>,
-        dag_store: Arc<dyn StorageService>,
+        dag_store: Arc<TokioMutex<dyn DagStorageService<DagBlock> + Send>>,
     ) -> Arc<Self> {
         let job_states = Arc::new(TokioMutex::new(HashMap::new()));
         let pending_mesh_jobs = Arc::new(TokioMutex::new(VecDeque::new()));
@@ -512,7 +504,7 @@ impl RuntimeContext {
             current_identity,
             default_mesh_service,
             Arc::new(StubSigner::new()),
-            Arc::new(StubDagStore::new()),
+            Arc::new(TokioMutex::new(StubDagStore::new())),
         ))
     }
 
@@ -523,7 +515,7 @@ impl RuntimeContext {
             current_identity,
             Arc::new(StubMeshNetworkService::new()),
             Arc::new(StubSigner::new()),
-            Arc::new(StubDagStore::new()),
+            Arc::new(TokioMutex::new(StubDagStore::new())),
         )
     }
 
@@ -534,7 +526,7 @@ impl RuntimeContext {
             current_identity.clone(),
             Arc::new(StubMeshNetworkService::new()),
             Arc::new(StubSigner::new()),
-            Arc::new(StubDagStore::new()),
+            Arc::new(TokioMutex::new(StubDagStore::new())),
         );
         futures::executor::block_on(ctx.mana_ledger.set_balance(&current_identity, initial_mana));
         ctx
@@ -924,7 +916,14 @@ impl RuntimeContext {
             HostAbiError::InternalError(format!("Failed to serialize final receipt for DAG: {}", e))
         })?;
 
-        let cid = self.dag_store.put(&final_receipt_bytes).await?;
+        let block = DagBlock {
+            cid: Cid::new_v1_dummy(0x71, 0x12, &final_receipt_bytes),
+            data: final_receipt_bytes,
+            links: vec![],
+        };
+        let mut store = self.dag_store.lock().await;
+        store.put(&block).map_err(HostAbiError::Common)?;
+        let cid = block.cid.clone();
         println!("[CONTEXT] Anchored receipt for job_id {:?} with CID: {:?}. Executor: {:?}. Receipt cost {}ms.", 
                  receipt.job_id, cid, receipt.executor_did, receipt.cpu_ms);
 
@@ -1115,7 +1114,7 @@ impl RuntimeContext {
         ));
 
         // Create stub DAG store for now (can be enhanced later)
-        let dag_store = Arc::new(StubDagStore::new());
+        let dag_store = Arc::new(TokioMutex::new(StubDagStore::new()));
 
         // Create RuntimeContext with real networking - this returns Arc<Self>
         let ctx = Self::new(identity, mesh_service, signer, dag_store);
@@ -1158,7 +1157,7 @@ impl RuntimeContext {
         current_identity: Did,
         signer: StubSigner,
         mesh_network_service: Arc<StubMeshNetworkService>,
-        dag_store: Arc<StubDagStore>,
+        dag_store: Arc<TokioMutex<StubDagStore>>,
     ) -> Arc<Self> {
         let job_states = Arc::new(TokioMutex::new(HashMap::new()));
         let pending_mesh_jobs = Arc::new(TokioMutex::new(VecDeque::new()));
@@ -1326,18 +1325,16 @@ impl Signer for StubSigner {
 
 #[derive(Debug, Clone)]
 pub struct StubDagStore {
-    // Renamed from StubStorageService for consistency if tests use this name
-    store: Arc<TokioMutex<HashMap<Cid, Vec<u8>>>>,
+    store: HashMap<Cid, DagBlock>,
 }
 impl StubDagStore {
     pub fn new() -> Self {
         Self {
-            store: Arc::new(TokioMutex::new(HashMap::new())),
+            store: HashMap::new(),
         }
     }
-    pub async fn all(&self) -> Result<HashMap<Cid, Vec<u8>>, HostAbiError> {
-        let store_lock = self.store.lock().await;
-        Ok(store_lock.clone())
+    pub fn all(&self) -> HashMap<Cid, DagBlock> {
+        self.store.clone()
     }
 }
 
@@ -1348,29 +1345,23 @@ impl Default for StubDagStore {
 }
 
 pub type RuntimeStubDagStore = StubDagStore;
-#[async_trait]
-impl StorageService for StubDagStore {
-    // Implements the local async StorageService trait
-    async fn put(&self, data: &[u8]) -> Result<Cid, HostAbiError> {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        std::hash::Hash::hash_slice(data, &mut hasher);
-        let hash_val = std::hash::Hasher::finish(&hasher);
-        let cid = Cid::new_v1_dummy(0x70, 0x12, &hash_val.to_ne_bytes());
-
-        let mut store_lock = self.store.lock().await;
-        store_lock.insert(cid.clone(), data.to_vec());
-        println!("[StubDagStore] Stored data with CID: {:?}", cid);
-        Ok(cid)
+impl DagStorageService<DagBlock> for StubDagStore {
+    fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
+        self.store.insert(block.cid.clone(), block.clone());
+        Ok(())
     }
-    async fn get(&self, cid: &Cid) -> Result<Option<Vec<u8>>, HostAbiError> {
-        let store_lock = self.store.lock().await;
-        let data = store_lock.get(cid).cloned();
-        if data.is_some() {
-            println!("[StubDagStore] Retrieved data for CID: {:?}", cid);
-        } else {
-            println!("[StubDagStore] No data found for CID: {:?}", cid);
-        }
-        Ok(data)
+
+    fn get(&self, cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
+        Ok(self.store.get(cid).cloned())
+    }
+
+    fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        self.store.remove(cid);
+        Ok(())
+    }
+
+    fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
+        Ok(self.store.contains_key(cid))
     }
 }
 

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -17,7 +17,8 @@ pub mod context;
 pub mod executor;
 
 // Re-export important types for convenience
-pub use context::{HostAbiError, RuntimeContext, Signer, StorageService};
+pub use context::{HostAbiError, RuntimeContext, Signer};
+pub use icn_dag::StorageService;
 
 // Re-export ABI constants
 pub use abi::*;
@@ -300,26 +301,44 @@ pub async fn host_anchor_receipt(
 }
 
 /// Creates a governance proposal using the runtime context.
-pub async fn host_create_governance_proposal(ctx: &RuntimeContext, payload_json: &str) -> Result<String, HostAbiError> {
-    let payload: context::CreateProposalPayload = serde_json::from_str(payload_json)
-        .map_err(|e| HostAbiError::InvalidParameters(format!("Failed to parse CreateProposalPayload JSON: {}", e)))?;
+pub async fn host_create_governance_proposal(
+    ctx: &RuntimeContext,
+    payload_json: &str,
+) -> Result<String, HostAbiError> {
+    let payload: context::CreateProposalPayload =
+        serde_json::from_str(payload_json).map_err(|e| {
+            HostAbiError::InvalidParameters(format!(
+                "Failed to parse CreateProposalPayload JSON: {}",
+                e
+            ))
+        })?;
     ctx.create_governance_proposal(payload).await
 }
 
 /// Casts a governance vote using the runtime context.
-pub async fn host_cast_governance_vote(ctx: &RuntimeContext, payload_json: &str) -> Result<(), HostAbiError> {
-    let payload: context::CastVotePayload = serde_json::from_str(payload_json)
-        .map_err(|e| HostAbiError::InvalidParameters(format!("Failed to parse CastVotePayload JSON: {}", e)))?;
+pub async fn host_cast_governance_vote(
+    ctx: &RuntimeContext,
+    payload_json: &str,
+) -> Result<(), HostAbiError> {
+    let payload: context::CastVotePayload = serde_json::from_str(payload_json).map_err(|e| {
+        HostAbiError::InvalidParameters(format!("Failed to parse CastVotePayload JSON: {}", e))
+    })?;
     ctx.cast_governance_vote(payload).await
 }
 
 /// Closes voting on a governance proposal. Currently not implemented.
-pub async fn host_close_governance_proposal_voting(ctx: &RuntimeContext, proposal_id: &str) -> Result<String, HostAbiError> {
+pub async fn host_close_governance_proposal_voting(
+    ctx: &RuntimeContext,
+    proposal_id: &str,
+) -> Result<String, HostAbiError> {
     ctx.close_governance_proposal_voting(proposal_id).await
 }
 
 /// Executes an accepted governance proposal. Currently not implemented.
-pub async fn host_execute_governance_proposal(ctx: &RuntimeContext, proposal_id: &str) -> Result<(), HostAbiError> {
+pub async fn host_execute_governance_proposal(
+    ctx: &RuntimeContext,
+    proposal_id: &str,
+) -> Result<(), HostAbiError> {
     ctx.execute_governance_proposal(proposal_id).await
 }
 
@@ -358,7 +377,7 @@ mod tests {
             test_did,
             Arc::new(StubMeshNetworkService::new()),
             Arc::new(StubSigner::new()),
-            Arc::new(StubDagStore::new()),
+            Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         )
     }
 

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -8,11 +8,12 @@
 // crates/icn-runtime/tests/mesh.rs
 
 use icn_common::{Cid, Did};
+use icn_dag::StorageService;
 use icn_identity::{ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes};
 use icn_mesh::{ActualMeshJob, JobId, JobSpec, JobState, MeshJobBid, Resources};
 use icn_runtime::context::{
     HostAbiError, JobAssignmentNotice, LocalMeshSubmitReceiptMessage, MeshNetworkService,
-    RuntimeContext, StorageService, StubDagStore, StubMeshNetworkService,
+    RuntimeContext, StubDagStore, StubMeshNetworkService,
 };
 use icn_runtime::host_submit_mesh_job;
 use serde_json::json;

--- a/tests/integration/job_pipeline.rs
+++ b/tests/integration/job_pipeline.rs
@@ -10,6 +10,7 @@ use icn_runtime::{
 use icn_mesh::{JobSpec, JobState}; // Added JobState
 use serde_json::json;
 use tokio::time::sleep;
+use tokio::sync::Mutex;
 use icn_common::Did; // Added Did
 use std::str::FromStr; // For Did::from_str
 
@@ -22,7 +23,7 @@ async fn end_to_end_mesh_job_execution() {
 
     let signer = StubSigner::new_with_keys(sk, pk);
     let net = Arc::new(StubMeshNetworkService::default()); // Assumes Default trait
-    let dag = Arc::new(RuntimeStubDagStore::default());   // Assumes Default trait
+    let dag = Arc::new(tokio::sync::Mutex::new(RuntimeStubDagStore::default()));   // Assumes Default trait
     
     // Using a simplified constructor or assuming one exists that takes these components.
     // The user provided `new_for_test` which I will add.
@@ -50,7 +51,7 @@ async fn end_to_end_mesh_job_execution() {
     sleep(Duration::from_secs(5)).await; 
 
     // 4. Check for anchored receipt in stub DAG
-    let all_dag_items = dag.all().await.expect("dag.all() failed"); // Assumes all() method
+    let all_dag_items = dag.lock().await.all();
     
     // We need to find the specific receipt for our job_id or verify its presence.
     // A generic check for !all_dag_items.is_empty() is a good start.


### PR DESCRIPTION
## Summary
- use `icn_dag::StorageService<DagBlock>` directly in `icn-runtime`
- update runtime context and executor to lock storage backends
- adapt `icn-node` to pass `StorageService` implementations
- adjust integration tests for new storage type

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68491249c694832493f0894e6d14ce05