### PR TITLE
[icn-node] add NodeConfig with file loading

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -18,6 +18,8 @@ log = "0.4"
 env_logger = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.5"
+serde_yaml = "0.9"
 clap = { version = "4.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 axum = { version = "0.7", features = ["json"] }

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -41,14 +41,25 @@ The current `main()` function is for demonstration and testing the library integ
 
 ## CLI Usage
 
-When running the `icn-node` binary you can specify a custom path for the mana ledger using `--mana-ledger-path`.
-This allows mana balances to persist between restarts.
+The node accepts configuration via CLI flags or a TOML/YAML file. Provide the
+file path with `--config <path>`. CLI flags override values found in the file.
+Below is a minimal example in TOML (the same keys can be used in YAML):
 
-```bash
-./target/debug/icn-node --mana-ledger-path ./icn_data/mana.sled
+```toml
+node_name = "Local Node"
+http_listen_addr = "127.0.0.1:8080"
+storage_backend = "file"
+storage_path = "./icn_data/node_store"
+mana_ledger_path = "./mana_ledger.sled"
 ```
 
-Restarting the node with the same path will retain previously stored balances.
+To start the node using this configuration:
+
+```bash
+./target/debug/icn-node --config ./node_config.toml
+```
+
+Any CLI option provided will override the value from the file.
 
 ## Contributing
 

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -1,0 +1,106 @@
+use clap::ArgMatches;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+/// Storage backends supported by the node.
+#[derive(clap::ValueEnum, Clone, Debug, Serialize, Deserialize)]
+pub enum StorageBackendType {
+    /// In-memory store, volatile.
+    Memory,
+    /// File-based persistence.
+    File,
+    /// SQLite database backend (requires `persist-sqlite` feature).
+    Sqlite,
+}
+
+/// Configuration values for running an ICN node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NodeConfig {
+    pub storage_backend: StorageBackendType,
+    pub storage_path: std::path::PathBuf,
+    pub mana_ledger_path: std::path::PathBuf,
+    pub http_listen_addr: String,
+    pub node_did: Option<String>,
+    pub node_private_key_bs58: Option<String>,
+    pub node_name: String,
+    pub listen_address: String,
+    pub bootstrap_peers: Option<Vec<String>>,
+    pub enable_p2p: bool,
+    pub api_key: Option<String>,
+    pub open_rate_limit: u64,
+}
+
+impl Default for NodeConfig {
+    fn default() -> Self {
+        Self {
+            storage_backend: StorageBackendType::Memory,
+            storage_path: "./icn_data/node_store".into(),
+            mana_ledger_path: "./mana_ledger.sled".into(),
+            http_listen_addr: "127.0.0.1:7845".to_string(),
+            node_did: None,
+            node_private_key_bs58: None,
+            node_name: "ICN Node".to_string(),
+            listen_address: "/ip4/0.0.0.0/tcp/0".to_string(),
+            bootstrap_peers: None,
+            enable_p2p: false,
+            api_key: None,
+            open_rate_limit: 60,
+        }
+    }
+}
+
+impl NodeConfig {
+    /// Load configuration from a TOML or YAML file. The format is inferred from the file extension.
+    pub fn from_file(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let data = fs::read_to_string(path)?;
+        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let config = match ext {
+            "toml" => toml::from_str(&data)?,
+            "yaml" | "yml" => serde_yaml::from_str(&data)?,
+            _ => return Err(format!("unsupported config extension: {ext}").into()),
+        };
+        Ok(config)
+    }
+
+    /// Apply CLI overrides onto this configuration.
+    pub fn apply_cli_overrides(&mut self, cli: &super::node::Cli, matches: &ArgMatches) {
+        if let Some(v) = &cli.storage_backend {
+            self.storage_backend = v.clone();
+        }
+        if let Some(v) = &cli.storage_path {
+            self.storage_path = v.clone();
+        }
+        if let Some(v) = &cli.mana_ledger_path {
+            self.mana_ledger_path = v.clone();
+        }
+        if let Some(v) = &cli.http_listen_addr {
+            self.http_listen_addr = v.clone();
+        }
+        if let Some(v) = &cli.node_did {
+            self.node_did = Some(v.clone());
+        }
+        if let Some(v) = &cli.node_private_key_bs58 {
+            self.node_private_key_bs58 = Some(v.clone());
+        }
+        if let Some(v) = &cli.node_name {
+            self.node_name = v.clone();
+        }
+        if let Some(v) = &cli.listen_address {
+            self.listen_address = v.clone();
+        }
+        if let Some(v) = &cli.bootstrap_peers {
+            self.bootstrap_peers = Some(v.clone());
+        }
+        if matches.contains_id("enable_p2p") {
+            self.enable_p2p = true;
+        }
+        if let Some(v) = &cli.api_key {
+            self.api_key = Some(v.clone());
+        }
+        if let Some(v) = cli.open_rate_limit {
+            self.open_rate_limit = v;
+        }
+    }
+}

--- a/crates/icn-node/src/lib.rs
+++ b/crates/icn-node/src/lib.rs
@@ -2,5 +2,6 @@
 //! This library exposes functionality to create and run ICN nodes
 
 #![allow(special_module_name)]
-pub mod main;
-pub use main::{app_router, app_router_with_options};
+pub mod config;
+pub mod node;
+pub use node::{app_router, app_router_with_options};


### PR DESCRIPTION
## Summary
- create `NodeConfig` with defaults and loader for TOML/YAML
- allow passing a configuration file via `--config`
- merge CLI values with file contents
- document example configuration file format

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_684ff06b9dd083248f5c6765b7fa7fbc