### PR TITLE
[runtime] persist mana ledger with sled

### DIFF
--- a/icn-runtime/tests/ledger_persistence.rs
+++ b/icn-runtime/tests/ledger_persistence.rs
@@ -1,0 +1,31 @@
+use icn_runtime::context::{RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner};
+use icn_common::Did;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
+
+#[tokio::test]
+async fn mana_persists_across_contexts() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let ledger_path = temp_dir.path().join("mana.sled");
+    let did = Did::parse("did:example:alice").unwrap();
+
+    let ctx1 = RuntimeContext::new_with_ledger_path(
+        did.clone(),
+        Arc::new(StubMeshNetworkService::new()),
+        Arc::new(StubSigner::new()),
+        Arc::new(TokioMutex::new(StubDagStore::new())),
+        ledger_path.clone(),
+    );
+    ctx1.mana_ledger.set_balance(&did, 42).unwrap();
+    drop(ctx1);
+
+    let ctx2 = RuntimeContext::new_with_ledger_path(
+        did.clone(),
+        Arc::new(StubMeshNetworkService::new()),
+        Arc::new(StubSigner::new()),
+        Arc::new(TokioMutex::new(StubDagStore::new())),
+        ledger_path,
+    );
+    assert_eq!(ctx2.mana_ledger.get_balance(&did), 42);
+}


### PR DESCRIPTION
## Summary
- add `new_with_ledger_path` to `RuntimeContext` to allow specifying the mana ledger location
- load the mana ledger from that path and use it across instances
- update helper constructors to use the new method
- test mana persistence across runtime restarts

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to finish due to environment limits)*
- `cargo test --all-features --workspace` *(failed to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684e4e9a2364832491418cd4076c8825