### PR TITLE
[icn-ccl] implement type compatibility and docs

### DIFF
--- a/icn-ccl/README.md
+++ b/icn-ccl/README.md
@@ -13,7 +13,14 @@ The `icn-ccl` crate is responsible for:
 
 ## Development Status
 
-Parsing, optimization, and WASM generation are **not** fully implemented yet. Numerous `TODO` comments in the source code outline the missing pieces.
+The compiler is functional and includes:
+
+* A parser built with [Pest](https://pest.rs)
+* A semantic analyzer with basic type checking
+* A simple optimizer for constant folding
+* A WASM backend built on `wasm-encoder`
+
+While minimal, these stages are enough to compile small example contracts.
 
 ## Basic Usage
 
@@ -24,6 +31,7 @@ use icn_ccl::compile_ccl_source_to_wasm;
 
 let source = "fn get_cost() -> Mana { return 10; }";
 let (wasm, meta) = compile_ccl_source_to_wasm(source)?;
+// `wasm` holds the compiled module and `meta` describes exports and other info
 ```
 
 CLI-oriented helpers live in the `cli` module for tools like `icn-cli` to compile `.ccl` files from disk.
@@ -36,7 +44,7 @@ CLI-oriented helpers live in the `cli` module for tools like `icn-cli` to compil
 
 ## Roadmap & Issues
 
-Future work includes fully implementing the parser, optimizer, and WASM backend. For specific tasks, check the [open issues](https://github.com/InterCooperative/icn-core/issues?q=label%3Accl).
+Future work focuses on expanding language features and improving optimization. For specific tasks, check the [open issues](https://github.com/InterCooperative/icn-core/issues?q=label%3Accl).
 
 ## Contributing
 

--- a/icn-ccl/src/ast.rs
+++ b/icn-ccl/src/ast.rs
@@ -43,6 +43,24 @@ pub enum TypeAnnotationNode {
     Custom(String), // For user-defined types or imported ones
 }
 
+impl TypeAnnotationNode {
+    /// Returns true if two types are considered compatible.
+    ///
+    /// Currently `Mana` and `Integer` are treated as interchangeable
+    /// since they share the same underlying WASM representation.
+    pub fn compatible_with(&self, other: &Self) -> bool {
+        self == other
+            || matches!((self, other),
+                (TypeAnnotationNode::Mana, TypeAnnotationNode::Integer)
+                    | (TypeAnnotationNode::Integer, TypeAnnotationNode::Mana))
+    }
+
+    /// Returns true if this type behaves like an integer number.
+    pub fn is_numeric(&self) -> bool {
+        matches!(self, TypeAnnotationNode::Integer | TypeAnnotationNode::Mana)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlockNode {
     pub statements: Vec<StatementNode>,

--- a/icn-ccl/src/semantic_analyzer.rs
+++ b/icn-ccl/src/semantic_analyzer.rs
@@ -184,7 +184,7 @@ impl SemanticAnalyzer {
                 let expected = self.current_return_type.clone().ok_or_else(|| {
                     CclError::InternalCompilerError("Return outside function".to_string())
                 })?;
-                if expr_ty != expected {
+                if !expr_ty.compatible_with(&expected) {
                     return Err(CclError::TypeError(format!(
                         "Return type mismatch: expected {:?}, got {:?}",
                         expected, expr_ty
@@ -261,7 +261,7 @@ impl SemanticAnalyzer {
                         }
                         for (arg_expr, param_ty) in arguments.iter().zip(params.iter()) {
                             let arg_ty = self.evaluate_expression(arg_expr)?;
-                            if &arg_ty != param_ty {
+                            if !arg_ty.compatible_with(param_ty) {
                                 return Err(CclError::TypeError(format!(
                                     "Argument type mismatch for `{}`: expected {:?}, got {:?}",
                                     name, param_ty, arg_ty
@@ -292,7 +292,7 @@ impl SemanticAnalyzer {
                     | BinaryOperator::Sub
                     | BinaryOperator::Mul
                     | BinaryOperator::Div => {
-                        if l == TypeAnnotationNode::Integer && r == TypeAnnotationNode::Integer {
+                        if l.is_numeric() && r.is_numeric() {
                             Ok(TypeAnnotationNode::Integer)
                         } else {
                             Err(CclError::TypeError(
@@ -301,7 +301,7 @@ impl SemanticAnalyzer {
                         }
                     }
                     BinaryOperator::Eq | BinaryOperator::Neq => {
-                        if l == r {
+                        if l.compatible_with(&r) {
                             Ok(TypeAnnotationNode::Bool)
                         } else {
                             Err(CclError::TypeError(
@@ -313,7 +313,7 @@ impl SemanticAnalyzer {
                     | BinaryOperator::Gt
                     | BinaryOperator::Lte
                     | BinaryOperator::Gte => {
-                        if l == TypeAnnotationNode::Integer && r == TypeAnnotationNode::Integer {
+                        if l.is_numeric() && r.is_numeric() {
                             Ok(TypeAnnotationNode::Bool)
                         } else {
                             Err(CclError::TypeError(

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -21,8 +21,10 @@ fn test_compile_simple_policy_end_to_end() {
         }
     "#;
 
-    let res = compile_ccl_source_to_wasm(ccl_source);
-    assert!(matches!(res, Err(CclError::TypeError(_))));
+    let res = compile_ccl_source_to_wasm(ccl_source).expect("compile success");
+    let (wasm, meta) = res;
+    assert!(wasm.starts_with(b"\0asm"));
+    assert!(meta.exports.contains(&"get_cost".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- implement numeric type compatibility between `Mana` and `Integer`
- update semantic analyzer accordingly
- adjust integration tests
- document current compiler capabilities

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-ccl -- -D warnings`
- `cargo test -p icn-ccl`

------
https://chatgpt.com/codex/tasks/task_e_6850a125e2dc8324a926698c1f81b981