### PR TITLE
[icn-node] gate sqlite store feature

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -31,6 +31,7 @@ async-trait = "0.1"
 default = ["icn-network/default"]
 with-libp2p = ["icn-network/libp2p", "icn-runtime/enable-libp2p", "enable-libp2p", "dep:libp2p"]
 enable-libp2p = []
+persist-sqlite = ["icn-dag/persist-sqlite"]
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json"] }


### PR DESCRIPTION
## Summary
- gate SqliteDagStore usage behind `persist-sqlite`
- add `persist-sqlite` feature to icn-node crate
- show runtime error if sqlite backend selected without feature

## Testing
- `cargo check --features persist-sqlite`
- `cargo check`
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-node --all-targets -- -D warnings` *(fails: unexpected `cfg` condition value)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684dec9c42448324b9ba0ee5dc945f89