### PR TITLE
[cli] fix outdated TODO

### DIFF
--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -312,4 +312,4 @@ async fn handle_gov_get_proposal(
     Ok(())
 }
 
-// TODO: Add tests for CLI commands, possibly using a mock HTTP server or by running the actual icn-node.
+// CLI command behavior is tested in `crates/icn-cli/tests`.


### PR DESCRIPTION
## Summary
- remove outdated TODO comment in the icn-cli crate

## Testing
- `cargo fmt --edition 2021 crates/icn-cli/src/main.rs`
- `timeout 20s cargo test --all-features --workspace` *(fails: timeout)*
- `timeout 20s cargo clippy --all-targets --all-features -- -D warnings` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684e30667610832481e6fc7bb963abb3