### PR TITLE
[icn-api] add transaction query types and handlers

### DIFF
--- a/crates/icn-api/README.md
+++ b/crates/icn-api/README.md
@@ -22,4 +22,26 @@ Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUT
 
 ## License
 
-Licensed under the Apache License, Version 2.0. See [LICENSE](../../LICENSE). 
+Licensed under the Apache License, Version 2.0. See [LICENSE](../../LICENSE).
+
+## Example Usage
+
+Submitting a transaction via the API:
+
+```rust
+use icn_api::submit_transaction_api;
+use icn_common::{SubmitTransactionRequest, Transaction, Did};
+
+let tx = Transaction {
+    id: "demo".into(),
+    timestamp: 0,
+    sender_did: Did::new("key", "alice"),
+    recipient_did: None,
+    payload_type: "demo".into(),
+    payload: vec![],
+    signature: None,
+};
+let req = SubmitTransactionRequest { transaction: tx };
+let resp = submit_transaction_api(req)?;
+println!("submitted {}", resp.transaction_id);
+```

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -51,3 +51,8 @@ Specific contributions to `icn-cli` could include:
 ## License
 
 This crate is licensed under the Apache 2.0 license, as is the entire `icn-core` repository.
+
+## New Commands
+
+- `icn-cli tx <JSON>` – submit a transaction to the node. Use `-` to read JSON from STDIN.
+- `icn-cli query <KEY>` – fetch data for a given key.

--- a/crates/icn-cli/tests/query.rs
+++ b/crates/icn-cli/tests/query.rs
@@ -1,0 +1,31 @@
+use assert_cmd::prelude::*;
+use icn_node::app_router;
+use std::process::Command;
+use tokio::task;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn query_command_returns_value() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{addr}");
+
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "query", "hello"])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("hello"));
+    })
+    .await
+    .unwrap();
+
+    server.abort();
+}

--- a/crates/icn-cli/tests/tx.rs
+++ b/crates/icn-cli/tests/tx.rs
@@ -1,0 +1,45 @@
+use assert_cmd::prelude::*;
+use icn_node::app_router;
+use std::process::Command;
+use tokio::task;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn tx_command_submits_transaction() {
+    let _ = std::fs::remove_dir_all("./mana_ledger.sled");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{addr}");
+
+    let tx_json = serde_json::json!({
+        "transaction": {
+            "id": "t1",
+            "timestamp": 0,
+            "sender_did": {"method":"key","id_string":"alice"},
+            "recipient_did": null,
+            "payload_type": "test",
+            "payload": [],
+            "signature": null
+        }
+    })
+    .to_string();
+
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "tx", &tx_json])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("Transaction submitted"));
+    })
+    .await
+    .unwrap();
+
+    server.abort();
+}

--- a/crates/icn-common/README.md
+++ b/crates/icn-common/README.md
@@ -41,4 +41,10 @@ Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUT
 
 ## License
 
-Licensed under the Apache License, Version 2.0. See [LICENSE](../../LICENSE). 
+Licensed under the Apache License, Version 2.0. See [LICENSE](../../LICENSE).
+
+## Transaction and Query Types
+
+The crate exposes `SubmitTransactionRequest`, `SubmitTransactionResponse`,
+`DataQueryRequest`, and `DataQueryResponse` for use by higher level crates such
+as `icn-api`, `icn-node`, and `icn-cli`.

--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -313,6 +313,34 @@ pub struct Transaction {
                               // TODO: Add fields like nonce, gas_limit, gas_price if relevant to economic model
 }
 
+/// Request to submit a transaction to an ICN node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubmitTransactionRequest {
+    /// Transaction to be stored or executed by the node.
+    pub transaction: Transaction,
+}
+
+/// Response returned after a transaction is accepted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubmitTransactionResponse {
+    /// Identifier assigned to the stored transaction.
+    pub transaction_id: String,
+}
+
+/// Request to query arbitrary data by key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataQueryRequest {
+    /// Opaque key or handle understood by the receiving node.
+    pub key: String,
+}
+
+/// Response to a data query.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DataQueryResponse {
+    /// Optional raw bytes returned for the provided key.
+    pub value: Option<Vec<u8>>,
+}
+
 // TODO: Define `DidDocument` struct for DID resolution.
 
 #[cfg(test)]

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -63,4 +63,11 @@ Future contributions to `icn-node` will focus on:
 
 ## License
 
-This crate is licensed under the Apache 2.0 license, as is the entire `icn-core` repository. 
+This crate is licensed under the Apache 2.0 license, as is the entire `icn-core` repository.
+
+## HTTP Endpoints
+
+Alongside governance and mesh job APIs, the node now exposes:
+
+- `POST /transaction/submit` – submit a serialized transaction.
+- `POST /data/query` – query arbitrary data by key.

--- a/crates/icn-node/tests/transaction.rs
+++ b/crates/icn-node/tests/transaction.rs
@@ -1,0 +1,40 @@
+use icn_common::{Did, SubmitTransactionRequest, Transaction};
+use icn_node::app_router;
+use reqwest::Client;
+use tokio::task;
+
+#[tokio::test]
+async fn submit_transaction_returns_id() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+
+    let tx = Transaction {
+        id: "t1".into(),
+        timestamp: 0,
+        sender_did: Did::new("key", "alice"),
+        recipient_did: None,
+        payload_type: "test".into(),
+        payload: vec![],
+        signature: None,
+    };
+    let req = SubmitTransactionRequest {
+        transaction: tx.clone(),
+    };
+
+    let client = Client::new();
+    let resp: serde_json::Value = client
+        .post(format!("http://{addr}/transaction/submit"))
+        .json(&req)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(resp["transaction_id"], tx.id);
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- add SubmitTransactionRequest/DataQueryRequest in icn-common
- expose submit_transaction_api and query_data_api in icn-api
- handle `/transaction/submit` and `/data/query` in icn-node
- extend icn-cli with `tx` and `query` commands
- document new APIs in crate READMEs
- add basic integration tests for new commands and endpoints

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build took too long)*
- `cargo test --all-features --workspace` *(fails: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_684ff0736994832481b6b882b6be793d