### PR TITLE
[mesh] add bid signature verification

### DIFF
--- a/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
@@ -8,7 +8,7 @@
 )]
 use anyhow::Result;
 use icn_common::{Cid, Did};
-use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes};
+use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes, SigningKey};
 use icn_mesh::{ActualMeshJob as Job, JobId, JobSpec, MeshJobBid as Bid, Resources};
 use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
 use icn_network::{NetworkMessage, NetworkService};
@@ -137,13 +137,20 @@ pub fn create_test_job(config: &TestJobConfig) -> Job {
 }
 
 /// Creates a test bid for the given job
-pub fn create_test_bid(job_id: &JobId, executor_did: &Did, price_mana: u64) -> Bid {
-    Bid {
+pub fn create_test_bid(
+    job_id: &JobId,
+    executor_did: &Did,
+    price_mana: u64,
+    signing_key: &SigningKey,
+) -> Bid {
+    let bid = Bid {
         job_id: job_id.clone(),
         executor_did: executor_did.clone(),
         price_mana,
         resources: Resources::default(),
-    }
+        signature: SignatureBytes(vec![]),
+    };
+    bid.sign(signing_key).unwrap()
 }
 
 /// Executes a job using SimpleExecutor and returns a signed receipt

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -222,12 +222,16 @@ mod cross_node_tests {
         
         // Node B: Create and submit bid
         let executor_did = Did::from_str("did:key:z6MkvBidNodeB")?;
-        let bid = MeshJobBid {
+        let unsigned_bid = MeshJobBid {
             job_id: test_job.id.clone(),
             executor_did: executor_did.clone(),
             price_mana: 20,
             resources: Resources::default(),
+            signature: SignatureBytes(vec![]),
         };
+        let bid_bytes = unsigned_bid.to_signable_bytes().unwrap();
+        let sig = node_b.signer.sign(&bid_bytes).unwrap();
+        let bid = MeshJobBid { signature: SignatureBytes(sig), ..unsigned_bid };
         
         // Node B broadcasts bid
         let bid_message = NetworkMessage::BidSubmission(bid.clone());
@@ -496,11 +500,20 @@ mod cross_node_tests {
         // Phase 4: Bidding
         info!("Phase 4: Node B submits bid");
         
-        let bid = MeshJobBid {
+        let unsigned_bid = MeshJobBid {
             job_id: test_job.id.clone(),
-            executor_did: executor_did.clone(), 
+            executor_did: executor_did.clone(),
             price_mana: 40,
             resources: Resources::default(),
+            signature: SignatureBytes(vec![]),
+        };
+        let sig_bytes = node_b
+            .signer
+            .sign(&unsigned_bid.to_signable_bytes().unwrap())
+            .unwrap();
+        let bid = MeshJobBid {
+            signature: SignatureBytes(sig_bytes),
+            ..unsigned_bid
         };
         
         let bid_message = NetworkMessage::BidSubmission(bid.clone());

--- a/tests/integration/multi_node_libp2p.rs
+++ b/tests/integration/multi_node_libp2p.rs
@@ -90,11 +90,18 @@ mod multi_node_libp2p {
         }).await?;
 
         // Send bid from Node B
-        let bid = MeshJobBid {
+        let unsigned_bid = MeshJobBid {
             job_id: job_id.clone(),
             executor_did: executor_did.clone(),
             price_mana: 30,
             resources: Resources::default(),
+            signature: SignatureBytes(vec![]),
+        };
+        let bid_bytes = unsigned_bid.to_signable_bytes().unwrap();
+        let sig = node_b.signer.sign(&bid_bytes).unwrap();
+        let bid = MeshJobBid {
+            signature: SignatureBytes(sig),
+            ..unsigned_bid
         };
         node_b_libp2p
             .broadcast_message(NetworkMessage::BidSubmission(bid))


### PR DESCRIPTION
## Summary
- extend `MeshJobBid` with `signature`
- implement signing & verification helpers
- sign bids in network tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: submit_transaction_and_query_data)*

------
https://chatgpt.com/codex/tasks/task_e_6850cba1d1dc8324a4656e8b32430c2a