### PR TITLE
[reputation] update formula and trait

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -36,3 +36,4 @@ persist-sqlite = ["icn-dag/persist-sqlite"]
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
+tempfile = "3"

--- a/crates/icn-node/src/main.rs
+++ b/crates/icn-node/src/main.rs
@@ -224,7 +224,7 @@ async fn rate_limit_middleware(
 
 // --- Public App Constructor (for tests or embedding) ---
 pub async fn app_router() -> Router {
-    app_router_with_options(None, None, None).await
+    app_router_with_options(None, None, None).await.0
 }
 
 /// Construct a router for tests or embedding with optional API key and rate limit.
@@ -248,7 +248,7 @@ pub async fn app_router_with_options(
         node_did.clone(),
         mesh_network_service,
         signer,
-        Arc::new(icn_identity::KeyDidResolver::default()),
+        Arc::new(icn_identity::KeyDidResolver),
         dag_store_for_rt,
         mana_ledger_path.unwrap_or_else(|| PathBuf::from("./mana_ledger.sled")),
     );
@@ -441,7 +441,7 @@ async fn main() {
             node_did.clone(),
             mesh_network_service,
             signer,
-            Arc::new(icn_identity::KeyDidResolver::default()),
+            Arc::new(icn_identity::KeyDidResolver),
             dag_store_for_rt,
             cli.mana_ledger_path.clone(),
         )

--- a/crates/icn-runtime/examples/libp2p_demo.rs
+++ b/crates/icn-runtime/examples/libp2p_demo.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         node_identity,
         vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         None, // No bootstrap peers for this demo
+        std::path::PathBuf::from("./mana_ledger.sled"),
     )
     .await?;
 

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -264,7 +264,7 @@ impl ReputationUpdater {
     }
     pub fn submit(&self, store: &dyn ReputationStore, receipt: &icn_identity::ExecutionReceipt) {
         let before = store.get_reputation(&receipt.executor_did);
-        store.record_receipt(receipt);
+        store.record_execution(&receipt.executor_did, receipt.success, receipt.cpu_ms);
         let after = store.get_reputation(&receipt.executor_did);
         log::debug!(
             "[ReputationUpdater] Executor {:?} reputation {} -> {} via receipt {:?}",
@@ -386,7 +386,7 @@ mod tests {
             test_did,
             Arc::new(StubMeshNetworkService::new()),
             Arc::new(StubSigner::new()),
-            Arc::new(icn_identity::KeyDidResolver::default()),
+            Arc::new(icn_identity::KeyDidResolver),
             Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         )
     }

--- a/crates/icn-runtime/tests/integration/cross_node_governance.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_governance.rs
@@ -14,7 +14,13 @@ mod cross_node_governance {
     ) -> anyhow::Result<Arc<RuntimeContext>> {
         let id = format!("did:key:z6Mkgov{id_suffix}");
         let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
-        let ctx = RuntimeContext::new_with_real_libp2p(&id, listen, bootstrap).await?;
+        let ctx = RuntimeContext::new_with_real_libp2p(
+            &id,
+            listen,
+            bootstrap,
+            std::path::PathBuf::from("./mana_ledger.sled"),
+        )
+        .await?;
         Ok(ctx)
     }
 

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -46,7 +46,14 @@ mod cross_node_tests {
         initial_mana: u64
     ) -> Result<Arc<RuntimeContext>, anyhow::Error> {
         let identity_str = format!("did:key:z6Mkv{}", identity_suffix);
-        let ctx = RuntimeContext::new_with_real_libp2p(&identity_str, bootstrap_peers).await?;
+        let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
+        let ctx = RuntimeContext::new_with_real_libp2p(
+            &identity_str,
+            listen,
+            bootstrap_peers,
+            std::path::PathBuf::from("./mana_ledger.sled"),
+        )
+        .await?;
         
         // Set initial mana for the identity
         let identity = Did::from_str(&identity_str)?;

--- a/crates/icn-runtime/tests/integration/libp2p_integration.rs
+++ b/crates/icn-runtime/tests/integration/libp2p_integration.rs
@@ -14,10 +14,14 @@ mod libp2p_integration_tests {
         // Test creating a RuntimeContext with real libp2p
         let node_identity = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
         
+        let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
         let result = RuntimeContext::new_with_real_libp2p(
             node_identity,
-            None  // No bootstrap peers for this simple test
-        ).await;
+            listen,
+            None,  // No bootstrap peers for this simple test
+            std::path::PathBuf::from("./mana_ledger.sled"),
+        )
+        .await;
         
         assert!(result.is_ok(), "Failed to create RuntimeContext with libp2p: {:?}", result.err());
         
@@ -64,10 +68,14 @@ mod libp2p_integration_tests {
         
         let node_identity = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
         
+        let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
         let result = RuntimeContext::new_with_real_libp2p(
             node_identity,
-            Some(bootstrap_peers)
-        ).await;
+            listen,
+            Some(bootstrap_peers),
+            std::path::PathBuf::from("./mana_ledger.sled"),
+        )
+        .await;
         
         assert!(result.is_ok(), "Failed to create RuntimeContext with bootstrap peers: {:?}", result.err());
         

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -505,7 +505,7 @@ fn new_mesh_test_context_with_two_executors() -> (
         submitter_did.clone(),
         network_service.clone(),
         Arc::new(StubSigner::new()),
-        Arc::new(icn_identity::KeyDidResolver::default()),
+        Arc::new(icn_identity::KeyDidResolver),
         dag_store.clone(),
     );
     submitter_ctx
@@ -517,7 +517,7 @@ fn new_mesh_test_context_with_two_executors() -> (
         executor1_did.clone(),
         network_service.clone(),
         Arc::new(StubSigner::new()),
-        Arc::new(icn_identity::KeyDidResolver::default()),
+        Arc::new(icn_identity::KeyDidResolver),
         dag_store.clone(),
     );
     executor1_ctx
@@ -529,7 +529,7 @@ fn new_mesh_test_context_with_two_executors() -> (
         executor2_did.clone(),
         network_service.clone(),
         Arc::new(StubSigner::new()),
-        Arc::new(icn_identity::KeyDidResolver::default()),
+        Arc::new(icn_identity::KeyDidResolver),
         dag_store.clone(),
     );
     executor2_ctx

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -4,12 +4,11 @@ use icn_identity::{
 };
 use icn_reputation::ReputationStore;
 use icn_runtime::{
-    context::{RuntimeContext, Signer, StubDagStore, StubMeshNetworkService, StubSigner},
+    context::{RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner},
     host_anchor_receipt, ReputationUpdater,
 };
-use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
-use tokio::sync::Mutex as TokioMutex;
 
 #[tokio::test]
 async fn anchor_receipt_updates_reputation() {
@@ -19,15 +18,10 @@ async fn anchor_receipt_updates_reputation() {
 
     let ctx = RuntimeContext::new_with_ledger_path(
         did.clone(),
-        Arc::new(icn_runtime::context::StubMeshNetworkService::new()),
-        Arc::new(icn_runtime::context::StubSigner::new_with_keys(
-            sk.clone(),
-            vk.clone(),
-        )),
-        Arc::new(icn_identity::KeyDidResolver::default()),
-        Arc::new(tokio::sync::Mutex::new(
-            icn_runtime::context::StubDagStore::new(),
-        )),
+        Arc::new(StubMeshNetworkService::new()),
+        Arc::new(StubSigner::new_with_keys(sk.clone(), vk)),
+        Arc::new(icn_identity::KeyDidResolver),
+        Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         std::path::PathBuf::from("./mana_ledger.sled"),
     );
     let job_id = Cid::new_v1_dummy(0x55, 0x13, b"rep_job");


### PR DESCRIPTION
## Summary
- incorporate success/failure into `ReputationStore`
- update in-memory and sled-backed stores
- send success info from `ReputationUpdater` and runtime
- adapt tests and examples

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: icn-dag tests)*

------
https://chatgpt.com/codex/tasks/task_e_684f71bf3c148324a33c6903dbcc34b3