### PR TITLE
[tests] add integration scenarios

### DIFF
--- a/crates/icn-node/tests/identity.rs
+++ b/crates/icn-node/tests/identity.rs
@@ -1,6 +1,5 @@
 use icn_node::config::NodeConfig;
 use icn_node::node::load_or_generate_identity;
-use std::path::PathBuf;
 use tempfile::tempdir;
 
 #[tokio::test]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,6 +7,26 @@ edition.workspace = true
 name = "federation"
 path = "integration/federation.rs"
 
+[[test]]
+name = "job_pipeline"
+path = "integration/job_pipeline.rs"
+
+[[test]]
+name = "multi_node_libp2p"
+path = "integration/multi_node_libp2p.rs"
+
+[[test]]
+name = "governance_sled_lifecycle"
+path = "integration/governance_sled_lifecycle.rs"
+
+[[test]]
+name = "job_submission_cli"
+path = "integration/job_submission_cli.rs"
+
+[[test]]
+name = "federation_sync_restart"
+path = "integration/federation_sync_restart.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true

--- a/tests/integration/federation_sync_restart.rs
+++ b/tests/integration/federation_sync_restart.rs
@@ -1,0 +1,46 @@
+#[cfg(feature = "enable-libp2p")]
+#[tokio::test]
+async fn federation_sync_after_restart() -> Result<(), anyhow::Error> {
+    use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
+    use icn_network::NetworkService;
+    use libp2p::Multiaddr;
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    let listen_addr: Multiaddr = "/ip4/127.0.0.1/tcp/37001".parse().unwrap();
+    let config_a = NetworkConfig {
+        listen_addresses: vec![listen_addr.clone()],
+        ..NetworkConfig::default()
+    };
+    let node_a = Libp2pNetworkService::new(config_a).await?;
+    let peer_a = *node_a.local_peer_id();
+    sleep(Duration::from_secs(1)).await;
+    let addr_a = node_a
+        .listening_addresses()
+        .get(0)
+        .cloned()
+        .expect("addr");
+    let config_b = NetworkConfig {
+        bootstrap_peers: vec![(peer_a, addr_a.clone())],
+        bootstrap_interval: Duration::from_secs(2),
+        ..NetworkConfig::default()
+    };
+    let node_b = Libp2pNetworkService::new(config_b).await?;
+    sleep(Duration::from_secs(3)).await;
+    assert!(node_b.get_network_stats().await?.peer_count > 0);
+
+    node_b.shutdown().await?;
+
+    let config_b_restart = NetworkConfig {
+        bootstrap_peers: vec![(peer_a, addr_a)],
+        bootstrap_interval: Duration::from_secs(2),
+        ..NetworkConfig::default()
+    };
+    let node_b2 = Libp2pNetworkService::new(config_b_restart).await?;
+    sleep(Duration::from_secs(5)).await;
+    assert!(node_b2.get_network_stats().await?.peer_count > 0);
+
+    node_a.shutdown().await?;
+    node_b2.shutdown().await?;
+    Ok(())
+}

--- a/tests/integration/governance_sled_lifecycle.rs
+++ b/tests/integration/governance_sled_lifecycle.rs
@@ -1,0 +1,34 @@
+use icn_governance::{GovernanceModule, ProposalStatus, ProposalType, VoteOption};
+use icn_common::Did;
+use std::str::FromStr;
+use tempfile::tempdir;
+
+#[cfg(feature = "persist-sled")]
+#[tokio::test]
+async fn governance_proposal_lifecycle_sled() {
+    let dir = tempdir().unwrap();
+    let mut gov = GovernanceModule::new_sled(dir.path().to_path_buf()).unwrap();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.set_quorum(2);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("test".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap();
+    gov
+        .cast_vote(Did::from_str("did:example:bob").unwrap(), &pid, VoteOption::Yes)
+        .unwrap();
+    let status = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
+    gov.execute_proposal(&pid).unwrap();
+
+    drop(gov);
+    let gov2 = GovernanceModule::new_sled(dir.path().to_path_buf()).unwrap();
+    let prop = gov2.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.status, ProposalStatus::Executed);
+}

--- a/tests/integration/job_submission_cli.rs
+++ b/tests/integration/job_submission_cli.rs
@@ -1,0 +1,36 @@
+use assert_cmd::prelude::*;
+use icn_node::app_router;
+use std::process::Command;
+use tokio::task;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn job_submission_via_cli() {
+    let _ = std::fs::remove_dir_all("./mana_ledger.sled");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move { axum::serve(listener, app_router().await).await.unwrap(); });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{addr}");
+    let job_json = serde_json::json!({
+        "manifest_cid": "cidv1-85-20-cli_job_manifest",
+        "spec_json": { "Echo": { "payload": "cli job" } },
+        "cost_mana": 50
+    })
+    .to_string();
+
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "mesh", "submit", &job_json])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("Successfully submitted job"));
+    })
+    .await
+    .unwrap();
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- add mesh job CLI command
- fix unused import warning in node identity tests
- integrate governance sled lifecycle test
- test job submission via CLI against a running node
- verify federation sync after restart

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6850fdd6b244832486358988e1dad97e