### PR TITLE
[icn-reputation] sled persistence store

### DIFF
--- a/crates/icn-reputation/Cargo.toml
+++ b/crates/icn-reputation/Cargo.toml
@@ -9,3 +9,13 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-identity = { path = "../icn-identity" }
 serde = { version = "1.0", features = ["derive"] }
+sled = { version = "0.34", optional = true }
+bincode = { version = "1.3", optional = true }
+
+[dev-dependencies]
+tempfile = "3"
+sled = { version = "0.34" }
+
+[features]
+default = ["persist-sled"]
+persist-sled = ["dep:sled", "dep:bincode"]

--- a/crates/icn-reputation/src/lib.rs
+++ b/crates/icn-reputation/src/lib.rs
@@ -5,6 +5,9 @@ use icn_identity::ExecutionReceipt;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+#[cfg(feature = "persist-sled")]
+pub mod sled_store;
+
 /// Store for retrieving and updating executor reputation scores.
 pub trait ReputationStore: Send + Sync {
     /// Returns the numeric reputation score for the given executor DID.

--- a/crates/icn-reputation/src/sled_store.rs
+++ b/crates/icn-reputation/src/sled_store.rs
@@ -1,0 +1,61 @@
+//! Sled-backed implementation of `ReputationStore`.
+
+#[cfg(feature = "persist-sled")]
+use crate::ReputationStore;
+#[cfg(feature = "persist-sled")]
+use icn_common::{CommonError, Did};
+#[cfg(feature = "persist-sled")]
+use icn_identity::ExecutionReceipt;
+#[cfg(feature = "persist-sled")]
+use std::path::PathBuf;
+
+#[cfg(feature = "persist-sled")]
+use bincode;
+#[cfg(feature = "persist-sled")]
+use sled;
+
+#[cfg(feature = "persist-sled")]
+#[derive(Debug)]
+pub struct SledReputationStore {
+    tree: sled::Tree,
+}
+
+#[cfg(feature = "persist-sled")]
+impl SledReputationStore {
+    /// Opens or creates a sled database at the given path.
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let db = sled::open(path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sled DB: {e}")))?;
+        let tree = db
+            .open_tree("reputation_scores")
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open tree: {e}")))?;
+        Ok(Self { tree })
+    }
+
+    fn read_score(&self, did: &Did) -> u64 {
+        self.tree
+            .get(did.to_string())
+            .ok()
+            .and_then(|opt| opt.and_then(|ivec| bincode::deserialize(&ivec).ok()))
+            .unwrap_or(0)
+    }
+
+    fn write_score(&self, did: &Did, score: u64) {
+        if let Ok(encoded) = bincode::serialize(&score) {
+            let _ = self.tree.insert(did.to_string(), encoded);
+            let _ = self.tree.flush();
+        }
+    }
+}
+
+#[cfg(feature = "persist-sled")]
+impl ReputationStore for SledReputationStore {
+    fn get_reputation(&self, did: &Did) -> u64 {
+        self.read_score(did)
+    }
+
+    fn record_receipt(&self, receipt: &ExecutionReceipt) {
+        let current = self.read_score(&receipt.executor_did);
+        self.write_score(&receipt.executor_did, current + 1);
+    }
+}

--- a/crates/icn-reputation/tests/sled.rs
+++ b/crates/icn-reputation/tests/sled.rs
@@ -1,0 +1,33 @@
+#[cfg(feature = "persist-sled")]
+mod tests {
+    use icn_common::{Cid, Did};
+    use icn_identity::{
+        did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt, SignatureBytes,
+    };
+    use icn_reputation::{sled_store::SledReputationStore, ReputationStore};
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sled_persists_score() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().to_path_buf();
+        let store = SledReputationStore::new(path.clone()).unwrap();
+
+        let (_sk, vk) = generate_ed25519_keypair();
+        let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+        let receipt = ExecutionReceipt {
+            job_id: Cid::new_v1_dummy(0x55, 0x12, b"r"),
+            executor_did: did.clone(),
+            result_cid: Cid::new_v1_dummy(0x55, 0x12, b"r"),
+            cpu_ms: 0,
+            sig: SignatureBytes(vec![]),
+        };
+        store.record_receipt(&receipt);
+        assert_eq!(store.get_reputation(&did), 1);
+        drop(store);
+
+        let store2 = SledReputationStore::new(path).unwrap();
+        assert_eq!(store2.get_reputation(&did), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add optional sled and bincode deps with persist-sled feature
- implement `SledReputationStore`
- expose sled module in `lib.rs`
- add persistence tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timeout)*
- `cargo test --all-features --workspace` *(failed: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684f69c64be08324860250e9ed957277