### PR TITLE
[ccl] wasm compile util and executor anchor flow

### DIFF
--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -115,6 +115,19 @@ impl WasmExecutor {
             engine: wasmtime::Engine::default(),
         }
     }
+
+    /// Executes the given job using [`execute_job`] and immediately anchors the
+    /// resulting receipt via the associated [`RuntimeContext`].
+    pub async fn execute_and_anchor_job(
+        &self,
+        job: &ActualMeshJob,
+    ) -> Result<Cid, crate::context::HostAbiError> {
+        let receipt = self
+            .execute_job(job)
+            .await
+            .map_err(crate::context::HostAbiError::Common)?;
+        self.ctx.anchor_receipt(&receipt).await
+    }
 }
 
 #[async_trait::async_trait]

--- a/icn-ccl/src/lib.rs
+++ b/icn-ccl/src/lib.rs
@@ -34,5 +34,37 @@ pub fn compile_ccl_source_to_wasm(source: &str) -> Result<(Vec<u8>, ContractMeta
     backend.compile_to_wasm(&optimized_ast)
 }
 
+/// Reads a CCL source file from disk and compiles it to WASM bytecode and metadata.
+///
+/// This is similar to [`cli::compile_ccl_file`] but returns the generated WASM
+/// bytes directly instead of writing them to disk. It also fills out the
+/// [`ContractMetadata`] with a placeholder CID and the SHA-256 hash of the
+/// source for auditing purposes.
+pub fn compile_ccl_file_to_wasm(
+    path: &std::path::Path,
+) -> Result<(Vec<u8>, ContractMetadata), CclError> {
+    use sha2::{Digest, Sha256};
+    use std::cmp::min;
+    use std::fs;
+
+    let source_code = fs::read_to_string(path).map_err(|e| {
+        CclError::IoError(format!(
+            "Failed to read source file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+
+    let (wasm, mut meta) = compile_ccl_source_to_wasm(&source_code)?;
+
+    // Placeholder CID calculation until real DAG integration is wired in.
+    meta.cid = format!("bafy2bzace{}", hex::encode(&wasm[0..min(10, wasm.len())]));
+
+    let digest = Sha256::digest(source_code.as_bytes());
+    meta.source_hash = format!("sha256:{:x}", digest);
+
+    Ok((wasm, meta))
+}
+
 // Re-export CLI helper functions for easier access by icn-cli
 pub use cli::{check_ccl_file, compile_ccl_file, explain_ccl_policy, format_ccl_file};


### PR DESCRIPTION
## Summary
- add `compile_ccl_file_to_wasm` for in-memory compilation
- expose executor helper to execute and anchor WASM jobs
- test executing a compiled WASM contract via HTTP pipeline

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: environment limits)*
- `cargo test --all-features --workspace` *(failed: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6850fdd1fa38832484a3997f41c50f13