### PR TITLE
[reputation] sled storage and scoring updates

### DIFF
--- a/crates/icn-reputation/Cargo.toml
+++ b/crates/icn-reputation/Cargo.toml
@@ -9,3 +9,14 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-identity = { path = "../icn-identity" }
 serde = { version = "1.0", features = ["derive"] }
+sled = { version = "0.34", optional = true }
+bincode = { version = "1.3", optional = true }
+
+[dev-dependencies]
+tempfile = "3"
+sled = { version = "0.34" }
+bincode = "1.3"
+
+[features]
+default = ["persist-sled"]
+persist-sled = ["dep:sled", "dep:bincode"]

--- a/crates/icn-reputation/src/lib.rs
+++ b/crates/icn-reputation/src/lib.rs
@@ -1,23 +1,28 @@
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "persist-sled")]
+use icn_common::CommonError;
 use icn_common::Did;
 use icn_identity::ExecutionReceipt;
 use std::collections::HashMap;
+#[cfg(feature = "persist-sled")]
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 /// Store for retrieving and updating executor reputation scores.
 pub trait ReputationStore: Send + Sync {
     /// Returns the numeric reputation score for the given executor DID.
-    fn get_reputation(&self, did: &Did) -> u64;
+    fn get_reputation(&self, did: &Did) -> i64;
 
-    /// Updates reputation metrics using an execution receipt.
-    fn record_receipt(&self, receipt: &ExecutionReceipt);
+    /// Updates reputation metrics using an execution receipt and whether it
+    /// represents a successful execution.
+    fn record_receipt(&self, receipt: &ExecutionReceipt, success: bool);
 }
 
 /// Simple in-memory reputation tracker for tests.
 #[derive(Default)]
 pub struct InMemoryReputationStore {
-    scores: Mutex<HashMap<Did, u64>>,
+    scores: Mutex<HashMap<Did, i64>>,
 }
 
 impl InMemoryReputationStore {
@@ -29,20 +34,83 @@ impl InMemoryReputationStore {
     }
 
     /// Sets the reputation score for a specific executor.
-    pub fn set_score(&self, did: Did, score: u64) {
+    pub fn set_score(&self, did: Did, score: i64) {
         self.scores.lock().unwrap().insert(did, score);
     }
 }
 
 impl ReputationStore for InMemoryReputationStore {
-    fn get_reputation(&self, did: &Did) -> u64 {
+    fn get_reputation(&self, did: &Did) -> i64 {
         *self.scores.lock().unwrap().get(did).unwrap_or(&0)
     }
 
-    fn record_receipt(&self, receipt: &ExecutionReceipt) {
+    fn record_receipt(&self, receipt: &ExecutionReceipt, success: bool) {
         let mut map = self.scores.lock().unwrap();
         let entry = map.entry(receipt.executor_did.clone()).or_insert(0);
-        *entry += 1;
+        let base = if success { 1 } else { -1 };
+        let delta = base + (receipt.cpu_ms / 1000) as i64;
+        *entry += delta;
+    }
+}
+
+#[cfg(feature = "persist-sled")]
+/// Persistent reputation store backed by sled.
+pub struct SledReputationStore {
+    db: sled::Db,
+    tree_name: String,
+}
+
+#[cfg(feature = "persist-sled")]
+impl SledReputationStore {
+    /// Creates a new sled-backed reputation store at the given path.
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let db = sled::open(path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sled DB: {e}")))?;
+        Ok(Self {
+            db,
+            tree_name: "reputation_v1".into(),
+        })
+    }
+
+    fn tree(&self) -> Result<sled::Tree, CommonError> {
+        self.db
+            .open_tree(&self.tree_name)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open tree: {e}")))
+    }
+}
+
+#[cfg(feature = "persist-sled")]
+impl ReputationStore for SledReputationStore {
+    fn get_reputation(&self, did: &Did) -> i64 {
+        self.tree()
+            .and_then(|tree| {
+                Ok(
+                    match tree.get(did.to_string()).map_err(|e| {
+                        CommonError::DatabaseError(format!("Failed to read reputation: {e}"))
+                    })? {
+                        Some(val) => bincode::deserialize(&val).map_err(|e| {
+                            CommonError::DeserializationError(format!(
+                                "Failed to deserialize score: {e}"
+                            ))
+                        })?,
+                        None => 0,
+                    },
+                )
+            })
+            .unwrap_or(0)
+    }
+
+    fn record_receipt(&self, receipt: &ExecutionReceipt, success: bool) {
+        if let Ok(tree) = self.tree() {
+            let current = self.get_reputation(&receipt.executor_did);
+            let base = if success { 1 } else { -1 };
+            let delta = base + (receipt.cpu_ms / 1000) as i64;
+            let new_score = current + delta;
+            if let Ok(encoded) = bincode::serialize(&new_score) {
+                let _ = tree.insert(receipt.executor_did.to_string(), encoded);
+                let _ = tree.flush();
+            }
+        }
     }
 }
 
@@ -51,6 +119,7 @@ mod tests {
     use super::*;
     use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
     use std::str::FromStr;
+    use tempfile::tempdir;
 
     #[test]
     fn reputation_updates() {
@@ -65,7 +134,30 @@ mod tests {
             cpu_ms: 0,
             sig: icn_identity::SignatureBytes(vec![]),
         };
-        store.record_receipt(&receipt);
+        store.record_receipt(&receipt, true);
         assert_eq!(store.get_reputation(&did), 1);
+        store.record_receipt(&receipt, false);
+        assert_eq!(store.get_reputation(&did), 0);
+    }
+
+    #[cfg(feature = "persist-sled")]
+    #[test]
+    fn sled_persistence() {
+        let dir = tempdir().unwrap();
+        let store = SledReputationStore::new(dir.path().to_path_buf()).unwrap();
+        let (_sk, vk) = generate_ed25519_keypair();
+        let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+        let receipt = ExecutionReceipt {
+            job_id: icn_common::Cid::new_v1_dummy(0x55, 0x12, b"r"),
+            executor_did: did.clone(),
+            result_cid: icn_common::Cid::new_v1_dummy(0x55, 0x12, b"r"),
+            cpu_ms: 1000,
+            sig: icn_identity::SignatureBytes(vec![]),
+        };
+        store.record_receipt(&receipt, true);
+        assert_eq!(store.get_reputation(&did), 2);
+        drop(store);
+        let store2 = SledReputationStore::new(dir.path().to_path_buf()).unwrap();
+        assert_eq!(store2.get_reputation(&did), 2);
     }
 }

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -673,7 +673,7 @@ impl RuntimeContext {
                         );
                         self.credit_mana(&receipt.executor_did, job.cost_mana)
                             .await?;
-                        self.reputation_store.record_receipt(&receipt);
+                        self.reputation_store.record_receipt(&receipt, true);
                         Ok(())
                     }
                     Err(e) => {
@@ -685,6 +685,7 @@ impl RuntimeContext {
                                 reason: format!("Failed to anchor receipt: {}", e),
                             },
                         );
+                        self.reputation_store.record_receipt(&receipt, false);
                         Err(HostAbiError::DagOperationFailed(format!(
                             "Failed to anchor receipt: {}",
                             e

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -262,9 +262,14 @@ impl ReputationUpdater {
     pub fn new() -> Self {
         ReputationUpdater
     }
-    pub fn submit(&self, store: &dyn ReputationStore, receipt: &icn_identity::ExecutionReceipt) {
+    pub fn submit(
+        &self,
+        store: &dyn ReputationStore,
+        receipt: &icn_identity::ExecutionReceipt,
+        success: bool,
+    ) {
         let before = store.get_reputation(&receipt.executor_did);
-        store.record_receipt(receipt);
+        store.record_receipt(receipt, success);
         let after = store.get_reputation(&receipt.executor_did);
         log::debug!(
             "[ReputationUpdater] Executor {:?} reputation {} -> {} via receipt {:?}",
@@ -304,7 +309,7 @@ pub async fn host_anchor_receipt(
     info!("[host_anchor_receipt] Receipt for job {:?} (executor {:?}) anchored with CID: {:?}. CPU cost: {}ms", 
           receipt.job_id, receipt.executor_did, anchored_cid, receipt.cpu_ms);
 
-    reputation_updater.submit(ctx.reputation_store.as_ref(), &receipt);
+    reputation_updater.submit(ctx.reputation_store.as_ref(), &receipt, true);
     Ok(anchored_cid)
 }
 

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -71,8 +71,8 @@ fn reputation_updater_increments_store() {
         cpu_ms: 1,
         sig: SignatureBytes(Vec::new()),
     };
-    updater.submit(&store, &receipt);
+    updater.submit(&store, &receipt, true);
     assert_eq!(store.get_reputation(&did), 1);
-    updater.submit(&store, &receipt);
+    updater.submit(&store, &receipt, true);
     assert_eq!(store.get_reputation(&did), 2);
 }


### PR DESCRIPTION
## Summary
- adjust `ReputationStore` to handle success flag and use i64 scores
- apply new formula in `InMemoryReputationStore`
- add `SledReputationStore` persistent backend
- pass success boolean through `ReputationUpdater` and runtime
- test persistent store behaviour

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684f69c7cae88324b359e07d7d3d662b