### PR TITLE
[governance] federation sync request via network service

### DIFF
--- a/crates/icn-governance/README.md
+++ b/crates/icn-governance/README.md
@@ -23,6 +23,14 @@ The API style emphasizes:
 *   **Flexibility:** Allowing for different governance models or parameters to be configured.
 *   **Interoperability:** Providing clear interfaces for other crates (e.g., `icn-cli`, `icn-node`) to interact with governance functions.
 
+## Federation Sync
+
+When built with the `federation` feature, this crate exposes
+`request_federation_sync`, an async helper that uses a provided
+`NetworkService` to request state from another peer. It sends a
+`FederationSyncRequest` message via the network layer and returns a
+`CommonError` if the underlying send fails.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-governance/tests/federation.rs
+++ b/crates/icn-governance/tests/federation.rs
@@ -1,0 +1,11 @@
+use icn_governance::request_federation_sync;
+use icn_network::{PeerId, StubNetworkService};
+
+#[cfg(feature = "federation")]
+#[tokio::test]
+async fn send_sync_request() {
+    let service = StubNetworkService::default();
+    let peer = PeerId("mock_peer_1".to_string());
+    let result = request_federation_sync(&service, &peer, None).await;
+    assert!(result.is_ok());
+}

--- a/crates/icn-network/tests/error_variants.rs
+++ b/crates/icn-network/tests/error_variants.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::field_reassign_with_default, clippy::uninlined_format_args)]
+
 #[cfg(feature = "libp2p")]
 mod error_variants {
     use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
@@ -9,7 +11,7 @@ mod error_variants {
         config.connection_timeout = std::time::Duration::from_secs(0);
         match Libp2pNetworkService::new(config).await {
             Err(MeshNetworkError::HandshakeFailed(_)) => {}
-            other => panic!("unexpected result: {:?}", other),
+            other => panic!("unexpected result: {other:?}"),
         }
     }
 
@@ -18,7 +20,7 @@ mod error_variants {
         let bytes = vec![1u8, 2, 3];
         match decode_network_message(&bytes) {
             Err(MeshNetworkError::MessageDecodeFailed(_)) => {}
-            other => panic!("unexpected result: {:?}", other),
+            other => panic!("unexpected result: {other:?}"),
         }
     }
 }

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1317,7 +1317,12 @@ impl RuntimeContext {
             .downcast_ref::<DefaultMeshNetworkService>()
         {
             let service = default_mesh.get_underlying_broadcast_service()?;
-            service.as_ref().clone().shutdown().await
+            service
+                .as_ref()
+                .clone()
+                .shutdown()
+                .await
+                .map_err(|e| CommonError::NetworkError(e.to_string()))
         } else {
             Ok(())
         }


### PR DESCRIPTION
## Summary
- inject `NetworkService` into `request_federation_sync`
- use the service to send a `FederationSyncRequest`
- map network errors to `CommonError`
- document `request_federation_sync` in the governance README
- allow clippy lints in `error_variants` test
- fix runtime `shutdown_network` error conversion
- test federation sync with `StubNetworkService`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: submit_transaction_and_query_data)*

------
https://chatgpt.com/codex/tasks/task_e_6850f8a7690083248a152b9f45abe7fc