### PR TITLE
[node] expose runtime status

### DIFF
--- a/crates/icn-dag/src/rocksdb_store.rs
+++ b/crates/icn-dag/src/rocksdb_store.rs
@@ -68,4 +68,9 @@ impl StorageService<DagBlock> for RocksDagStore {
         })?;
         Ok(result.is_some())
     }
+
+    fn len(&self) -> Result<u64, CommonError> {
+        use rocksdb::IteratorMode;
+        Ok(self.db.iterator(IteratorMode::Start).count() as u64)
+    }
 }

--- a/crates/icn-dag/src/sled_store.rs
+++ b/crates/icn-dag/src/sled_store.rs
@@ -89,4 +89,9 @@ impl StorageService<DagBlock> for SledDagStore {
         })?;
         Ok(exists)
     }
+
+    fn len(&self) -> Result<u64, CommonError> {
+        let tree = self.tree()?;
+        Ok(tree.len() as u64)
+    }
 }

--- a/crates/icn-dag/src/sqlite_store.rs
+++ b/crates/icn-dag/src/sqlite_store.rs
@@ -98,4 +98,12 @@ impl StorageService<DagBlock> for SqliteDagStore {
             })?;
         Ok(count > 0)
     }
+
+    fn len(&self) -> Result<u64, CommonError> {
+        let count: u64 = self
+            .conn
+            .query_row("SELECT COUNT(1) FROM blocks", [], |row| row.get(0))
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to count blocks: {}", e)))?;
+        Ok(count)
+    }
 }

--- a/crates/icn-node/src/main.rs
+++ b/crates/icn-node/src/main.rs
@@ -551,10 +551,8 @@ async fn info_handler(State(state): State<AppState>) -> impl IntoResponse {
 
 // GET /status – Node status.
 async fn status_handler(State(state): State<AppState>) -> impl IntoResponse {
-    // TODO: Fetch more dynamic status from RuntimeContext if available (e.g., peer count from NetworkService)
-    let peer_count = 0; // Placeholder
-                        // let current_block_height = state.runtime_context.dag_store.get_latest_block_height().await.unwrap_or(0); // Example
-    let current_block_height = 0; // Placeholder
+    let peer_count = state.runtime_context.peer_count().await;
+    let current_block_height = state.runtime_context.block_height().await;
     let status = NodeStatus {
         is_online: true, // Basic check
         peer_count,

--- a/crates/icn-node/tests/status.rs
+++ b/crates/icn-node/tests/status.rs
@@ -1,0 +1,28 @@
+use icn_node::app_router;
+use reqwest::Client;
+use serde_json::Value;
+use tokio::task;
+
+#[tokio::test]
+async fn status_endpoint_returns_runtime_metrics() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+
+    let url = format!("http://{addr}/status");
+    let json: Value = Client::new()
+        .get(&url)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(json["peer_count"].as_u64().unwrap(), 0);
+    assert_eq!(json["current_block_height"].as_u64().unwrap(), 0);
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- add `len()` to DAG `StorageService` trait to report stored block count
- extend `RuntimeContext` with `peer_count` and `block_height`
- query these new methods in HTTP `status_handler`
- test `/status` endpoint for peer and block metrics

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684ff56ce97c8324af5b0dcb6e3a4443