### PR TITLE
[runtime] verify receipts via DidResolver

### DIFF
--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -82,6 +82,22 @@ pub fn verifying_key_from_did_key(did: &Did) -> Result<VerifyingKey, CommonError
         .map_err(|e| CommonError::IdentityError(format!("Invalid verifying key bytes: {e}")))
 }
 
+/// Resolves a [`Did`] to a verifying key.
+pub trait DidResolver: Send + Sync {
+    /// Return the verifying key associated with `did`.
+    fn resolve(&self, did: &Did) -> Result<VerifyingKey, CommonError>;
+}
+
+/// Simple resolver for `did:key` identifiers.
+#[derive(Debug, Default)]
+pub struct KeyDidResolver;
+
+impl DidResolver for KeyDidResolver {
+    fn resolve(&self, did: &Did) -> Result<VerifyingKey, CommonError> {
+        verifying_key_from_did_key(did)
+    }
+}
+
 /// Convenience wrapper around signing raw bytes with an Ed25519 SigningKey.
 pub fn sign_message(sk: &SigningKey, msg: &[u8]) -> EdSignature {
     sk.sign(msg)

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -1,16 +1,36 @@
 use icn_common::Cid;
-use icn_identity::{ExecutionReceipt, SignatureBytes};
-use icn_runtime::{context::RuntimeContext, host_anchor_receipt, ReputationUpdater};
+use icn_identity::{
+    did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt, SignatureBytes,
+};
+use icn_runtime::{
+    context::{RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner},
+    host_anchor_receipt, ReputationUpdater,
+};
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
 
 #[tokio::test]
 async fn anchor_receipt_updates_reputation() {
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:rep", 0);
+    let (sk, pk) = generate_ed25519_keypair();
+    let did_str = did_key_from_verifying_key(&pk);
+    let did = icn_common::Did::from_str(&did_str).unwrap();
+    let signer = StubSigner::new_with_keys(sk, pk);
+    let ctx = RuntimeContext::new_for_test(
+        did.clone(),
+        signer,
+        Arc::new(StubMeshNetworkService::new()),
+        Arc::new(TokioMutex::new(StubDagStore::new())),
+    );
+    ctx.mana_ledger
+        .set_balance(&did, 0)
+        .expect("set initial mana");
     let job_id = Cid::new_v1_dummy(0x55, 0x13, b"rep_job");
     let result_cid = Cid::new_v1_dummy(0x55, 0x14, b"res");
 
     let receipt = ExecutionReceipt {
         job_id: job_id.clone(),
-        executor_did: ctx.current_identity.clone(),
+        executor_did: did.clone(),
         result_cid,
         cpu_ms: 1,
         sig: SignatureBytes(Vec::new()),
@@ -18,7 +38,7 @@ async fn anchor_receipt_updates_reputation() {
 
     let mut msg = Vec::new();
     msg.extend_from_slice(receipt.job_id.to_string().as_bytes());
-    msg.extend_from_slice(ctx.current_identity.to_string().as_bytes());
+    msg.extend_from_slice(did.to_string().as_bytes());
     msg.extend_from_slice(receipt.result_cid.to_string().as_bytes());
     msg.extend_from_slice(&receipt.cpu_ms.to_le_bytes());
     let sig_bytes = ctx.signer.sign(&msg).expect("sign");


### PR DESCRIPTION
## Summary
- add `DidResolver` trait in `icn-identity`
- verify execution receipts using resolver in `RuntimeContext`
- test receipt verification with real keys in reputation test

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684e653e8f448324b9f8fd67c875abf8