### PR TITLE
[icn-runtime] update reputation updater

### DIFF
--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -253,18 +253,16 @@ pub async fn host_account_credit_mana(
 }
 
 // Placeholder for a reputation updater service/struct
+use icn_reputation::ReputationStore;
+
 pub struct ReputationUpdater;
 
 impl ReputationUpdater {
     pub fn new() -> Self {
         ReputationUpdater
     }
-    pub fn submit(&self, receipt: &icn_identity::ExecutionReceipt) {
-        // TODO: Implement actual reputation update logic
-        println!(
-            "[ReputationUpdater STUB] Submitted receipt for job_id: {:?}, executor: {:?}",
-            receipt.job_id, receipt.executor_did
-        );
+    pub fn submit(&self, store: &dyn ReputationStore, receipt: &icn_identity::ExecutionReceipt) {
+        store.record_receipt(receipt);
     }
 }
 
@@ -296,7 +294,7 @@ pub async fn host_anchor_receipt(
     info!("[host_anchor_receipt] Receipt for job {:?} (executor {:?}) anchored with CID: {:?}. CPU cost: {}ms", 
           receipt.job_id, receipt.executor_did, anchored_cid, receipt.cpu_ms);
 
-    reputation_updater.submit(&receipt); // This is a stub for now
+    reputation_updater.submit(ctx.reputation_store.as_ref(), &receipt);
     Ok(anchored_cid)
 }
 

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -1,0 +1,39 @@
+use icn_common::Cid;
+use icn_identity::{ExecutionReceipt, SignatureBytes};
+use icn_runtime::{context::RuntimeContext, host_anchor_receipt, ReputationUpdater};
+
+#[tokio::test]
+async fn anchor_receipt_updates_reputation() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:rep", 0);
+    let job_id = Cid::new_v1_dummy(0x55, 0x13, b"rep_job");
+    let result_cid = Cid::new_v1_dummy(0x55, 0x14, b"res");
+
+    let receipt = ExecutionReceipt {
+        job_id: job_id.clone(),
+        executor_did: ctx.current_identity.clone(),
+        result_cid,
+        cpu_ms: 1,
+        sig: SignatureBytes(Vec::new()),
+    };
+
+    let mut msg = Vec::new();
+    msg.extend_from_slice(receipt.job_id.to_string().as_bytes());
+    msg.extend_from_slice(ctx.current_identity.to_string().as_bytes());
+    msg.extend_from_slice(receipt.result_cid.to_string().as_bytes());
+    msg.extend_from_slice(&receipt.cpu_ms.to_le_bytes());
+    let sig_bytes = ctx.signer.sign(&msg).expect("sign");
+    let mut signed_receipt = receipt.clone();
+    signed_receipt.sig = SignatureBytes(sig_bytes);
+
+    let json = serde_json::to_string(&signed_receipt).unwrap();
+    let updater = ReputationUpdater::new();
+
+    host_anchor_receipt(&ctx, &json, &updater)
+        .await
+        .expect("anchor");
+
+    assert_eq!(
+        ctx.reputation_store.get_reputation(&ctx.current_identity),
+        1
+    );
+}


### PR DESCRIPTION
## Summary
- wire ReputationStore into ReputationUpdater
- update host_anchor_receipt to record reputation
- add a unit test to confirm score updates

## Testing
- `cargo check -p icn-runtime`
- `cargo test -p icn-runtime anchor_receipt_updates_reputation -- --nocapture`
- `cargo fmt`

------
https://chatgpt.com/codex/tasks/task_e_684e3067d7ec8324b28d6602ae393248