### PR TITLE
[icn-dag] persistent dag store + merkle verification

### DIFF
--- a/crates/icn-common/Cargo.toml
+++ b/crates/icn-common/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0" # For examples and potentially some utils
 bs58 = "0.5.0" # For CID string representation example
 thiserror = "1.0" # For idiomatic error definitions
+sha2 = "0.10"
 
 [dev-dependencies]
 # No specific dev-dependencies yet, but common ones like `pretty_assertions` could be added here.

--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -13,14 +13,17 @@ serde_json = "1.0"
 sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
 rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
+rocksdb = { version = "0.21", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"
 sled = { version = "0.34", optional = false }
 bincode = { version = "1.3", optional = false }
 rusqlite = { version = "0.29", optional = false, features = ["bundled"] }
+rocksdb = { version = "0.21", optional = false }
 
 [features]
 default = ["persist-sled"]
 persist-sled = ["dep:sled", "dep:bincode"]
 persist-sqlite = ["dep:rusqlite"]
+persist-rocksdb = ["dep:rocksdb", "dep:bincode"]

--- a/crates/icn-dag/src/index.rs
+++ b/crates/icn-dag/src/index.rs
@@ -1,0 +1,46 @@
+use icn_common::{Cid, DagBlock, DagLink};
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Default)]
+pub struct DagTraversalIndex {
+    adjacency: HashMap<Cid, Vec<Cid>>,
+}
+
+impl DagTraversalIndex {
+    pub fn new() -> Self {
+        Self {
+            adjacency: HashMap::new(),
+        }
+    }
+
+    pub fn index_block(&mut self, block: &DagBlock) {
+        self.adjacency.insert(
+            block.cid.clone(),
+            block.links.iter().map(|l| l.cid.clone()).collect(),
+        );
+    }
+
+    pub fn remove_block(&mut self, cid: &Cid) {
+        self.adjacency.remove(cid);
+        for children in self.adjacency.values_mut() {
+            children.retain(|c| c != cid);
+        }
+    }
+
+    pub fn traverse(&self, start: &Cid) -> Vec<Cid> {
+        let mut visited = HashSet::new();
+        let mut stack = vec![start.clone()];
+        let mut order = Vec::new();
+        while let Some(cid) = stack.pop() {
+            if visited.insert(cid.clone()) {
+                order.push(cid.clone());
+                if let Some(children) = self.adjacency.get(&cid) {
+                    for child in children.iter().rev() {
+                        stack.push(child.clone());
+                    }
+                }
+            }
+        }
+        order
+    }
+}

--- a/crates/icn-dag/src/sqlite_store.rs
+++ b/crates/icn-dag/src/sqlite_store.rs
@@ -22,6 +22,7 @@ impl SqliteDagStore {
 
 impl StorageService<DagBlock> for SqliteDagStore {
     fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
+        icn_common::verify_block_integrity(block)?;
         let encoded = serde_json::to_vec(block).map_err(|e| {
             CommonError::SerializationError(format!(
                 "Failed to serialize block {}: {}",

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -527,22 +527,36 @@ impl RuntimeContext {
     pub fn new_with_stubs(current_identity_str: &str) -> Arc<Self> {
         let current_identity = Did::from_str(current_identity_str)
             .expect("Invalid DID for test context in new_with_stubs");
+        #[cfg(feature = "persist-sqlite")]
+        let dag_store = Arc::new(TokioMutex::new(
+            icn_dag::sqlite_store::SqliteDagStore::new(PathBuf::from("./dag.sqlite")).unwrap(),
+        ));
+        #[cfg(not(feature = "persist-sqlite"))]
+        let dag_store = Arc::new(TokioMutex::new(StubDagStore::new()));
+
         Self::new(
             current_identity,
             Arc::new(StubMeshNetworkService::new()),
             Arc::new(StubSigner::new()),
-            Arc::new(TokioMutex::new(StubDagStore::new())),
+            dag_store,
         )
     }
 
     pub fn new_with_stubs_and_mana(current_identity_str: &str, initial_mana: u64) -> Arc<Self> {
         let current_identity = Did::from_str(current_identity_str)
             .expect("Invalid DID for test context in new_with_stubs_and_mana");
+        #[cfg(feature = "persist-sqlite")]
+        let dag_store = Arc::new(TokioMutex::new(
+            icn_dag::sqlite_store::SqliteDagStore::new(PathBuf::from("./dag.sqlite")).unwrap(),
+        ));
+        #[cfg(not(feature = "persist-sqlite"))]
+        let dag_store = Arc::new(TokioMutex::new(StubDagStore::new()));
+
         let ctx = Self::new(
             current_identity.clone(),
             Arc::new(StubMeshNetworkService::new()),
             Arc::new(StubSigner::new()),
-            Arc::new(TokioMutex::new(StubDagStore::new())),
+            dag_store,
         );
         ctx.mana_ledger
             .set_balance(&current_identity, initial_mana)


### PR DESCRIPTION
## Summary
- add SHA-256 CID helper and integrity check
- implement RocksDB DAG store
- add traversal index cache
- store validation on insert
- use SQLite store for runtime stubs

## Testing
- `cargo test -p icn-common`
- `cargo fmt --all -- --check`
- *(failed to run full `cargo clippy` and workspace tests due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684cfeef0ef483248e75cd6caa81a316