### PR TITLE
[repo] add justfile utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ cargo build --no-default-features --features "with-libp2p persist-sqlite"
 ./target/debug/icn-cli status
 ```
 
+### Justfile Commands
+
+Common development tasks are defined in a `justfile` at the repository root. Install [just](https://github.com/casey/just) and run:
+
+```bash
+just format   # check formatting
+just lint     # run clippy
+just test     # execute all tests
+just build    # build all crates
+just devnet   # launch the containerized federation devnet
+```
+
+
 ### Enabling Peer Discovery and Persistent Storage
 
 1. **Compile with libp2p support** using `cargo build --features with-libp2p`.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,26 @@
+# Common development commands
+
+# Format the code using cargo fmt
+format:
+    cargo fmt --all -- --check
+
+# Run clippy linting
+lint:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# Run the full test suite
+# This mirrors CI by testing all crates with all features enabled
+# and executing integration tests for the CLI crate
+
+test:
+    cargo test --all-features --workspace
+
+# Build all crates with all features
+build:
+    cargo build --all-features --workspace
+
+# Launch the containerized federation devnet
+# Requires Docker and docker-compose
+
+devnet:
+    cd icn-devnet && ./launch_federation.sh


### PR DESCRIPTION
## Summary
- add repo-wide `justfile` with common recipes
- document how to use `just` commands in README

## Testing
- `cargo fmt --all -- --check`
- `timeout 30 cargo clippy --all-targets --all-features -- -D warnings` *(fails: timed out)*
- `timeout 30 cargo test --all-features --workspace` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6850fdd333c883249d1a439ea7fd57f4