### PR TITLE
[icn-common] add signable trait

### DIFF
--- a/crates/icn-common/Cargo.toml
+++ b/crates/icn-common/Cargo.toml
@@ -13,6 +13,8 @@ serde_json = "1.0" # For examples and potentially some utils
 bs58 = "0.5.0" # For CID string representation example
 thiserror = "1.0" # For idiomatic error definitions
 sha2 = "0.10"
+ed25519-dalek = { version = "2.0.0-pre.3", features = ["rand_core"] }
+serde_bytes = "0.11"
 
 [dev-dependencies]
-# No specific dev-dependencies yet, but common ones like `pretty_assertions` could be added here.
+rand_core = { version = "0.6", features = ["getrandom"] }

--- a/crates/icn-common/tests/signable.rs
+++ b/crates/icn-common/tests/signable.rs
@@ -1,0 +1,68 @@
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use icn_common::{
+    compute_merkle_cid, Cid, DagBlock, DagLink, Did, DidDocument, Signable, Transaction,
+};
+use rand_core::OsRng;
+
+#[test]
+fn transaction_sign_verify() {
+    let sk = SigningKey::generate(&mut OsRng);
+    let pk: VerifyingKey = sk.verifying_key();
+    let tx = Transaction {
+        id: "tx1".to_string(),
+        timestamp: 1,
+        sender_did: Did::new("key", "a"),
+        recipient_did: None,
+        payload_type: "test".to_string(),
+        payload: b"hello".to_vec(),
+        signature: None,
+    };
+
+    let sig = tx.sign(&sk).unwrap();
+    assert!(tx.verify(&sig, &pk).is_ok());
+
+    let mut bad_tx = tx.clone();
+    bad_tx.payload.push(1);
+    assert!(bad_tx.verify(&sig, &pk).is_err());
+}
+
+#[test]
+fn dagblock_sign_verify() {
+    let sk = SigningKey::generate(&mut OsRng);
+    let pk = sk.verifying_key();
+
+    let link_cid = Cid::new_v1_sha256(0x71, b"child");
+    let link = DagLink {
+        cid: link_cid,
+        name: "child".into(),
+        size: 5,
+    };
+    let data = b"parent".to_vec();
+    let cid = compute_merkle_cid(0x71, &data, std::slice::from_ref(&link));
+    let block = DagBlock {
+        cid,
+        data,
+        links: vec![link],
+    };
+
+    let sig = block.sign(&sk).unwrap();
+    assert!(block.verify(&sig, &pk).is_ok());
+
+    let mut bad_block = block.clone();
+    bad_block.data.push(0);
+    assert!(bad_block.verify(&sig, &pk).is_err());
+}
+
+#[test]
+fn did_document_sign_verify() {
+    let sk = SigningKey::generate(&mut OsRng);
+    let pk = sk.verifying_key();
+    let did = Did::new("key", "abc");
+    let doc = DidDocument {
+        id: did.clone(),
+        public_key: pk.as_bytes().to_vec(),
+    };
+
+    let sig = doc.sign(&sk).unwrap();
+    assert!(doc.verify(&sig, &pk).is_ok());
+}

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -1,5 +1,6 @@
 use icn_ccl::compile_ccl_source_to_wasm;
 use icn_common::{Cid, DagBlock};
+use icn_dag::sled_store::SledDagStore;
 use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
 use icn_mesh::{ActualMeshJob, JobSpec};
 use icn_runtime::context::{RuntimeContext, StubMeshNetworkService, StubSigner};
@@ -9,10 +10,8 @@ use std::sync::Arc;
 use std::thread;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex as TokioMutex;
-use icn_dag::sled_store::SledDagStore;
 
 fn ctx_with_temp_store(did: &str, mana: u64) -> Arc<RuntimeContext> {
-    use std::path::PathBuf;
     let temp = tempfile::tempdir().unwrap();
     let dag_store = Arc::new(TokioMutex::new(
         SledDagStore::new(temp.path().join("dag")).unwrap(),
@@ -23,7 +22,7 @@ fn ctx_with_temp_store(did: &str, mana: u64) -> Arc<RuntimeContext> {
         Arc::new(StubSigner::new()),
         Arc::new(icn_identity::KeyDidResolver),
         dag_store,
-        PathBuf::from(temp.path().join("mana")),
+        temp.path().join("mana"),
     );
     ctx.mana_ledger
         .set_balance(&icn_common::Did::from_str(did).unwrap(), mana)


### PR DESCRIPTION
## Summary
- implement Signable trait and SignatureBytes
- define DidDocument struct
- implement Signable for DagBlock, Transaction, and DidDocument
- test signing and verification
- fix clippy warning in ccl integration test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --no-run` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_685086763c6c83249784ee9e5d1b8ecd