### PR TITLE
[icn-mesh] JobSpec structure and bid scoring update

### DIFF
--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -43,6 +43,9 @@ mod libp2p_mesh_integration {
         let manifest_cid = Cid::new_v1_dummy(0x71, 0x12, b"dummy_manifest_data");
         let job_spec = JobSpec::Echo {
             payload: "hello world".to_string(),
+            input_cids: Vec::new(),
+            output_cids: Vec::new(),
+            required_resources: Resources::default(),
         };
         Job {
             id: job_id,

--- a/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
@@ -123,6 +123,9 @@ pub fn create_test_job(config: &TestJobConfig) -> Job {
     let manifest_cid = Cid::new_v1_dummy(0x71, 0x12, b"dummy_manifest_data");
     let job_spec = JobSpec::Echo {
         payload: config.payload.clone(),
+        input_cids: Vec::new(),
+        output_cids: Vec::new(),
+        required_resources: Resources::default(),
     };
 
     Job {

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -51,11 +51,11 @@ impl JobExecutor for SimpleExecutor {
         let start_time = SystemTime::now();
 
         let result_bytes = match &job.spec {
-            JobSpec::Echo { payload } => {
+            JobSpec::Echo { payload, .. } => {
                 info!("[SimpleExecutor] Executing echo job: {:?}", job.id);
                 format!("Echo: {}", payload).into_bytes()
             }
-            JobSpec::GenericPlaceholder => {
+            JobSpec::GenericPlaceholder { .. } => {
                 info!(
                     "[SimpleExecutor] Executing hash job (placeholder): {:?}",
                     job.id
@@ -215,6 +215,9 @@ mod tests {
             manifest_cid,
             spec: JobSpec::Echo {
                 payload: "Hello Echo Test".to_string(),
+                input_cids: Vec::new(),
+                output_cids: Vec::new(),
+                required_resources: Resources::default(),
             }, // Corrected JobSpec usage
             creator_did: Did::from_str("did:example:jobcreator").unwrap(),
             cost_mana: 10,
@@ -247,6 +250,9 @@ mod tests {
             manifest_cid: dummy_cid_for_executor_test("manifest1"),
             spec: JobSpec::Echo {
                 payload: "hello".to_string(),
+                input_cids: Vec::new(),
+                output_cids: Vec::new(),
+                required_resources: Resources::default(),
             },
             creator_did: Did::from_str("did:example:jobcreator").unwrap(),
             cost_mana: 10,

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -65,6 +65,9 @@ mod runtime_host_abi_tests {
             manifest_cid,
             spec: JobSpec::Echo {
                 payload: payload.to_string(),
+                input_cids: Vec::new(),
+                output_cids: Vec::new(),
+                required_resources: Resources::default(),
             },
             creator_did: creator_did.clone(),
             cost_mana,

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -31,7 +31,12 @@ mod cross_node_tests {
         ActualMeshJob {
             id: job_id,
             manifest_cid,
-            spec: JobSpec::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+            spec: JobSpec::Echo {
+                payload: format!("Cross-node test job {}", job_id_suffix),
+                input_cids: Vec::new(),
+                output_cids: Vec::new(),
+                required_resources: Resources::default(),
+            },
             creator_did: creator_did.clone(),
             cost_mana,
             max_execution_wait_ms: None,

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -37,7 +37,7 @@ async fn wasm_executor_runs_wasm() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x11, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -159,7 +159,7 @@ async fn test_wasm_executor_with_ccl() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -54,7 +54,7 @@ async fn wasm_executor_runs_compiled_ccl() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,
@@ -97,7 +97,7 @@ async fn wasm_executor_runs_compiled_addition() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"jobadd"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,
@@ -140,7 +140,7 @@ async fn wasm_executor_fails_without_run() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job2"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,

--- a/tests/integration/job_pipeline.rs
+++ b/tests/integration/job_pipeline.rs
@@ -31,7 +31,12 @@ async fn end_to_end_mesh_job_execution() {
     ctx.spawn_mesh_job_manager().await;
 
     // 2. Submit a basic Echo job
-    let job_spec = JobSpec::Echo { payload: "hello world".to_owned() }; // Assumes JobSpec::Echo variant
+    let job_spec = JobSpec::Echo {
+        payload: "hello world".to_owned(),
+        input_cids: Vec::new(),
+        output_cids: Vec::new(),
+        required_resources: Resources::default(),
+    }; // Assumes JobSpec::Echo variant
     let manifest_cid = "bafybeigdyrzt7dpbrm3kmhgtr5mk6yzqq3wj7owxsbs2hlkzbfio4ilv5e"; // any CID string
     
     // Constructing the JSON payload for ActualMeshJob as expected by host_submit_mesh_job

--- a/tests/integration/multi_node_libp2p.rs
+++ b/tests/integration/multi_node_libp2p.rs
@@ -19,7 +19,12 @@ mod multi_node_libp2p {
         ActualMeshJob {
             id: job_id,
             manifest_cid,
-            spec: JobSpec::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+            spec: JobSpec::Echo {
+                payload: format!("Cross-node test job {}", job_id_suffix),
+                input_cids: Vec::new(),
+                output_cids: Vec::new(),
+                required_resources: Resources::default(),
+            },
             creator_did: creator_did.clone(),
             cost_mana,
             max_execution_wait_ms: None,


### PR DESCRIPTION
## Summary
- expand `JobSpec` with input/output fields and required resources
- implement option-based bid scoring with mana and reputation checks
- integrate scoring into executor selection logic
- update tests for new `JobSpec` layout and add edge case coverage

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation halted)*
- `cargo test --all-features --workspace` *(failed: compilation halted)*

------
https://chatgpt.com/codex/tasks/task_e_6850fdce6be8832496ad5e7edbd66a3f