### PR TITLE
[runtime] implement host env methods

### DIFF
--- a/crates/icn-dag/src/index.rs
+++ b/crates/icn-dag/src/index.rs
@@ -1,4 +1,4 @@
-use icn_common::{Cid, DagBlock, DagLink};
+use icn_common::{Cid, DagBlock};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Default)]

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -6,10 +6,11 @@
 //! storage and manipulation, crucial for the InterCooperative Network (ICN) data model.
 //! It handles DAG primitives, content addressing, storage abstraction, and serialization formats.
 
-use icn_common::{
-    compute_merkle_cid, verify_block_integrity, Cid, CommonError, DagBlock, DagLink, NodeInfo,
-    ICN_CORE_VERSION,
-};
+#[cfg(test)]
+use icn_common::compute_merkle_cid;
+#[cfg(test)]
+use icn_common::DagLink;
+use icn_common::{Cid, CommonError, DagBlock, NodeInfo, ICN_CORE_VERSION};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions}; // For FileDagStore

--- a/crates/icn-dag/src/rocksdb_store.rs
+++ b/crates/icn-dag/src/rocksdb_store.rs
@@ -1,5 +1,4 @@
 use crate::{Cid, CommonError, DagBlock, StorageService};
-use icn_common::verify_block_integrity;
 use rocksdb::{Options, DB};
 use std::path::PathBuf;
 


### PR DESCRIPTION
## Summary
- implement ConcreteHostEnvironment methods using RuntimeContext
- fix unused imports in icn-dag
- test env functions for invalid UTF-8, invalid DID, and insufficient mana

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: could not complete within time constraints)*

------
https://chatgpt.com/codex/tasks/task_e_684d02e8ae1c8324bb455cbf0a546278