### PR TITLE
[ci] ensure clippy component installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
 
+      - name: Install clippy component
+        run: rustup component add clippy
+
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- add explicit installation of clippy to CI workflow

## Testing
- `cargo fmt --all -- --check` *(fails: trailing characters at line 1 column 47)*
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: Failed to create mana ledger "./mana_ledger.json"*)

------
https://chatgpt.com/codex/tasks/task_e_684bda3304c083249a244964c4cfc1c6