### PR TITLE
[network] governance propagation support

### DIFF
--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -68,6 +68,7 @@ pub enum NetworkMessage {
     JobAssignmentNotification(JobId, Did),
     SubmitReceipt(ExecutionReceipt),
     ProposalAnnouncement(Vec<u8>),
+    VoteAnnouncement(Vec<u8>),
 }
 
 impl NetworkMessage {
@@ -82,6 +83,7 @@ impl NetworkMessage {
             NetworkMessage::JobAssignmentNotification(_, _) => "JobAssignmentNotification",
             NetworkMessage::SubmitReceipt(_) => "SubmitReceipt",
             NetworkMessage::ProposalAnnouncement(_) => "ProposalAnnouncement",
+            NetworkMessage::VoteAnnouncement(_) => "VoteAnnouncement",
         }
     }
 }

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -44,3 +44,8 @@ persist-sled = ["icn-governance/persist-sled"]
 name = "cross_node_job_execution"
 path = "tests/cross_node_job_execution.rs"
 required-features = ["enable-libp2p"]
+
+[[test]]
+name = "cross_node_governance"
+path = "tests/integration/cross_node_governance.rs"
+required-features = ["enable-libp2p"]

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -178,6 +178,7 @@ pub struct CastVotePayload {
 pub trait MeshNetworkService: Send + Sync + std::fmt::Debug + DowncastSync {
     async fn announce_job(&self, job: &ActualMeshJob) -> Result<(), HostAbiError>;
     async fn announce_proposal(&self, proposal_bytes: Vec<u8>) -> Result<(), HostAbiError>;
+    async fn announce_vote(&self, vote_bytes: Vec<u8>) -> Result<(), HostAbiError>;
     async fn collect_bids_for_job(
         &self,
         job_id: &JobId,
@@ -240,6 +241,14 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             .broadcast_message(msg)
             .await
             .map_err(|e| HostAbiError::NetworkError(format!("Failed to announce proposal: {}", e)))
+    }
+
+    async fn announce_vote(&self, vote_bytes: Vec<u8>) -> Result<(), HostAbiError> {
+        let msg = NetworkMessage::VoteAnnouncement(vote_bytes);
+        self.inner
+            .broadcast_message(msg)
+            .await
+            .map_err(|e| HostAbiError::NetworkError(format!("Failed to announce vote: {}", e)))
     }
 
     async fn collect_bids_for_job(
@@ -1028,9 +1037,26 @@ impl RuntimeContext {
                 )))
             }
         };
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         let mut gov = self.governance_module.lock().await;
         gov.cast_vote(self.current_identity.clone(), &proposal_id, vote_option)
-            .map_err(HostAbiError::Common)
+            .map_err(HostAbiError::Common)?;
+        let vote = icn_governance::Vote {
+            voter: self.current_identity.clone(),
+            proposal_id: proposal_id.clone(),
+            option: vote_option,
+            voted_at: now,
+        };
+        drop(gov);
+        let encoded = bincode::serialize(&vote)
+            .map_err(|e| HostAbiError::InternalError(format!("Failed to serialize vote: {}", e)))?;
+        if let Err(e) = self.mesh_network_service.announce_vote(encoded).await {
+            warn!("Failed to broadcast vote for {:?}: {}", proposal_id, e);
+        }
+        Ok(())
     }
 
     pub async fn close_governance_proposal_voting(
@@ -1070,6 +1096,21 @@ impl RuntimeContext {
         }
         gov.insert_external_proposal(proposal)
             .map_err(HostAbiError::Common)
+    }
+
+    /// Inserts a vote received from the network into the local GovernanceModule.
+    pub async fn ingest_external_vote(&self, vote_bytes: &[u8]) -> Result<(), HostAbiError> {
+        let vote: icn_governance::Vote = bincode::deserialize(vote_bytes)
+            .map_err(|e| HostAbiError::InternalError(format!("Failed to decode vote: {}", e)))?;
+        let mut gov = self.governance_module.lock().await;
+        if gov
+            .get_proposal(&vote.proposal_id)
+            .map_err(HostAbiError::Common)?
+            .is_none()
+        {
+            return Ok(());
+        }
+        gov.insert_external_vote(vote).map_err(HostAbiError::Common)
     }
 
     /// Create a new RuntimeContext with real libp2p networking
