### PR TITLE
[runtime] host metrics counters

### DIFF
--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -28,12 +28,16 @@ downcast-rs = "1.2.0"
 futures = "0.3"
 wasmtime = { version = "15", features = ["async"] }
 bincode = "1.3"
+once_cell = "1.21"
+prometheus-client = "0.22"
 
 [dev-dependencies]
 anyhow = "1.0.75"
 wat = "1.0"
 # For temporary ledger storage during tests
 tempfile = "3"
+# Ensure sequential execution for metrics tests
+serial_test = { version = "3", features = ["async"] }
 # temp-dir = "0.1"
 
 [features]

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod abi;
 pub mod context;
 pub mod executor;
+pub mod metrics;
 
 // Re-export important types for convenience
 pub use context::{HostAbiError, RuntimeContext, Signer};
@@ -54,7 +55,7 @@ pub async fn host_submit_mesh_job(
     ctx: &RuntimeContext,
     job_json: &str,
 ) -> Result<Cid, HostAbiError> {
-    // TODO: record metric `icn_runtime_abi_call_total{method="host_submit_mesh_job"}`
+    metrics::HOST_SUBMIT_MESH_JOB_CALLS.inc();
     println!(
         "[RUNTIME_ABI] host_submit_mesh_job called with job_json: {}",
         job_json
@@ -121,7 +122,7 @@ pub async fn host_submit_mesh_job(
 pub fn host_get_pending_mesh_jobs(
     ctx: &RuntimeContext,
 ) -> Result<Vec<icn_mesh::ActualMeshJob>, HostAbiError> {
-    // TODO: record metric `icn_runtime_abi_call_total{method="host_get_pending_mesh_jobs"}`
+    metrics::HOST_GET_PENDING_MESH_JOBS_CALLS.inc();
     println!("[RUNTIME_ABI] host_get_pending_mesh_jobs called.");
 
     // Directly clone the jobs from the queue. This provides a snapshot.
@@ -152,7 +153,7 @@ pub async fn host_account_get_mana(
     ctx: &RuntimeContext,
     account_id_str: &str,
 ) -> Result<u64, HostAbiError> {
-    // TODO: record metric `icn_runtime_abi_call_total{method="host_account_get_mana"}`
+    metrics::HOST_ACCOUNT_GET_MANA_CALLS.inc();
     println!(
         "[RUNTIME_ABI] host_account_get_mana called for account: {}",
         account_id_str
@@ -185,7 +186,7 @@ pub async fn host_account_spend_mana(
     account_id_str: &str,
     amount: u64,
 ) -> Result<(), HostAbiError> {
-    // TODO: record metric `icn_runtime_abi_call_total{method="host_account_spend_mana"}`
+    metrics::HOST_ACCOUNT_SPEND_MANA_CALLS.inc();
     println!(
         "[RUNTIME_ABI] host_account_spend_mana called for account: {} amount: {}",
         account_id_str, amount
@@ -650,5 +651,51 @@ mod tests {
         assert_eq!(ctx.current_identity.to_string(), node_did_str);
         let balance = ctx.get_mana(&ctx.current_identity).await.unwrap();
         assert_eq!(balance, initial_mana);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_metrics_increment_on_host_submit_mesh_job() {
+        use crate::metrics::HOST_SUBMIT_MESH_JOB_CALLS;
+        let ctx = create_test_context_with_mana(50);
+        let job = create_test_mesh_job(10);
+        let job_json = serde_json::to_string(&job).unwrap();
+        let before = HOST_SUBMIT_MESH_JOB_CALLS.get();
+        host_submit_mesh_job(&ctx, &job_json).await.unwrap();
+        assert!(HOST_SUBMIT_MESH_JOB_CALLS.get() > before);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_metrics_increment_on_host_get_pending_mesh_jobs() {
+        use crate::metrics::HOST_GET_PENDING_MESH_JOBS_CALLS;
+        let ctx = create_test_context();
+        let before = HOST_GET_PENDING_MESH_JOBS_CALLS.get();
+        host_get_pending_mesh_jobs(&ctx).unwrap();
+        assert!(HOST_GET_PENDING_MESH_JOBS_CALLS.get() > before);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_metrics_increment_on_host_account_get_mana() {
+        use crate::metrics::HOST_ACCOUNT_GET_MANA_CALLS;
+        let ctx = create_test_context_with_mana(20);
+        let before = HOST_ACCOUNT_GET_MANA_CALLS.get();
+        host_account_get_mana(&ctx, TEST_IDENTITY_DID_STR)
+            .await
+            .unwrap();
+        assert!(HOST_ACCOUNT_GET_MANA_CALLS.get() > before);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_metrics_increment_on_host_account_spend_mana() {
+        use crate::metrics::HOST_ACCOUNT_SPEND_MANA_CALLS;
+        let ctx = create_test_context_with_mana(20);
+        let before = HOST_ACCOUNT_SPEND_MANA_CALLS.get();
+        host_account_spend_mana(&ctx, TEST_IDENTITY_DID_STR, 5)
+            .await
+            .unwrap();
+        assert!(HOST_ACCOUNT_SPEND_MANA_CALLS.get() > before);
     }
 }

--- a/crates/icn-runtime/src/metrics.rs
+++ b/crates/icn-runtime/src/metrics.rs
@@ -1,0 +1,14 @@
+use once_cell::sync::Lazy;
+use prometheus_client::metrics::counter::Counter;
+
+/// Counts calls to `host_submit_mesh_job`.
+pub static HOST_SUBMIT_MESH_JOB_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Counts calls to `host_get_pending_mesh_jobs`.
+pub static HOST_GET_PENDING_MESH_JOBS_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Counts calls to `host_account_get_mana`.
+pub static HOST_ACCOUNT_GET_MANA_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Counts calls to `host_account_spend_mana`.
+pub static HOST_ACCOUNT_SPEND_MANA_CALLS: Lazy<Counter> = Lazy::new(Counter::default);

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -1,5 +1,6 @@
 use icn_common::Cid;
 use icn_identity::{ExecutionReceipt, SignatureBytes};
+use icn_reputation::ReputationStore;
 use icn_runtime::{context::RuntimeContext, host_anchor_receipt, ReputationUpdater};
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- count calls to host ABI functions with new Prometheus counters
- integrate metrics into `host_submit_mesh_job`, `host_get_pending_mesh_jobs`, `host_account_get_mana`, and `host_account_spend_mana`
- expose counters via new `metrics` module
- import `ReputationStore` trait for reputation tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-runtime --all-targets --all-features -- -D warnings`
- `cargo test -p icn-runtime` *(fails: could not acquire lock on `mana_ledger.sled`)*

------
https://chatgpt.com/codex/tasks/task_e_684e654055348324a61496cd03de41bc