### PR TITLE
[ci] run icn-cli tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --workspace
 
+      - name: Run icn-cli integration tests
+        run: cargo test --all-features -p icn-cli
+
       - name: Build release (nightly only, for early detection of issues)
         if: matrix.rust == 'nightly'
         run: cargo build --release --all-features --workspace


### PR DESCRIPTION
## Summary
- run CLI tests directly in CI workflow

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build hang)*
- `cargo test --all-features --workspace` *(failed: could not compile `icn-runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_684f5683c6948324a0e10697a95a570b