### PR TITLE
[icn-runtime] log reputation updates

### DIFF
--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -262,7 +262,16 @@ impl ReputationUpdater {
         ReputationUpdater
     }
     pub fn submit(&self, store: &dyn ReputationStore, receipt: &icn_identity::ExecutionReceipt) {
+        let before = store.get_reputation(&receipt.executor_did);
         store.record_receipt(receipt);
+        let after = store.get_reputation(&receipt.executor_did);
+        log::debug!(
+            "[ReputationUpdater] Executor {:?} reputation {} -> {} via receipt {:?}",
+            receipt.executor_did,
+            before,
+            after,
+            receipt.job_id
+        );
     }
 }
 

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -37,3 +37,20 @@ async fn anchor_receipt_updates_reputation() {
         1
     );
 }
+#[test]
+fn reputation_updater_increments_store() {
+    let store = icn_reputation::InMemoryReputationStore::new();
+    let updater = ReputationUpdater::new();
+    let did = icn_common::Did::new("key", "tester");
+    let receipt = ExecutionReceipt {
+        job_id: Cid::new_v1_dummy(0x55, 0x15, b"rep"),
+        executor_did: did.clone(),
+        result_cid: Cid::new_v1_dummy(0x55, 0x15, b"res"),
+        cpu_ms: 1,
+        sig: SignatureBytes(Vec::new()),
+    };
+    updater.submit(&store, &receipt);
+    assert_eq!(store.get_reputation(&did), 1);
+    updater.submit(&store, &receipt);
+    assert_eq!(store.get_reputation(&did), 2);
+}


### PR DESCRIPTION
## Summary
- extend `ReputationUpdater::submit` to log before/after scores
- add unit test for direct submission via `ReputationUpdater`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not finish in environment)*
- `cargo test --all-features --workspace` *(failed: could not finish in environment)*

------
https://chatgpt.com/codex/tasks/task_e_684e4e96b41c8324af9e64f73f89d94c