### PR TITLE
[dag][economics][runtime] sqlite persistence and file ledger

### DIFF
--- a/MULTI_NODE_GUIDE.md
+++ b/MULTI_NODE_GUIDE.md
@@ -11,8 +11,9 @@ This guide explains how to set up and run a local multi-node InterCooperative Ne
     cargo build --package icn-node --features with-libp2p
     ```
 2.  **Understanding CLI Arguments**: Familiarize yourself with the `icn-node` CLI arguments. Key arguments for multi-node setups include:
-    *   `--storage-backend file`: To ensure each node has persistent, independent storage.
-    *   `--storage-path <PATH>`: Unique path for each node's data (e.g., `./node1_data`, `./node2_data`).
+    *   `--storage-backend file`: Store DAG blocks on disk using simple files.
+    *   `--storage-backend sqlite`: Persist DAG blocks in a SQLite database (requires the `persist-sqlite` feature).
+    *   `--storage-path <PATH>`: Unique path for each node's data (e.g., `./node1_data`, `./node2_data`). The mana ledger file `mana_ledger.json` will be stored here.
     *   `--network-backend libp2p`: Essential for actual P2P communication.
     *   `--listen-address <MULTIADDR>` (Future): Will specify the network address each node listens on (e.g., `/ip4/127.0.0.1/tcp/6001`).
     *   `--bootstrap-peers <MULTIADDR_LIST>` (Future): Comma-separated list of multiaddresses of other peers to connect to for discovery.

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -31,6 +31,8 @@ bincode = "1.3"
 [dev-dependencies]
 anyhow = "1.0.75"
 wat = "1.0"
+# For temporary ledger storage during tests
+tempfile = "3"
 # temp-dir = "0.1"
 
 [features]

--- a/crates/icn-runtime/examples/libp2p_demo.rs
+++ b/crates/icn-runtime/examples/libp2p_demo.rs
@@ -38,7 +38,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Test basic runtime functionality still works
     let identity = icn_common::Did::from_str(node_identity)?;
-    runtime_ctx.mana_ledger.set_balance(&identity, 1000).await;
+    runtime_ctx
+        .mana_ledger
+        .set_balance(&identity, 1000)
+        .expect("init mana");
 
     let balance = runtime_ctx.get_mana(&identity).await?;
     println!("✅ Mana operations working: balance = {balance}");

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -300,26 +300,44 @@ pub async fn host_anchor_receipt(
 }
 
 /// Creates a governance proposal using the runtime context.
-pub async fn host_create_governance_proposal(ctx: &RuntimeContext, payload_json: &str) -> Result<String, HostAbiError> {
-    let payload: context::CreateProposalPayload = serde_json::from_str(payload_json)
-        .map_err(|e| HostAbiError::InvalidParameters(format!("Failed to parse CreateProposalPayload JSON: {}", e)))?;
+pub async fn host_create_governance_proposal(
+    ctx: &RuntimeContext,
+    payload_json: &str,
+) -> Result<String, HostAbiError> {
+    let payload: context::CreateProposalPayload =
+        serde_json::from_str(payload_json).map_err(|e| {
+            HostAbiError::InvalidParameters(format!(
+                "Failed to parse CreateProposalPayload JSON: {}",
+                e
+            ))
+        })?;
     ctx.create_governance_proposal(payload).await
 }
 
 /// Casts a governance vote using the runtime context.
-pub async fn host_cast_governance_vote(ctx: &RuntimeContext, payload_json: &str) -> Result<(), HostAbiError> {
-    let payload: context::CastVotePayload = serde_json::from_str(payload_json)
-        .map_err(|e| HostAbiError::InvalidParameters(format!("Failed to parse CastVotePayload JSON: {}", e)))?;
+pub async fn host_cast_governance_vote(
+    ctx: &RuntimeContext,
+    payload_json: &str,
+) -> Result<(), HostAbiError> {
+    let payload: context::CastVotePayload = serde_json::from_str(payload_json).map_err(|e| {
+        HostAbiError::InvalidParameters(format!("Failed to parse CastVotePayload JSON: {}", e))
+    })?;
     ctx.cast_governance_vote(payload).await
 }
 
 /// Closes voting on a governance proposal. Currently not implemented.
-pub async fn host_close_governance_proposal_voting(ctx: &RuntimeContext, proposal_id: &str) -> Result<String, HostAbiError> {
+pub async fn host_close_governance_proposal_voting(
+    ctx: &RuntimeContext,
+    proposal_id: &str,
+) -> Result<String, HostAbiError> {
     ctx.close_governance_proposal_voting(proposal_id).await
 }
 
 /// Executes an accepted governance proposal. Currently not implemented.
-pub async fn host_execute_governance_proposal(ctx: &RuntimeContext, proposal_id: &str) -> Result<(), HostAbiError> {
+pub async fn host_execute_governance_proposal(
+    ctx: &RuntimeContext,
+    proposal_id: &str,
+) -> Result<(), HostAbiError> {
     ctx.execute_governance_proposal(proposal_id).await
 }
 
@@ -365,9 +383,9 @@ mod tests {
     fn create_test_context_with_mana(initial_mana: u64) -> Arc<RuntimeContext> {
         let ctx = create_test_context();
         let test_did = Did::from_str(TEST_IDENTITY_DID_STR).unwrap();
-        futures::executor::block_on(async {
-            ctx.mana_ledger.set_balance(&test_did, initial_mana).await;
-        });
+        ctx.mana_ledger
+            .set_balance(&test_did, initial_mana)
+            .expect("set initial mana");
         ctx
     }
 
@@ -590,7 +608,9 @@ mod tests {
         let other_account_id = OTHER_IDENTITY_DID_STR;
 
         let other_did = Did::from_str(other_account_id).unwrap();
-        futures::executor::block_on(ctx.mana_ledger.set_balance(&other_did, 50));
+        ctx.mana_ledger
+            .set_balance(&other_did, 50)
+            .expect("set mana for other did");
 
         let spend_amount = 10u64;
         let result = host_account_spend_mana(&mut ctx, other_account_id, spend_amount).await;

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -44,7 +44,7 @@ mod runtime_host_abi_tests {
         runtime_ctx
             .mana_ledger
             .set_balance(&identity_did, initial_mana)
-            .await;
+            .expect("init mana");
 
         Ok(runtime_ctx)
     }

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -49,7 +49,10 @@ mod cross_node_tests {
         
         // Set initial mana for the identity
         let identity = Did::from_str(&identity_str)?;
-        ctx.mana_ledger.set_balance(&identity, initial_mana).await;
+        ctx
+            .mana_ledger
+            .set_balance(&identity, initial_mana)
+            .expect("init mana");
         
         Ok(ctx)
     }

--- a/crates/icn-runtime/tests/integration/libp2p_integration.rs
+++ b/crates/icn-runtime/tests/integration/libp2p_integration.rs
@@ -34,7 +34,10 @@ mod libp2p_integration_tests {
         
         // Test basic mana operations still work
         let identity = Did::from_str(node_identity).unwrap();
-        ctx.mana_ledger.set_balance(&identity, 1000).await;
+        ctx
+            .mana_ledger
+            .set_balance(&identity, 1000)
+            .expect("init mana");
         
         let balance = ctx.get_mana(&identity).await;
         assert!(balance.is_ok(), "Failed to get mana balance: {:?}", balance.err());

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -581,7 +581,7 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
     node_a_ctx
         .mana_ledger
         .set_balance(&node_a_ctx.current_identity, 1000)
-        .await;
+        .expect("set mana for node A");
     println!("[test-mesh-runtime] Node A context created, mana set. Spawning Job Manager.");
     node_a_ctx.clone().spawn_mesh_job_manager().await;
 
@@ -610,7 +610,7 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
     node_b_ctx
         .mana_ledger
         .set_balance(&node_b_ctx.current_identity, 500)
-        .await;
+        .expect("set mana for node B");
     println!("[test-mesh-runtime] Node B context created, mana set.");
 
     // Get the underlying Libp2pNetworkService for Node B to broadcast messages


### PR DESCRIPTION
## Summary
- implement `ManaLedger` for file-backed ledger
- use `FileManaLedger` inside runtime context
- clarify sqlite usage in the multi-node guide
- update tests and examples for new ledger API

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68491453a3ac8324a5515b3cb8a1aadc