### PR TITLE
[icn-node] enhance info endpoint test

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1133,7 +1133,16 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        // TODO: Deserialize and check content if needed
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let info: NodeInfo = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(info.name, "ICN Test/Embedded Node");
+        assert_eq!(info.version, ICN_CORE_VERSION);
+        assert!(info.status_message.contains("Mana: 1000"));
+        assert!(info.status_message.contains("Node DID:"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- improve `info_endpoint_works` test to deserialize `NodeInfo`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: submit_transaction_and_query_data assertion)*

------
https://chatgpt.com/codex/tasks/task_e_6850cba5e32c8324b632ea0136c3590d