### PR TITLE
[icn-node] sled governance persistence option

### DIFF
--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -21,6 +21,8 @@ pub struct NodeConfig {
     pub storage_backend: StorageBackendType,
     pub storage_path: std::path::PathBuf,
     pub mana_ledger_path: std::path::PathBuf,
+    /// Path where governance proposals and votes are persisted via sled.
+    pub governance_db_path: std::path::PathBuf,
     pub http_listen_addr: String,
     pub node_did: Option<String>,
     pub node_private_key_bs58: Option<String>,
@@ -42,6 +44,7 @@ impl Default for NodeConfig {
             storage_backend: StorageBackendType::Memory,
             storage_path: "./icn_data/node_store".into(),
             mana_ledger_path: "./mana_ledger.sled".into(),
+            governance_db_path: "./governance_db".into(),
             http_listen_addr: "127.0.0.1:7845".to_string(),
             node_did: None,
             node_private_key_bs58: None,
@@ -80,6 +83,9 @@ impl NodeConfig {
         }
         if let Some(v) = &cli.mana_ledger_path {
             self.mana_ledger_path = v.clone();
+        }
+        if let Some(v) = &cli.governance_db_path {
+            self.governance_db_path = v.clone();
         }
         if let Some(v) = &cli.http_listen_addr {
             self.http_listen_addr = v.clone();

--- a/crates/icn-node/tests/governance_persistence.rs
+++ b/crates/icn-node/tests/governance_persistence.rs
@@ -1,0 +1,55 @@
+use icn_common::Did;
+use icn_governance::{ProposalType, VoteOption};
+use icn_node::app_router_with_options;
+use std::str::FromStr;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn governance_persists_between_restarts() {
+    let dir = tempdir().unwrap();
+    let ledger_path = dir.path().join("mana.sled");
+    let gov_path = dir.path().join("gov.sled");
+
+    let (_router, ctx) = app_router_with_options(
+        None,
+        None,
+        Some(ledger_path.clone()),
+        Some(gov_path.clone()),
+    )
+    .await;
+
+    let pid = {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.add_member(Did::from_str("did:example:alice").unwrap());
+        gov.add_member(Did::from_str("did:example:bob").unwrap());
+        gov.submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("hello".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap()
+    };
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.cast_vote(
+            Did::from_str("did:example:bob").unwrap(),
+            &pid,
+            VoteOption::Yes,
+        )
+        .unwrap();
+    }
+
+    drop(_router);
+
+    let (_router2, ctx2) = app_router_with_options(
+        None,
+        None,
+        Some(ledger_path.clone()),
+        Some(gov_path.clone()),
+    )
+    .await;
+    let gov2 = ctx2.governance_module.lock().await;
+    let prop = gov2.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.votes.len(), 1);
+}

--- a/crates/icn-node/tests/ledger.rs
+++ b/crates/icn-node/tests/ledger.rs
@@ -8,12 +8,13 @@ async fn ledger_persists_between_restarts() {
     let dir = tempdir().unwrap();
     let ledger_path = dir.path().join("mana.sled");
 
-    let (_router, ctx) = app_router_with_options(None, None, Some(ledger_path.clone())).await;
+    let (_router, ctx) = app_router_with_options(None, None, Some(ledger_path.clone()), None).await;
     let did = Did::from_str("did:example:alice").unwrap();
     ctx.mana_ledger.set_balance(&did, 42).expect("set balance");
 
     drop(_router);
 
-    let (_router2, ctx2) = app_router_with_options(None, None, Some(ledger_path.clone())).await;
+    let (_router2, ctx2) =
+        app_router_with_options(None, None, Some(ledger_path.clone()), None).await;
     assert_eq!(ctx2.mana_ledger.get_balance(&did), 42);
 }


### PR DESCRIPTION
## Summary
- add `governance_db_path` to `NodeConfig` and CLI
- configure `RuntimeContext` to use custom governance sled path
- accept governance DB path in `app_router_with_options`
- add test verifying proposals persist after restart

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test --all-features --workspace` *(failed: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6850fdcf63f8832489520a4b639e0401