### PR TITLE
[common|runtime] clean stale TODOs

### DIFF
--- a/crates/icn-common/Cargo.toml
+++ b/crates/icn-common/Cargo.toml
@@ -16,5 +16,3 @@ sha2 = "0.10"
 
 [dev-dependencies]
 # No specific dev-dependencies yet, but common ones like `pretty_assertions` could be added here.
-
-# TODO: Add other common utility crates like 'hex', 'log', 'thiserror' as needed.

--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -112,8 +112,6 @@ pub enum CommonError {
     NotImplemented(String),
 }
 
-// TODO: Define struct for DIDs (e.g., pub struct Did { method: String, id_string: String, ... })
-// TODO: Define struct for CIDs (e.g., pub struct Cid { version: u64, codec: u64, hash: Vec<u8> })
 // TODO: Define common traits e.g. pub trait Signable { fn sign(&self, key: &Key) -> Signature; fn verify(&self, signature: &Signature, public_key: &PublicKey) -> bool; }
 
 // --- Real Protocol Data Models ---
@@ -316,7 +314,6 @@ pub struct Transaction {
 }
 
 // TODO: Define `DidDocument` struct for DID resolution.
-// TODO: Define structs for cryptographic keys (`PublicKey`, `PrivateKey`, `KeyPair`) and signatures.
 
 #[cfg(test)]
 mod tests {

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -42,7 +42,6 @@ serial_test = { version = "3", features = ["async"] }
 
 [features]
 default = []
-# TODO: Define features if needed, e.g., for different execution environments or optional components.
 enable-libp2p = ["dep:libp2p"]
 persist-sled = ["icn-governance/persist-sled"]
 

--- a/crates/icn-runtime/src/abi.rs
+++ b/crates/icn-runtime/src/abi.rs
@@ -9,7 +9,6 @@ pub const ABI_HOST_ACCOUNT_GET_MANA: u32 = 10;
 
 /// ABI Index for `host_account_spend_mana`.
 /// Attempts to spend mana from the current account/identity.
-/// TODO: Define this function and its parameters.
 pub const ABI_HOST_ACCOUNT_SPEND_MANA: u32 = 11; // Example, TBD
 
 /// ABI Index for `host_submit_mesh_job`.


### PR DESCRIPTION
## Summary
- remove outdated TODO lines from `icn-common`
- trim stale note in `icn-runtime`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: trait bounds for DidResolver)*
- `cargo test --all-features --workspace` *(fails: missing DidResolver impl)*

------
https://chatgpt.com/codex/tasks/task_e_684f568214f88324b56024d3583224bb