### PR TITLE
[repo] ignore ccl governance db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Cargo.lock
 # Logs and temporary
 *.log
 tmp/
+icn-ccl/governance_db/


### PR DESCRIPTION
## Summary
- clean up leftover governance_db data
- keep the icn-ccl/governance_db directory out of git

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace`

------
https://chatgpt.com/codex/tasks/task_e_684cf3a80e20832496c8568fbd0c0094