### PR TITLE
[cli] clarify comment about CLI command tests

### DIFF
--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -312,4 +312,4 @@ async fn handle_gov_get_proposal(
     Ok(())
 }
 
-// CLI command behavior is tested in `crates/icn-cli/tests`.
+// CLI command behavior is covered by tests in `crates/icn-cli/tests`.


### PR DESCRIPTION
## Summary
- clarify CLI comment about where tests live

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: environment limits)*
- `cargo test --all-features --workspace` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684e4e957bb88324b1080e7dc5cd084f