### PR TITLE
[icn-network] handle request-response events

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -26,6 +26,7 @@ hex = "0.4"
 bs58 = "0.5"
 libp2p = { version = "0.53.2", optional = true }
 async-trait = "0.1"
+toml = "0.5"
 
 [features]
 default = ["icn-network/default"]


### PR DESCRIPTION
## Summary
- support request-response events in Libp2pNetworkService
- default to enabling P2P when `with-libp2p` feature is active
- allow bootstrap peers via optional config file

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation stopped)*
- `cargo test --all-features --workspace` *(failed: compilation stopped)*

------
https://chatgpt.com/codex/tasks/task_e_684ff06b064883248502baf590d2d206