### PR TITLE
[icn-node] persist node identity

### DIFF
--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -51,6 +51,8 @@ http_listen_addr = "127.0.0.1:8080"
 storage_backend = "file"
 storage_path = "./icn_data/node_store"
 mana_ledger_path = "./mana_ledger.sled"
+node_did_path = "./icn_data/node_did.txt"
+node_private_key_path = "./icn_data/node_sk.bs58"
 ```
 
 To start the node using this configuration:
@@ -60,6 +62,16 @@ To start the node using this configuration:
 ```
 
 Any CLI option provided will override the value from the file.
+
+Useful CLI flags include:
+
+* `--node-did-path <PATH>` – location to read/write the node DID string
+* `--node-private-key-path <PATH>` – location to read/write the node private key
+
+When the node starts, it will attempt to load its DID and private key from the
+configured paths. If no key material exists, a new Ed25519 key pair is generated
+and written to these files. Subsequent runs will reuse the persisted identity
+allowing consistent node identification across restarts.
 
 ## Contributing
 

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -24,6 +24,10 @@ pub struct NodeConfig {
     pub http_listen_addr: String,
     pub node_did: Option<String>,
     pub node_private_key_bs58: Option<String>,
+    /// Path where the node DID string will be stored/loaded.
+    pub node_did_path: std::path::PathBuf,
+    /// Path where the node's private key will be stored/loaded (bs58 encoded).
+    pub node_private_key_path: std::path::PathBuf,
     pub node_name: String,
     pub listen_address: String,
     pub bootstrap_peers: Option<Vec<String>>,
@@ -41,6 +45,8 @@ impl Default for NodeConfig {
             http_listen_addr: "127.0.0.1:7845".to_string(),
             node_did: None,
             node_private_key_bs58: None,
+            node_did_path: "./icn_data/node_did.txt".into(),
+            node_private_key_path: "./icn_data/node_sk.bs58".into(),
             node_name: "ICN Node".to_string(),
             listen_address: "/ip4/0.0.0.0/tcp/0".to_string(),
             bootstrap_peers: None,
@@ -83,6 +89,12 @@ impl NodeConfig {
         }
         if let Some(v) = &cli.node_private_key_bs58 {
             self.node_private_key_bs58 = Some(v.clone());
+        }
+        if let Some(v) = &cli.node_did_path {
+            self.node_did_path = v.clone();
+        }
+        if let Some(v) = &cli.node_private_key_path {
+            self.node_private_key_path = v.clone();
         }
         if let Some(v) = &cli.node_name {
             self.node_name = v.clone();

--- a/crates/icn-node/tests/identity.rs
+++ b/crates/icn-node/tests/identity.rs
@@ -1,0 +1,28 @@
+use icn_node::config::NodeConfig;
+use icn_node::node::load_or_generate_identity;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn identity_persists_between_runs() {
+    let dir = tempdir().unwrap();
+    let did_path = dir.path().join("node.did");
+    let key_path = dir.path().join("node.key");
+
+    let mut cfg1 = NodeConfig {
+        node_did_path: did_path.clone(),
+        node_private_key_path: key_path.clone(),
+        ..Default::default()
+    };
+    let (_sk1, _pk1, did1) = load_or_generate_identity(&mut cfg1);
+
+    let mut cfg2 = NodeConfig {
+        node_did_path: did_path.clone(),
+        node_private_key_path: key_path.clone(),
+        ..Default::default()
+    };
+    let (_sk2, _pk2, did2) = load_or_generate_identity(&mut cfg2);
+
+    assert_eq!(did1, did2);
+    assert_eq!(cfg2.node_did.as_deref(), Some(did1.as_str()));
+}


### PR DESCRIPTION
## Summary
- store node DID and private key on disk
- load persisted key and DID or generate a new pair
- expose CLI options for identity paths
- document persistence in README
- test identity persistence between runs

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6850f8a1f1d0832491b8411d9db6bf31