### PR TITLE
[icn-runtime] expand error variants

### DIFF
--- a/crates/icn-network/src/error.rs
+++ b/crates/icn-network/src/error.rs
@@ -23,6 +23,18 @@ pub enum MeshNetworkError {
     #[error("Peer not found: {0}")]
     PeerNotFound(String),
 
+    #[error("Connection to peer {peer_id:?} failed: {cause}")]
+    ConnectionFailed {
+        peer_id: Option<crate::PeerId>,
+        cause: String,
+    },
+
+    #[error("Network channel unexpectedly closed")]
+    ChannelClosed,
+
+    #[error("Unexpected message type: {msg_type}")]
+    UnexpectedMessage { msg_type: String },
+
     #[error("Invalid input or parameters: {0}")]
     InvalidInput(String),
 

--- a/crates/icn-runtime/tests/error_variants.rs
+++ b/crates/icn-runtime/tests/error_variants.rs
@@ -1,0 +1,33 @@
+use icn_network::error::MeshNetworkError;
+use icn_runtime::context::HostAbiError;
+use icn_runtime::error::MeshJobError;
+
+#[test]
+fn host_abi_network_error_maps_to_connection_failed() {
+    let err = HostAbiError::NetworkError("disconnected".to_string());
+    let mesh_err: MeshJobError = err.into();
+    match mesh_err {
+        MeshJobError::Network(MeshNetworkError::ConnectionFailed {
+            peer_id: None,
+            cause,
+        }) => {
+            assert_eq!(cause, "disconnected");
+        }
+        other => panic!("Unexpected variant: {other:?}"),
+    }
+}
+
+#[test]
+fn host_abi_invalid_params_maps_to_invalid_spec() {
+    let err = HostAbiError::InvalidParameters("bad".to_string());
+    let mesh_err: MeshJobError = err.into();
+    match mesh_err {
+        MeshJobError::InvalidSpec {
+            job_id: None,
+            reason,
+        } => {
+            assert_eq!(reason, "bad");
+        }
+        _ => panic!("Unexpected mapping: {mesh_err:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- add new variants to `MeshNetworkError`
- expand `MeshJobError` variants
- convert `HostAbiError` into new variants
- test new conversion paths

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build took too long)*
- `cargo test --all-features --workspace` *(fails: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_6850867929808324ad7091f13fc6569f