### PR TITLE
[reputation] add sled store

### DIFF
--- a/crates/icn-reputation/src/sled_store.rs
+++ b/crates/icn-reputation/src/sled_store.rs
@@ -1,0 +1,60 @@
+//! Sled-backed implementation of the [`ReputationStore`] trait.
+
+use crate::ReputationStore;
+use icn_common::{CommonError, Did};
+use std::path::PathBuf;
+
+#[cfg(feature = "persist-sled")]
+use bincode;
+#[cfg(feature = "persist-sled")]
+use sled;
+
+/// Persistent sled-backed reputation store.
+#[cfg(feature = "persist-sled")]
+pub struct SledReputationStore {
+    tree: sled::Tree,
+}
+
+#[cfg(feature = "persist-sled")]
+impl SledReputationStore {
+    /// Opens or creates a sled-backed store at the given path.
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let db = sled::open(path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sled DB: {e}")))?;
+        let tree = db
+            .open_tree("reputation_v1")
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open tree: {e}")))?;
+        Ok(Self { tree })
+    }
+
+    fn read_score(&self, did: &Did) -> u64 {
+        if let Ok(Some(bytes)) = self.tree.get(did.to_string()) {
+            bincode::deserialize(&bytes).unwrap_or(0)
+        } else {
+            0
+        }
+    }
+
+    fn write_score(&self, did: &Did, score: u64) {
+        if let Ok(encoded) = bincode::serialize(&score) {
+            let _ = self.tree.insert(did.to_string(), encoded);
+            let _ = self.tree.flush();
+        }
+    }
+}
+
+#[cfg(feature = "persist-sled")]
+impl ReputationStore for SledReputationStore {
+    fn get_reputation(&self, did: &Did) -> u64 {
+        self.read_score(did)
+    }
+
+    fn record_execution(&self, executor: &Did, success: bool, cpu_ms: u64) {
+        let current = self.read_score(executor);
+        let base: i64 = if success { 1 } else { -1 };
+        let delta: i64 = base + (cpu_ms / 1000) as i64;
+        let updated = (current as i64) + delta;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        self.write_score(executor, new_score);
+    }
+}

--- a/crates/icn-reputation/tests/sled.rs
+++ b/crates/icn-reputation/tests/sled.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "persist-sled")]
+mod tests {
+    use icn_common::Did;
+    use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
+    use icn_reputation::sled_store::SledReputationStore;
+    use icn_reputation::ReputationStore;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sled_round_trip() {
+        let dir = tempdir().unwrap();
+        let path: PathBuf = dir.path().join("rep.sled");
+        let store = SledReputationStore::new(path.clone()).unwrap();
+
+        let (_sk, vk) = generate_ed25519_keypair();
+        let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+
+        store.record_execution(&did, true, 1000);
+        assert_eq!(store.get_reputation(&did), 2);
+
+        drop(store);
+        let reopened = SledReputationStore::new(path).unwrap();
+        assert_eq!(reopened.get_reputation(&did), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SledReputationStore` in its own module
- expose sled-backed store through feature flag
- add integration test verifying persistence

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timed out)*
- `cargo test --all-features --workspace` *(failed: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684fc1bb97748324a36952cb01054884