### PR TITLE
[api,node,cli] add transaction query endpoints

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -40,6 +40,30 @@ use crate::governance_trait::{
 // TODO: Add other API methods: submit_transaction, query_data, etc.
 // }
 
+/// Submits a transaction to the node.
+///
+/// This stub implementation simply parses the provided JSON into a
+/// [`Transaction`] and returns its `id`. In a real implementation the
+/// transaction would be validated and persisted.
+pub fn submit_transaction(tx_json: String) -> Result<String, CommonError> {
+    let tx: icn_common::Transaction = serde_json::from_str(&tx_json).map_err(|e| {
+        CommonError::DeserializationError(format!(
+            "Failed to parse Transaction JSON: {} (Input: '{}')",
+            e, tx_json
+        ))
+    })?;
+    Ok(tx.id.clone())
+}
+
+/// Queries data from the node.
+///
+/// Currently this function is a placeholder that simply echoes the query
+/// string back to the caller. It demonstrates the API shape for future
+/// data access capabilities.
+pub fn query_data(query: String) -> Result<String, CommonError> {
+    Ok(format!("Query result for: {}", query))
+}
+
 /// Retrieves basic information about the ICN node.
 /// This function would typically be part of an RPC service.
 pub fn get_node_info() -> Result<NodeInfo, CommonError> {

--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -1,0 +1,53 @@
+use icn_common::{Did, Transaction};
+use icn_node::app_router;
+use reqwest::Client;
+use tokio::task;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn submit_transaction_and_query() {
+    let _ = std::fs::remove_dir_all("./mana_ledger.sled");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let client = Client::new();
+    let base = format!("http://{}", addr);
+
+    // Submit a transaction
+    let tx = Transaction {
+        id: "tx1".to_string(),
+        timestamp: 1,
+        sender_did: Did::new("key", "alice"),
+        recipient_did: None,
+        payload_type: "test".to_string(),
+        payload: b"hello".to_vec(),
+        signature: None,
+    };
+    let resp = client
+        .post(&format!("{}/transaction/submit", base))
+        .json(&tx)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let id_resp: String = resp.json().await.unwrap();
+    assert_eq!(id_resp, tx.id);
+
+    // Query data endpoint
+    let resp = client
+        .post(&format!("{}/data/query", base))
+        .json(&serde_json::json!({"query": "example"}))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let result: String = resp.json().await.unwrap();
+    assert!(result.contains("example"));
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- implement `submit_transaction` and `query_data` API stubs
- expose new HTTP handlers in `icn-node`
- add tests for new endpoints in `icn-cli`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test --all-features --workspace` *(failed: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68508c6d5f148324baa0828857046033