### PR TITLE
[dag] deprecate default store helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The project has achieved a significant milestone, delivering an MVP with a funct
 
 *   **Modular Crate Structure:** Well-defined crates for common types (`icn-common`), API definitions (`icn-api`), DAG L1 logic (`icn-dag`), identity placeholders (`icn-identity`), networking abstractions (`icn-network`), a node runner (`icn-node`), a CLI (`icn-cli`), and the Cooperative Contract Language compiler (`icn-ccl`, located at the repository root outside `crates/`).
 *   **Real Protocol Data Models:** Core data types like DIDs, CIDs, DagBlocks, Transactions, and NodeStatus are defined in `icn-common` and utilize `serde` for serialization.
-*   **In-Memory DAG Store:** `icn-dag` provides a basic in-memory L1 DAG block store (`put_block`, `get_block`).
+*   **In-Memory DAG Store:** `icn-dag` ships with an in-memory DAG store implementing the `StorageService` trait. Use this trait directly rather than the deprecated `put_block`/`get_block` helpers.
 *   **API Layer:** `icn-api` exposes functions for node interaction (info, status) and DAG operations (submit, retrieve blocks).
 *   **Node & CLI Prototypes:**
     *   `icn-node`: A binary that demonstrates the integration of API, DAG, and networking components. When compiled with `with-libp2p` and started with `--enable-p2p`, it joins the libp2p mesh, discovers peers, and exchanges messages via gossipsub.

--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -1,6 +1,6 @@
-use reqwest::StatusCode;
 use icn_common::{Cid, DagBlock, Did, Transaction};
 use icn_node::app_router;
+use reqwest::StatusCode;
 use tokio::task;
 
 #[tokio::test]

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1115,9 +1115,8 @@ impl RuntimeContext {
         &self,
         proposal_id_str: &str,
     ) -> Result<String, HostAbiError> {
-        let proposal_id = ProposalId::from_str(proposal_id_str).map_err(|e| {
-            HostAbiError::InvalidParameters(format!("Invalid proposal id: {e}"))
-        })?;
+        let proposal_id = ProposalId::from_str(proposal_id_str)
+            .map_err(|e| HostAbiError::InvalidParameters(format!("Invalid proposal id: {e}")))?;
 
         let mut gov = self.governance_module.lock().await;
         let status = gov
@@ -1143,9 +1142,8 @@ impl RuntimeContext {
         &self,
         proposal_id_str: &str,
     ) -> Result<(), HostAbiError> {
-        let proposal_id = ProposalId::from_str(proposal_id_str).map_err(|e| {
-            HostAbiError::InvalidParameters(format!("Invalid proposal id: {e}"))
-        })?;
+        let proposal_id = ProposalId::from_str(proposal_id_str)
+            .map_err(|e| HostAbiError::InvalidParameters(format!("Invalid proposal id: {e}")))?;
 
         let mut gov = self.governance_module.lock().await;
         gov.execute_proposal(&proposal_id)

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -14,9 +14,9 @@
 
 pub mod abi;
 pub mod context;
+pub mod error;
 pub mod executor;
 pub mod metrics;
-pub mod error;
 
 // Re-export important types for convenience
 pub use context::{HostAbiError, RuntimeContext, Signer};

--- a/crates/icn-runtime/tests/governance.rs
+++ b/crates/icn-runtime/tests/governance.rs
@@ -1,10 +1,10 @@
+use icn_common::Did;
+use icn_governance::{ProposalId, ProposalStatus, VoteOption};
 use icn_runtime::context::RuntimeContext;
 use icn_runtime::{
     host_close_governance_proposal_voting, host_create_governance_proposal,
     host_execute_governance_proposal,
 };
-use icn_governance::{ProposalId, ProposalStatus, VoteOption};
-use icn_common::Did;
 use std::str::FromStr;
 
 #[tokio::test]
@@ -33,8 +33,18 @@ async fn proposal_can_be_closed_and_executed() {
     // cast votes directly using governance module
     {
         let mut gov = ctx.governance_module.lock().await;
-        gov.cast_vote(Did::from_str("did:icn:test:bob").unwrap(), &pid, VoteOption::Yes).unwrap();
-        gov.cast_vote(Did::from_str("did:icn:test:charlie").unwrap(), &pid, VoteOption::Yes).unwrap();
+        gov.cast_vote(
+            Did::from_str("did:icn:test:bob").unwrap(),
+            &pid,
+            VoteOption::Yes,
+        )
+        .unwrap();
+        gov.cast_vote(
+            Did::from_str("did:icn:test:charlie").unwrap(),
+            &pid,
+            VoteOption::Yes,
+        )
+        .unwrap();
     }
     // close voting
     let status = host_close_governance_proposal_voting(&ctx, &pid_str)
@@ -47,7 +57,9 @@ async fn proposal_can_be_closed_and_executed() {
         .expect("execute proposal");
     {
         let gov = ctx.governance_module.lock().await;
-        assert!(gov.members().contains(&Did::from_str("did:icn:test:dave").unwrap()));
+        assert!(gov
+            .members()
+            .contains(&Did::from_str("did:icn:test:dave").unwrap()));
         let prop = gov.get_proposal(&pid).unwrap().unwrap();
         assert_eq!(prop.status, ProposalStatus::Executed);
     }

--- a/icn-ccl/src/ast.rs
+++ b/icn-ccl/src/ast.rs
@@ -50,9 +50,11 @@ impl TypeAnnotationNode {
     /// since they share the same underlying WASM representation.
     pub fn compatible_with(&self, other: &Self) -> bool {
         self == other
-            || matches!((self, other),
+            || matches!(
+                (self, other),
                 (TypeAnnotationNode::Mana, TypeAnnotationNode::Integer)
-                    | (TypeAnnotationNode::Integer, TypeAnnotationNode::Mana))
+                    | (TypeAnnotationNode::Integer, TypeAnnotationNode::Mana)
+            )
     }
 
     /// Returns true if this type behaves like an integer number.


### PR DESCRIPTION
## Summary
- deprecate `put_block` and `get_block` using `DEFAULT_IN_MEMORY_STORE`
- update DAG tests to rely on explicit `StorageService`
- note deprecation in README
- format code

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: submit_transaction_and_query_data)*

------
https://chatgpt.com/codex/tasks/task_e_6850cba8100c83248e37941e4ca9de30