### PR TITLE
[icn-ccl] store SHA-256 source hash

### DIFF
--- a/icn-ccl/Cargo.toml
+++ b/icn-ccl/Cargo.toml
@@ -13,6 +13,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 hex = "0.4" # Added for placeholder CID/hash generation in cli.rs
+# Hashing
+sha2 = "0.10"
 # WASM generation
 wasm-encoder = "0.233"
 # wasm-tools = "1.208"  # Example, for WASM manipulation/validation

--- a/icn-ccl/src/cli.rs
+++ b/icn-ccl/src/cli.rs
@@ -1,23 +1,38 @@
 // icn-ccl/src/cli.rs
+use crate::error::CclError;
+use crate::metadata::ContractMetadata;
+use crate::optimizer::Optimizer;
 use crate::parser::parse_ccl_source;
 use crate::semantic_analyzer::SemanticAnalyzer;
-use crate::optimizer::Optimizer;
 use crate::wasm_backend::WasmBackend;
-use crate::metadata::ContractMetadata;
-use crate::error::CclError;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::PathBuf;
 // use icn_common::Cid; // If calculating actual CIDs
 
 // This function would be called by `icn-cli ccl compile ...`
-pub fn compile_ccl_file(source_path: &PathBuf, output_wasm_path: &PathBuf, output_meta_path: &PathBuf) -> Result<ContractMetadata, CclError> {
-    println!("[CCL CLI Lib] Compiling {} to {} (meta: {})", source_path.display(), output_wasm_path.display(), output_meta_path.display());
+pub fn compile_ccl_file(
+    source_path: &PathBuf,
+    output_wasm_path: &PathBuf,
+    output_meta_path: &PathBuf,
+) -> Result<ContractMetadata, CclError> {
+    println!(
+        "[CCL CLI Lib] Compiling {} to {} (meta: {})",
+        source_path.display(),
+        output_wasm_path.display(),
+        output_meta_path.display()
+    );
 
-    let source_code = fs::read_to_string(source_path)
-        .map_err(|e| CclError::IoError(format!("Failed to read source file {}: {}", source_path.display(), e)))?;
+    let source_code = fs::read_to_string(source_path).map_err(|e| {
+        CclError::IoError(format!(
+            "Failed to read source file {}: {}",
+            source_path.display(),
+            e
+        ))
+    })?;
 
     let ast = parse_ccl_source(&source_code)?;
-    
+
     let mut semantic_analyzer = SemanticAnalyzer::new();
     semantic_analyzer.analyze(&ast)?;
 
@@ -29,23 +44,40 @@ pub fn compile_ccl_file(source_path: &PathBuf, output_wasm_path: &PathBuf, outpu
 
     // Calculate CID of wasm_bytecode (placeholder)
     // In reality, use icn_dag or similar to produce a real CID
-    let wasm_cid_placeholder = format!("bafy2bzace{}", hex::encode(&wasm_bytecode[0..min(10, wasm_bytecode.len())])); // Very rough placeholder
+    let wasm_cid_placeholder = format!(
+        "bafy2bzace{}",
+        hex::encode(&wasm_bytecode[0..min(10, wasm_bytecode.len())])
+    ); // Very rough placeholder
     metadata.cid = wasm_cid_placeholder;
 
-    // TODO: Calculate source_hash for metadata
-    // For a proper hash, you'd use a crypto library e.g. sha2::Sha256
-    metadata.source_hash = format!("sha256:placeholder_{}", hex::encode(&source_code.as_bytes()[0..min(10, source_code.len())]));
+    // Calculate SHA-256 hash of the source code
+    let hash = Sha256::digest(source_code.as_bytes());
+    metadata.source_hash = format!("sha256:{:x}", hash);
 
+    fs::write(output_wasm_path, &wasm_bytecode).map_err(|e| {
+        CclError::IoError(format!(
+            "Failed to write WASM file {}: {}",
+            output_wasm_path.display(),
+            e
+        ))
+    })?;
 
-    fs::write(output_wasm_path, &wasm_bytecode)
-        .map_err(|e| CclError::IoError(format!("Failed to write WASM file {}: {}", output_wasm_path.display(), e)))?;
-    
-    let metadata_json = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| CclError::InternalCompilerError(format!("Failed to serialize metadata: {}", e)))?;
-    fs::write(output_meta_path, metadata_json)
-        .map_err(|e| CclError::IoError(format!("Failed to write metadata file {}: {}", output_meta_path.display(), e)))?;
+    let metadata_json = serde_json::to_string_pretty(&metadata).map_err(|e| {
+        CclError::InternalCompilerError(format!("Failed to serialize metadata: {}", e))
+    })?;
+    fs::write(output_meta_path, metadata_json).map_err(|e| {
+        CclError::IoError(format!(
+            "Failed to write metadata file {}: {}",
+            output_meta_path.display(),
+            e
+        ))
+    })?;
 
-    println!("[CCL CLI Lib] Compilation successful. WASM: {}, Meta: {}", output_wasm_path.display(), output_meta_path.display());
+    println!(
+        "[CCL CLI Lib] Compilation successful. WASM: {}, Meta: {}",
+        output_wasm_path.display(),
+        output_meta_path.display()
+    );
     Ok(metadata)
 }
 
@@ -62,7 +94,11 @@ pub fn check_ccl_file(source_path: &PathBuf) -> Result<(), CclError> {
 
 // This function would be called by `icn-cli ccl fmt ...`
 pub fn format_ccl_file(source_path: &PathBuf, _inplace: bool) -> Result<String, CclError> {
-    println!("[CCL CLI Lib] Formatting {} (Inplace: {}) (Formatting logic pending)", source_path.display(), _inplace);
+    println!(
+        "[CCL CLI Lib] Formatting {} (Inplace: {}) (Formatting logic pending)",
+        source_path.display(),
+        _inplace
+    );
     let source_code = fs::read_to_string(source_path)?;
     // TODO: Implement actual CCL auto-formatter using the Pest grammar and AST
     // For now, just return the original source
@@ -70,12 +106,19 @@ pub fn format_ccl_file(source_path: &PathBuf, _inplace: bool) -> Result<String, 
 }
 
 // This function would be called by `icn-cli ccl explain ...`
-pub fn explain_ccl_policy(source_path: &PathBuf, _target_construct: Option<String>) -> Result<String, CclError> {
-     println!("[CCL CLI Lib] Explaining {} (Target: {:?}) (Explanation logic pending)", source_path.display(), _target_construct);
+pub fn explain_ccl_policy(
+    source_path: &PathBuf,
+    _target_construct: Option<String>,
+) -> Result<String, CclError> {
+    println!(
+        "[CCL CLI Lib] Explaining {} (Target: {:?}) (Explanation logic pending)",
+        source_path.display(),
+        _target_construct
+    );
     // TODO: Implement logic to analyze a CCL policy and explain its behavior,
     // potentially focusing on a specific rule or function.
     Ok(format!("Explanation for {} (stub):\nThis policy is designed to govern resources based on CCL principles.", source_path.display()))
 }
 
 // Helper for min, replace with std::cmp::min
-use std::cmp::min; 
+use std::cmp::min;

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 // icn-ccl/tests/integration_tests.rs
 #![allow(clippy::uninlined_format_args)]
 use icn_ccl::{compile_ccl_source_to_wasm, CclError, ContractMetadata};
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
@@ -47,6 +48,13 @@ fn test_compile_ccl_file_cli_function() {
             let meta_content = fs::read_to_string(&output_meta_path).unwrap();
             let parsed_meta: ContractMetadata = serde_json::from_str(&meta_content).unwrap();
             assert_eq!(parsed_meta.cid, metadata.cid); // Check consistency
+
+            let expected_hash = {
+                let digest = Sha256::digest(source_content.as_bytes());
+                format!("sha256:{:x}", digest)
+            };
+            assert_eq!(metadata.source_hash, expected_hash);
+            assert_eq!(parsed_meta.source_hash, expected_hash);
 
             println!(
                 "CLI compile_ccl_file test successful. Metadata: {:?}",


### PR DESCRIPTION
## Summary
- compute SHA-256 hash of CCL source in CLI compile path
- depend on `sha2`
- assert hash is set in CLI compile test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-ccl --all-targets --all-features -- -D warnings` *(fails: unused imports in icn-dag)*
- `cargo test -p icn-ccl`

------
https://chatgpt.com/codex/tasks/task_e_684d0423d69083249dff983bcf33bd46