### PR TITLE
[runtime] extend MeshJobError and docs

### DIFF
--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -23,6 +23,31 @@ The API style emphasizes:
 *   **Modularity:** Clear separation between the runtime environment and the code being executed.
 *   **Well-Defined Interface:** A stable and clear set of host functions for guest code.
 
+## Error Handling
+
+`MeshJobError` is used throughout the runtime to represent failures while processing mesh jobs. The following variants may be returned:
+
+* `Network` – underlying mesh network failures.
+* `NoSuitableExecutor` – executor selection could not find a valid candidate.
+* `MissingOrInvalidReceipt` – receipt was not produced or failed validation.
+* `UnknownJob` – the referenced job does not exist in runtime state.
+* `ExecutionTimeout` – executor failed to provide a receipt in time.
+* `ProcessingFailure` – generic failure while handling a job.
+* `Serialization` – failed to encode or decode job data.
+* `InvalidSpec` – job specification or parameters are invalid.
+* `PermissionDenied` – caller lacks permission for the operation.
+* `InvalidJobState` – operation attempted on a job in the wrong state.
+* `Internal` – unexpected internal runtime error.
+* `HostAbi` – wrapper for a lower level `HostAbiError`.
+* `Economic` – issues related to mana or payment logic.
+* `NotImplemented` – feature is not yet implemented.
+* `DagOperationFailed` – failure while interacting with the DAG store.
+* `InvalidSignature` – signature verification failed for a receipt or message.
+* `CryptoError` – other cryptographic failure.
+* `WasmExecutionError` – execution engine reported an error.
+* `ResourceLimitExceeded` – operation exceeded allowed resources.
+* `InvalidSystemApiCall` – attempted to call an invalid system API.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-runtime/src/error.rs
+++ b/crates/icn-runtime/src/error.rs
@@ -57,6 +57,27 @@ pub enum MeshJobError {
     #[error("Economic error related to mana or payments: {0}")]
     Economic(String), // Could also be `#[from] EconError` if that's defined
 
+    #[error("Feature not implemented: {0}")]
+    NotImplemented(String),
+
+    #[error("DAG operation failed: {0}")]
+    DagOperationFailed(String),
+
+    #[error("Invalid signature for job {job_id:?}: {reason}")]
+    InvalidSignature { job_id: Option<Cid>, reason: String },
+
+    #[error("Cryptographic error: {0}")]
+    CryptoError(String),
+
+    #[error("WASM execution error: {0}")]
+    WasmExecutionError(String),
+
+    #[error("Resource limit exceeded: {0}")]
+    ResourceLimitExceeded(String),
+
+    #[error("Invalid system API call: {0}")]
+    InvalidSystemApiCall(String),
+
     // TODO [error_handling]: Add more specific error variants as needed
 }
 
@@ -91,6 +112,21 @@ impl From<HostAbiError> for MeshJobError {
                 job_id: Cid::default(),
                 reason: format!("Job submission failed via host ABI: {}", reason),
             },
+            HostAbiError::NotImplemented(msg) => MeshJobError::NotImplemented(msg),
+            HostAbiError::DagOperationFailed(msg) => MeshJobError::DagOperationFailed(msg),
+            HostAbiError::SignatureError(msg) => MeshJobError::InvalidSignature {
+                job_id: None,
+                reason: msg,
+            },
+            HostAbiError::CryptoError(msg) => MeshJobError::CryptoError(msg),
+            HostAbiError::WasmExecutionError(msg) => MeshJobError::WasmExecutionError(msg),
+            HostAbiError::ResourceLimitExceeded(msg) => {
+                MeshJobError::ResourceLimitExceeded(msg)
+            }
+            HostAbiError::InvalidSystemApiCall(msg) => {
+                MeshJobError::InvalidSystemApiCall(msg)
+            }
+            HostAbiError::InternalError(msg) => MeshJobError::Internal(msg),
             other => MeshJobError::HostAbi(other),
         }
     }

--- a/crates/icn-runtime/tests/error_variants.rs
+++ b/crates/icn-runtime/tests/error_variants.rs
@@ -31,3 +31,30 @@ fn host_abi_invalid_params_maps_to_invalid_spec() {
         _ => panic!("Unexpected mapping: {mesh_err:?}"),
     }
 }
+
+#[test]
+fn host_abi_signature_error_maps_to_invalid_signature() {
+    let err = HostAbiError::SignatureError("bad sig".to_string());
+    let mesh_err: MeshJobError = err.into();
+    match mesh_err {
+        MeshJobError::InvalidSignature {
+            job_id: None,
+            reason,
+        } => {
+            assert_eq!(reason, "bad sig");
+        }
+        other => panic!("Unexpected mapping: {other:?}"),
+    }
+}
+
+#[test]
+fn host_abi_dag_error_maps_to_dag_failed() {
+    let err = HostAbiError::DagOperationFailed("store".to_string());
+    let mesh_err: MeshJobError = err.into();
+    match mesh_err {
+        MeshJobError::DagOperationFailed(msg) => {
+            assert_eq!(msg, "store");
+        }
+        other => panic!("Unexpected mapping: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- expand `MeshJobError` with additional variants
- map new `HostAbiError` conversions to the extended enum
- document the error variants
- test conversion of new variants

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build stalled)*
- `cargo test --all-features --workspace` *(failed: build stalled)*

------
https://chatgpt.com/codex/tasks/task_e_6850a127c5248324871eb275b0f88867