### PR TITLE
[reputation] add sled backend and docs

### DIFF
--- a/crates/icn-reputation/Cargo.toml
+++ b/crates/icn-reputation/Cargo.toml
@@ -9,3 +9,14 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-identity = { path = "../icn-identity" }
 serde = { version = "1.0", features = ["derive"] }
+sled = { version = "0.34", optional = true }
+bincode = { version = "1.3", optional = true }
+
+[dev-dependencies]
+tempfile = "3.0"
+sled = { version = "0.34", optional = false }
+bincode = "1.3"
+
+[features]
+default = ["persist-sled"]
+persist-sled = ["dep:sled", "dep:bincode"]

--- a/crates/icn-reputation/README.md
+++ b/crates/icn-reputation/README.md
@@ -1,5 +1,28 @@
 # ICN Reputation Crate
 
 This crate provides reputation tracking utilities for the InterCooperative Network (ICN).
-It defines the `ReputationStore` trait used by the mesh scheduling logic and a simple
-in-memory implementation useful for testing.
+It defines the `ReputationStore` trait used by the mesh scheduling logic and ships with
+both in-memory and persistent backends.
+
+## Scoring Formula
+
+Mesh executor bids are scored using the formula implemented in `icn-mesh`:
+
+```text
+score = w_price * price_score + w_rep * reputation_score + w_res * resource_score
+```
+
+Where:
+
+* `price_score` = `1000 / bid.price_mana`
+* `reputation_score` = value returned by `ReputationStore::get_reputation`
+* `resource_score` = CPU cores + (memory_mb / 1024)
+
+The default weights are `w_price = 1.0`, `w_rep = 50.0` and `w_res = 1.0`.
+
+Executors gain reputation each time a valid execution receipt is recorded.
+
+## Available Backends
+
+* `InMemoryReputationStore` – fast, non-persistent store ideal for tests.
+* `SledReputationStore` – persistent backend backed by a [`sled`](https://github.com/spacejam/sled) database (enabled by the `persist-sled` feature).

--- a/crates/icn-reputation/src/lib.rs
+++ b/crates/icn-reputation/src/lib.rs
@@ -3,9 +3,32 @@
 use icn_common::Did;
 use icn_identity::ExecutionReceipt;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 /// Store for retrieving and updating executor reputation scores.
+///
+/// # Examples
+///
+/// ```
+/// use icn_reputation::{InMemoryReputationStore, ReputationStore};
+/// use icn_identity::{generate_ed25519_keypair, did_key_from_verifying_key, ExecutionReceipt, SignatureBytes};
+/// use icn_common::{Cid, Did};
+/// use std::str::FromStr;
+///
+/// let store = InMemoryReputationStore::new();
+/// let (_sk, vk) = generate_ed25519_keypair();
+/// let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+/// let receipt = ExecutionReceipt {
+///     job_id: Cid::new_v1_dummy(0x55, 0x12, b"r"),
+///     executor_did: did.clone(),
+///     result_cid: Cid::new_v1_dummy(0x55, 0x12, b"r"),
+///     cpu_ms: 0,
+///     sig: SignatureBytes(vec![]),
+/// };
+/// store.record_receipt(&receipt);
+/// assert_eq!(store.get_reputation(&did), 1);
+/// ```
 pub trait ReputationStore: Send + Sync {
     /// Returns the numeric reputation score for the given executor DID.
     fn get_reputation(&self, did: &Did) -> u64;
@@ -43,6 +66,87 @@ impl ReputationStore for InMemoryReputationStore {
         let mut map = self.scores.lock().unwrap();
         let entry = map.entry(receipt.executor_did.clone()).or_insert(0);
         *entry += 1;
+    }
+}
+
+#[cfg(feature = "persist-sled")]
+/// Persistent reputation tracker backed by `sled`.
+///
+/// ```
+/// use icn_reputation::{SledReputationStore, ReputationStore};
+/// use icn_identity::{generate_ed25519_keypair, did_key_from_verifying_key, ExecutionReceipt, SignatureBytes};
+/// use icn_common::{Cid, Did};
+/// use std::str::FromStr;
+/// use tempfile::TempDir;
+///
+/// let dir = TempDir::new().unwrap();
+/// let store = SledReputationStore::new(dir.path().to_path_buf()).unwrap();
+/// let (_sk, vk) = generate_ed25519_keypair();
+/// let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+/// let receipt = ExecutionReceipt {
+///     job_id: Cid::new_v1_dummy(0x55, 0x12, b"r"),
+///     executor_did: did.clone(),
+///     result_cid: Cid::new_v1_dummy(0x55, 0x12, b"r"),
+///     cpu_ms: 0,
+///     sig: SignatureBytes(vec![]),
+/// };
+/// store.record_receipt(&receipt);
+/// assert_eq!(store.get_reputation(&did), 1);
+/// ```
+pub struct SledReputationStore {
+    tree: sled::Tree,
+}
+
+#[cfg(feature = "persist-sled")]
+impl SledReputationStore {
+    pub fn new(path: PathBuf) -> Result<Self, icn_common::CommonError> {
+        let db = sled::open(path).map_err(|e| {
+            icn_common::CommonError::DatabaseError(format!("Failed to open sled DB: {e}"))
+        })?;
+        let tree = db.open_tree("reputation_scores").map_err(|e| {
+            icn_common::CommonError::DatabaseError(format!("Failed to open tree: {e}"))
+        })?;
+        Ok(Self { tree })
+    }
+
+    fn write_score(&self, did: &Did, score: u64) -> Result<(), icn_common::CommonError> {
+        let encoded = bincode::serialize(&score).map_err(|e| {
+            icn_common::CommonError::SerializationError(format!("Failed to serialize score: {e}"))
+        })?;
+        self.tree.insert(did.to_string(), encoded).map_err(|e| {
+            icn_common::CommonError::DatabaseError(format!("Failed to store score: {e}"))
+        })?;
+        self.tree.flush().map_err(|e| {
+            icn_common::CommonError::DatabaseError(format!("Failed to flush tree: {e}"))
+        })?;
+        Ok(())
+    }
+
+    fn read_score(&self, did: &Did) -> Result<u64, icn_common::CommonError> {
+        if let Some(val) = self.tree.get(did.to_string()).map_err(|e| {
+            icn_common::CommonError::DatabaseError(format!("Failed to read score: {e}"))
+        })? {
+            let score: u64 = bincode::deserialize(&val).map_err(|e| {
+                icn_common::CommonError::DeserializationError(format!(
+                    "Failed to deserialize score: {e}"
+                ))
+            })?;
+            Ok(score)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+#[cfg(feature = "persist-sled")]
+impl ReputationStore for SledReputationStore {
+    fn get_reputation(&self, did: &Did) -> u64 {
+        self.read_score(did).unwrap_or(0)
+    }
+
+    fn record_receipt(&self, receipt: &ExecutionReceipt) {
+        let current = self.read_score(&receipt.executor_did).unwrap_or(0);
+        let _ = self.write_score(&receipt.executor_did, current + 1);
     }
 }
 


### PR DESCRIPTION
## Summary
- document scoring formula and backends in icn-reputation crate
- implement `SledReputationStore`
- add rustdoc examples for `ReputationStore` and `SledReputationStore`

## Testing
- `cargo clippy -p icn-reputation --all-targets --all-features -- -D warnings`
- `cargo test -p icn-reputation`

------
https://chatgpt.com/codex/tasks/task_e_684f69c4520c83249c72f910827d151c