### PR TITLE
[mesh/runtime] implement selection and mana refunds

### DIFF
--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -425,4 +425,33 @@ mod tests {
 
         assert_eq!(selected.unwrap(), high);
     }
+
+    #[test]
+    fn test_select_executor_uses_price_when_reputation_equal() {
+        let job_id = dummy_cid("job_price");
+        let a = Did::from_str("did:icn:test:a").unwrap();
+        let b = Did::from_str("did:icn:test:b").unwrap();
+
+        let rep_store = icn_reputation::InMemoryReputationStore::new();
+        rep_store.set_score(a.clone(), 3);
+        rep_store.set_score(b.clone(), 3);
+
+        let bid_a = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: a.clone(),
+            price_mana: 20,
+            resources: Resources::default(),
+        };
+        let bid_b = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: b.clone(),
+            price_mana: 5,
+            resources: Resources::default(),
+        };
+
+        let policy = SelectionPolicy;
+        let selected = select_executor(&job_id, vec![bid_a, bid_b.clone()], &policy, &rep_store);
+
+        assert_eq!(selected.unwrap(), b);
+    }
 }

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -15,6 +15,7 @@ icn-mesh = { path = "../icn-mesh" }
 icn-network = { path = "../icn-network", features = ["libp2p"] }
 icn-dag = { path = "../icn-dag" }
 icn-governance = { path = "../icn-governance", default-features = false, features = ["serde"] }
+icn-reputation = { path = "../icn-reputation" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- enhance mesh executor selection logic
- track reputation and mana in runtime context
- refund mana on failed job and update reputation on completion
- add coverage tests

## Testing
- `cargo clippy -p icn-mesh -p icn-runtime --all-targets --all-features -- -D warnings`
- `cargo test -p icn-mesh -p icn-runtime`

------
https://chatgpt.com/codex/tasks/task_e_684decb138ac83248ccf64704d09bfda