### PR TITLE
[mesh] implement bid scoring

### DIFF
--- a/crates/icn-network/tests/error_variants.rs
+++ b/crates/icn-network/tests/error_variants.rs
@@ -5,11 +5,13 @@ mod error_variants {
 
     #[tokio::test]
     async fn handshake_error_on_zero_timeout() {
-        let mut config = NetworkConfig::default();
-        config.connection_timeout = std::time::Duration::from_secs(0);
+        let config = NetworkConfig {
+            connection_timeout: std::time::Duration::from_secs(0),
+            ..Default::default()
+        };
         match Libp2pNetworkService::new(config).await {
             Err(MeshNetworkError::HandshakeFailed(_)) => {}
-            other => panic!("unexpected result: {:?}", other),
+            other => panic!("unexpected result: {other:?}"),
         }
     }
 
@@ -18,7 +20,7 @@ mod error_variants {
         let bytes = vec![1u8, 2, 3];
         match decode_network_message(&bytes) {
             Err(MeshNetworkError::MessageDecodeFailed(_)) => {}
-            other => panic!("unexpected result: {:?}", other),
+            other => panic!("unexpected result: {other:?}"),
         }
     }
 }

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1317,7 +1317,12 @@ impl RuntimeContext {
             .downcast_ref::<DefaultMeshNetworkService>()
         {
             let service = default_mesh.get_underlying_broadcast_service()?;
-            service.as_ref().clone().shutdown().await
+            service
+                .as_ref()
+                .clone()
+                .shutdown()
+                .await
+                .map_err(|e| CommonError::NetworkError(e.to_string()))
         } else {
             Ok(())
         }


### PR DESCRIPTION
## Summary
- score bids using price, reputation and resources
- choose highest scoring executor with mana checks
- document `SelectionPolicy` and `score_bid`
- test resource weighting and zero-score when mana missing
- fix clippy in network tests and map shutdown errors

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: submit_transaction_and_query_data)*

------
https://chatgpt.com/codex/tasks/task_e_6850f8a4b91483249f2bb1a57a608f98