@@ -1416,6 +1457,11 @@ impl MeshNetworkService for StubMeshNetworkService {
 
     async fn announce_proposal(&self, _proposal_bytes: Vec<u8>) -> Result<(), HostAbiError> {
         println!("[StubMeshNetworkService] Announced proposal (stub)");
+        Ok(())
+    }
+
+    async fn announce_vote(&self, _vote_bytes: Vec<u8>) -> Result<(), HostAbiError> {
+        println!("[StubMeshNetworkService] Announced vote (stub)");
         Ok(())
     }
 

--- a/crates/icn-runtime/tests/integration/cross_node_governance.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_governance.rs
@@ -1,0 +1,92 @@
+#[cfg(feature = "enable-libp2p")]
+mod cross_node_governance {
+    use icn_governance::Proposal;
+    use icn_network::{NetworkMessage, NetworkService};
+    use icn_runtime::context::RuntimeContext;
+    use icn_runtime::{host_cast_governance_vote, host_create_governance_proposal};
+    use libp2p::{Multiaddr, PeerId as Libp2pPeerId};
+    use std::sync::Arc;
+    use tokio::time::{sleep, timeout, Duration};
+
+    async fn create_ctx(
+        id_suffix: &str,
+        bootstrap: Option<Vec<(Libp2pPeerId, Multiaddr)>>,
+    ) -> anyhow::Result<Arc<RuntimeContext>> {
+        let id = format!("did:key:z6Mkgov{id_suffix}");
+        let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
+        let ctx = RuntimeContext::new_with_real_libp2p(&id, listen, bootstrap).await?;
+        Ok(ctx)
+    }
+
+    #[tokio::test]
+    async fn proposal_and_vote_propagate() -> anyhow::Result<()> {
+        let node_a = create_ctx("A", None).await?;
+        let a_net = node_a.get_libp2p_service()?;
+        let a_peer = *a_net.local_peer_id();
+        let mut addrs = Vec::new();
+        for _ in 0..10 {
+            sleep(Duration::from_millis(500)).await;
+            addrs = a_net.listening_addresses();
+            if !addrs.is_empty() {
+                break;
+            }
+        }
+        assert!(!addrs.is_empty());
+
+        let node_b = create_ctx("B", Some(vec![(a_peer, addrs[0].clone())])).await?;
+        let b_net = node_b.get_libp2p_service()?;
+        sleep(Duration::from_secs(2)).await;
+
+        let mut b_rx = b_net.subscribe().await?;
+        let mut a_rx = a_net.subscribe().await?;
+
+        let payload = serde_json::json!({
+            "proposal_type_str": "GenericText",
+            "type_specific_payload": b"hello".to_vec(),
+            "description": "test",
+            "duration_secs": 60
+        });
+        let pid_str = host_create_governance_proposal(&node_a, &payload.to_string()).await?;
+
+        let proposal_bytes = timeout(Duration::from_secs(10), async {
+            loop {
+                if let Some(NetworkMessage::ProposalAnnouncement(bytes)) = b_rx.recv().await {
+                    break bytes;
+                }
+            }
+        })
+        .await
+        .expect("timeout waiting for proposal");
+        node_b.ingest_external_proposal(&proposal_bytes).await?;
+        let proposal: Proposal = bincode::deserialize(&proposal_bytes)?;
+        {
+            let gov = node_b.governance_module.lock().await;
+            assert!(gov.get_proposal(&proposal.id)?.is_some());
+        }
+
+        let vote_payload = serde_json::json!({
+            "proposal_id_str": proposal.id.0,
+            "vote_option_str": "yes"
+        });
+        host_cast_governance_vote(&node_b, &vote_payload.to_string()).await?;
+
+        let vote_bytes = timeout(Duration::from_secs(10), async {
+            loop {
+                if let Some(NetworkMessage::VoteAnnouncement(bytes)) = a_rx.recv().await {
+                    break bytes;
+                }
+            }
+        })
+        .await
+        .expect("timeout waiting for vote");
+        node_a.ingest_external_vote(&vote_bytes).await?;
+        {
+            let gov = node_a.governance_module.lock().await;
+            let pid = icn_governance::ProposalId(pid_str.clone());
+            let prop = gov.get_proposal(&pid)?.unwrap();
+            assert_eq!(prop.votes.len(), 1);
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- add VoteAnnouncement type in icn-network
- propagate votes via MeshNetworkService in icn-runtime
- allow GovernanceModule to ingest external votes
- test cross-node proposal and vote propagation

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68491454e1d88324bd80a019a73a58a8