### PR TITLE
[runtime] wasm memory helpers and tests

### DIFF
--- a/crates/icn-runtime/src/memory.rs
+++ b/crates/icn-runtime/src/memory.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+use wasmtime::{Caller, Memory};
+
+use crate::{context::RuntimeContext, HostAbiError};
+
+/// Retrieves the guest memory from the caller.
+fn get_memory(caller: &mut Caller<'_, Arc<RuntimeContext>>) -> Result<Memory, HostAbiError> {
+    caller
+        .get_export("memory")
+        .and_then(|e| e.into_memory())
+        .ok_or_else(|| HostAbiError::InvalidParameters("memory export missing".into()))
+}
+
+/// Reads a slice of bytes from guest memory.
+pub fn read_bytes(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    len: u32,
+) -> Result<Vec<u8>, HostAbiError> {
+    let memory = get_memory(caller)?;
+    let mut buf = vec![0u8; len as usize];
+    memory
+        .read(caller, ptr as usize, &mut buf)
+        .map_err(|e| HostAbiError::InvalidParameters(format!("memory read failed: {e}")))?;
+    Ok(buf)
+}
+
+/// Reads a UTF-8 string from guest memory.
+pub fn read_string(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    len: u32,
+) -> Result<String, HostAbiError> {
+    let bytes = read_bytes(caller, ptr, len)?;
+    String::from_utf8(bytes)
+        .map_err(|e| HostAbiError::InvalidParameters(format!("utf8 error: {e}")))
+}
+
+/// Writes bytes into guest memory at the given pointer.
+pub fn write_bytes(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    data: &[u8],
+) -> Result<(), HostAbiError> {
+    let memory = get_memory(caller)?;
+    memory
+        .write(caller, ptr as usize, data)
+        .map_err(|e| HostAbiError::InvalidParameters(format!("memory write failed: {e}")))
+}
+
+/// Writes a UTF-8 string into guest memory at the given pointer.
+pub fn write_string(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    data: &str,
+) -> Result<(), HostAbiError> {
+    write_bytes(caller, ptr, data.as_bytes())
+}

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -5,11 +5,8 @@ use icn_mesh::{ActualMeshJob, JobSpec};
 use icn_runtime::context::RuntimeContext;
 use icn_runtime::executor::{JobExecutor, WasmExecutor};
 use std::str::FromStr;
-use std::thread;
-use tokio::runtime::Runtime;
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "nested tokio runtime not yet supported"]
 async fn wasm_executor_runs_wasm() {
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 42);
     let (sk, vk) = generate_ed25519_keypair();
@@ -45,11 +42,6 @@ async fn wasm_executor_runs_wasm() {
     };
 
     let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
-    let job_clone = job.clone();
-    let handle = thread::spawn(move || {
-        let rt = Runtime::new().unwrap();
-        rt.block_on(async { exec.execute_job(&job_clone).await })
-    });
-    let receipt = handle.join().unwrap().unwrap();
+    let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
 }


### PR DESCRIPTION
## Summary
- add helper functions for reading/writing strings and bytes between guest WASM memory and Rust
- expose wasm wrappers for `host_submit_mesh_job` and `host_anchor_receipt`
- link wrappers in `WasmExecutor`
- run WASM executor integration test without nested runtimes

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build took too long)*
- `cargo test --all-features --workspace` *(failed: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_68516a4d4b788324b1961b72e168aa3e