### PR TITLE
[governance,network] implement federation sync messaging

### DIFF
--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -768,13 +768,15 @@ pub async fn request_federation_sync(
     target_peer: &PeerId,
     since_timestamp: Option<u64>,
 ) -> Result<(), CommonError> {
-    let _ = since_timestamp; // currently unused
-    let msg = NetworkMessage::FederationSyncRequest(Did::default());
+    let payload = since_timestamp
+        .map(|ts| Did::new("sync", &ts.to_string()))
+        .unwrap_or_default();
+
+    let msg = NetworkMessage::FederationSyncRequest(payload);
     service
         .send_message(target_peer, msg)
         .await
-        .map_err(map_mesh_err)?;
-    Ok(())
+        .map_err(map_mesh_err)
 }
 
 #[cfg(feature = "federation")]

--- a/crates/icn-network/Cargo.toml
+++ b/crates/icn-network/Cargo.toml
@@ -40,6 +40,7 @@ icn-mesh = { path = "../icn-mesh" }
 icn-runtime = { path = "../icn-runtime" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
+icn-governance = { path = "../icn-governance", features = ["federation"] }
 
 [features]
 default = []

--- a/crates/icn-network/tests/federation_sync.rs
+++ b/crates/icn-network/tests/federation_sync.rs
@@ -1,0 +1,65 @@
+#![allow(
+    unused_imports,
+    clippy::clone_on_copy,
+    clippy::uninlined_format_args,
+    clippy::field_reassign_with_default,
+    dead_code
+)]
+
+#[cfg(all(feature = "libp2p", feature = "federation"))]
+mod federation_sync {
+    use icn_common::Did;
+    use icn_governance::request_federation_sync;
+    use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
+    use icn_network::{NetworkMessage, NetworkService, PeerId};
+    use tokio::time::{sleep, timeout, Duration};
+
+    #[tokio::test]
+    async fn federation_sync_message_delivered() {
+        // Node A
+        let config_a = NetworkConfig::default();
+        let node_a = Libp2pNetworkService::new(config_a)
+            .await
+            .expect("node A start");
+        let peer_a = node_a.local_peer_id().clone();
+        sleep(Duration::from_secs(1)).await;
+        let addr_a = node_a
+            .listening_addresses()
+            .into_iter()
+            .next()
+            .expect("node A addr");
+
+        // Node B bootstraps to A
+        let mut config_b = NetworkConfig::default();
+        config_b.bootstrap_peers = vec![(peer_a, addr_a.clone())];
+        let node_b = Libp2pNetworkService::new(config_b)
+            .await
+            .expect("node B start");
+
+        // Allow peers to connect
+        sleep(Duration::from_secs(2)).await;
+
+        let mut sub_b = node_b.subscribe().await.expect("subscribe");
+        let peer_b = PeerId(node_b.local_peer_id().to_string());
+
+        let ts = 42u64;
+        request_federation_sync(&node_a, &peer_b, Some(ts))
+            .await
+            .expect("send sync");
+
+        let msg = timeout(Duration::from_secs(5), sub_b.recv())
+            .await
+            .expect("recv timeout")
+            .expect("recv message");
+
+        match msg {
+            NetworkMessage::FederationSyncRequest(did) => {
+                assert_eq!(did, Did::new("sync", &ts.to_string()));
+            }
+            other => panic!("unexpected message: {:?}", other),
+        }
+
+        node_a.shutdown().await.unwrap();
+        node_b.shutdown().await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- implement real federation sync request using `NetworkService::send_message`
- add `icn-governance` dev dependency for network tests
- add new network integration test for federation sync

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6850fdcf6cac83249f95ee4aa19da365