### PR TITLE
[icn-network] track ping latency

### DIFF
--- a/crates/icn-network/Cargo.toml
+++ b/crates/icn-network/Cargo.toml
@@ -23,6 +23,8 @@ async-trait = "0.1.77"
 downcast-rs = "1.2.0"
 bincode = "1.3"
 oneshot = "0.1"
+once_cell = "1.21"
+prometheus-client = "0.22"
 
 # libp2p dependencies with consistent versions
 libp2p = { version = "0.53.2", features = ["tokio", "gossipsub", "mdns", "kad", "macros", "ping", "yamux", "noise", "tcp", "dns", "request-response"], optional = true }

--- a/crates/icn-network/src/metrics.rs
+++ b/crates/icn-network/src/metrics.rs
@@ -1,0 +1,15 @@
+use once_cell::sync::Lazy;
+use prometheus_client::metrics::gauge::Gauge;
+use std::sync::atomic::AtomicU64;
+
+/// Last observed ping round-trip time in milliseconds.
+pub static PING_LAST_RTT_MS: Lazy<Gauge<f64, AtomicU64>> = Lazy::new(Gauge::default);
+
+/// Minimum observed ping round-trip time in milliseconds.
+pub static PING_MIN_RTT_MS: Lazy<Gauge<f64, AtomicU64>> = Lazy::new(Gauge::default);
+
+/// Maximum observed ping round-trip time in milliseconds.
+pub static PING_MAX_RTT_MS: Lazy<Gauge<f64, AtomicU64>> = Lazy::new(Gauge::default);
+
+/// Average ping round-trip time in milliseconds.
+pub static PING_AVG_RTT_MS: Lazy<Gauge<f64, AtomicU64>> = Lazy::new(Gauge::default);


### PR DESCRIPTION
## Summary
- extend `NetworkStats` with latency fields
- track ping RTTs in `Libp2pNetworkService`
- expose Prometheus gauges for ping latency
- test latency metrics update after connections

## Testing
- `cargo fmt --all -- --check`
- `timeout 60 cargo clippy --all-targets --all-features --workspace` *(fails: command timed out)*
- `timeout 60 cargo test --all-features --workspace` *(fails: command timed out)*


------
https://chatgpt.com/codex/tasks/task_e_684ff073f6c083249ea428c24070f095