### PR TITLE
[icn-network] enable libp2p mesh integration tests

### DIFF
--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -1,5 +1,4 @@
-#[cfg(all(test, feature = "libp2p"))]
-#[cfg(any())]
+#![cfg(feature = "libp2p")]
 mod libp2p_mesh_integration {
     #![allow(
         unused_imports,


### PR DESCRIPTION
## Summary
- allow libp2p mesh integration tests to compile when the libp2p feature is enabled

## Testing
- `cargo check -p icn-network --features libp2p`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process was interrupted)*
- `cargo test --all-features --workspace` *(failed: process was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684d02ec8c108324b1b5813a87ea9a7a