### PR TITLE
[icn-network] enable kademlia peer discovery

### DIFF
--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -19,11 +19,15 @@ use downcast_rs::{impl_downcast, DowncastSync};
 use icn_common::{Cid, CommonError, DagBlock, Did, NodeInfo};
 use icn_identity::ExecutionReceipt;
 use icn_mesh::{ActualMeshJob as Job, JobId, MeshJobBid as Bid};
+#[cfg(feature = "libp2p")]
+use libp2p::PeerId as Libp2pPeerId;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::Debug;
+#[cfg(feature = "libp2p")]
+use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::mpsc::Receiver;
 // Removed unused imports for testing Kademlia disabled build
@@ -54,6 +58,22 @@ impl PeerId {
     }
     pub fn to_string(&self) -> String {
         self.0.clone()
+    }
+}
+
+#[cfg(feature = "libp2p")]
+impl From<Libp2pPeerId> for PeerId {
+    fn from(p: Libp2pPeerId) -> Self {
+        PeerId(p.to_string())
+    }
+}
+
+#[cfg(feature = "libp2p")]
+impl std::convert::TryFrom<PeerId> for Libp2pPeerId {
+    type Error = libp2p::identity::ParseError;
+
+    fn try_from(value: PeerId) -> Result<Self, Self::Error> {
+        Self::from_str(&value.0)
     }
 }
 

--- a/crates/icn-network/tests/libp2p_bootstrap.rs
+++ b/crates/icn-network/tests/libp2p_bootstrap.rs
@@ -12,8 +12,8 @@ mod libp2p_bootstrap_tests {
     use libp2p::PeerId as Libp2pPeerId;
     use std::time::Duration;
     use tokio::time::sleep;
-    #[ignore]
     #[tokio::test]
+    #[ignore]
     async fn test_two_nodes_discover_each_other() {
         println!("Starting test_two_nodes_discover_each_other...");
 

--- a/crates/icn-network/tests/reconnect.rs
+++ b/crates/icn-network/tests/reconnect.rs
@@ -1,0 +1,52 @@
+#![allow(
+    unused_imports,
+    clippy::clone_on_copy,
+    clippy::uninlined_format_args,
+    clippy::field_reassign_with_default
+)]
+
+#[cfg(feature = "libp2p")]
+mod reconnect_tests {
+    use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
+    use icn_network::NetworkService;
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn test_reconnect_after_restart() {
+        let listen_addr: libp2p::Multiaddr = "/ip4/127.0.0.1/tcp/34001".parse().unwrap();
+        let config1 = NetworkConfig {
+            listen_addresses: vec![listen_addr.clone()],
+            ..NetworkConfig::default()
+        };
+        let node1 = Libp2pNetworkService::new(config1).await.expect("n1");
+        let peer1 = *node1.local_peer_id();
+
+        // node2 with small bootstrap interval
+        let config2 = NetworkConfig {
+            bootstrap_peers: vec![(peer1, listen_addr.clone())],
+            bootstrap_interval: Duration::from_secs(2),
+            ..NetworkConfig::default()
+        };
+        let node2 = Libp2pNetworkService::new(config2).await.expect("n2 start");
+
+        sleep(Duration::from_secs(3)).await;
+        assert!(node2.get_network_stats().await.unwrap().peer_count > 0);
+
+        node2.shutdown().await.unwrap();
+
+        // restart node2
+        let config2b = NetworkConfig {
+            bootstrap_peers: vec![(peer1, listen_addr.clone())],
+            bootstrap_interval: Duration::from_secs(2),
+            ..NetworkConfig::default()
+        };
+        let node2b = Libp2pNetworkService::new(config2b).await.expect("n2b");
+
+        sleep(Duration::from_secs(5)).await;
+        assert!(node2b.get_network_stats().await.unwrap().peer_count > 0);
+
+        node1.shutdown().await.unwrap();
+        node2b.shutdown().await.unwrap();
+    }
+}

--- a/crates/icn-node/src/main.rs
+++ b/crates/icn-node/src/main.rs
@@ -103,11 +103,12 @@ struct Cli {
     node_name: Option<String>,
 
     #[clap(
-        long,
+        long = "listen-address",
+        alias = "p2p-listen-addr",
         default_value = "/ip4/0.0.0.0/tcp/0",
         help = "Libp2p listen address for P2P networking"
     )]
-    p2p_listen_addr: String,
+    listen_address: String,
 
     #[clap(
         long,
@@ -358,7 +359,7 @@ async fn main() {
         {
             info!(
                 "Enabling libp2p networking with P2P listen address: {}",
-                cli.p2p_listen_addr
+                cli.listen_address
             );
 
             // Parse bootstrap peers if provided
@@ -400,7 +401,7 @@ async fn main() {
             };
 
             let listen_addr = cli
-                .p2p_listen_addr
+                .listen_address
                 .parse::<Multiaddr>()
                 .expect("Invalid p2p listen multiaddr");
             let listen_addrs = vec![listen_addr];


### PR DESCRIPTION
## Summary
- add libp2p PeerId conversions for Kademlia
- expose `--listen-address` CLI flag in `icn-node`
- extend network tests with reconnection scenario
- keep discovery tests but ignore by default

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6849144e8a008324b526ee16982f2f83