### PR TITLE
[mesh] expand JobSpec and scoring

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1229,7 +1229,11 @@ mod tests {
 
         let job_req = SubmitJobRequest {
             manifest_cid: Cid::new_v1_dummy(0x55, 0x14, b"test_manifest").to_string(),
-            spec_json: serde_json::json!({ "Echo": { "payload": "hello" } }),
+            spec_json: serde_json::to_value(&icn_mesh::JobSpec {
+                kind: icn_mesh::JobKind::Echo { payload: "hello".into() },
+                ..Default::default()
+            })
+            .unwrap(),
             cost_mana: 50,
         };
         let job_req_json = serde_json::to_string(&job_req).unwrap();
@@ -1262,7 +1266,11 @@ mod tests {
         // Step 1: Submit a job via HTTP
         let job_req = SubmitJobRequest {
             manifest_cid: Cid::new_v1_dummy(0x55, 0x14, b"pipeline_test_manifest").to_string(),
-            spec_json: serde_json::json!({ "Echo": { "payload": "HTTP pipeline test" } }),
+            spec_json: serde_json::to_value(&icn_mesh::JobSpec {
+                kind: icn_mesh::JobKind::Echo { payload: "HTTP pipeline test".into() },
+                ..Default::default()
+            })
+            .unwrap(),
             cost_mana: 100,
         };
         let job_req_json = serde_json::to_string(&job_req).unwrap();
@@ -1394,7 +1402,11 @@ mod tests {
         // Step 1: Submit a job
         let job_req = SubmitJobRequest {
             manifest_cid: Cid::new_v1_dummy(0x55, 0x14, b"simple_test").to_string(),
-            spec_json: serde_json::json!({ "Echo": { "payload": "simple test" } }),
+            spec_json: serde_json::to_value(&icn_mesh::JobSpec {
+                kind: icn_mesh::JobKind::Echo { payload: "simple test".into() },
+                ..Default::default()
+            })
+            .unwrap(),
             cost_mana: 50,
         };
         let job_req_json = serde_json::to_string(&job_req).unwrap();
@@ -1470,7 +1482,7 @@ mod tests {
         // Submit job referencing the WASM CID
         let job_req = SubmitJobRequest {
             manifest_cid: wasm_cid.to_string(),
-            spec_json: serde_json::json!("GenericPlaceholder"),
+            spec_json: serde_json::to_value(&icn_mesh::JobSpec::default()).unwrap(),
             cost_mana: 0,
         };
         let job_req_json = serde_json::to_string(&job_req).unwrap();
@@ -1501,7 +1513,7 @@ mod tests {
         let job = ActualMeshJob {
             id: job_id.clone(),
             manifest_cid: wasm_cid.clone(),
-            spec: JobSpec::GenericPlaceholder,
+            spec: JobSpec::default(),
             creator_did: ctx.current_identity.clone(),
             cost_mana: 0,
             max_execution_wait_ms: None,

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -50,12 +50,12 @@ impl JobExecutor for SimpleExecutor {
         );
         let start_time = SystemTime::now();
 
-        let result_bytes = match &job.spec {
-            JobSpec::Echo { payload } => {
+        let result_bytes = match &job.spec.kind {
+            JobKind::Echo { payload } => {
                 info!("[SimpleExecutor] Executing echo job: {:?}", job.id);
                 format!("Echo: {}", payload).into_bytes()
             }
-            JobSpec::GenericPlaceholder => {
+            JobKind::GenericPlaceholder => {
                 info!(
                     "[SimpleExecutor] Executing hash job (placeholder): {:?}",
                     job.id

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -63,8 +63,11 @@ mod runtime_host_abi_tests {
         let job = ActualMeshJob {
             id: job_id,
             manifest_cid,
-            spec: JobSpec::Echo {
-                payload: payload.to_string(),
+            spec: JobSpec {
+                kind: JobKind::Echo {
+                    payload: payload.to_string(),
+                },
+                ..Default::default()
             },
             creator_did: creator_did.clone(),
             cost_mana,

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -31,7 +31,10 @@ mod cross_node_tests {
         ActualMeshJob {
             id: job_id,
             manifest_cid,
-            spec: JobSpec::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+            spec: JobSpec {
+                kind: JobKind::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+                ..Default::default()
+            },
             creator_did: creator_did.clone(),
             cost_mana,
             max_execution_wait_ms: None,

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -37,7 +37,7 @@ async fn wasm_executor_runs_wasm() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x11, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,


### PR DESCRIPTION
## Summary
- expand `JobSpec` with `JobKind`, inputs, outputs and resource requirements
- weight scoring by job resources with mana/reputation checks
- integrate scoring into executor selection
- adjust runtime/node tests for new structure
- cover edge cases in mesh scoring tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: Blocking waiting for file lock)*
- `cargo test --all-features --workspace` *(failed: Blocking waiting for file lock)*

------
https://chatgpt.com/codex/tasks/task_e_685166468ccc8324844d8027c9b695a5