### PR TITLE
[icn-mesh] extend JobSpec with resource fields

### DIFF
--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -16,7 +16,7 @@ mod libp2p_mesh_integration {
     use anyhow::Result;
     use icn_common::{Cid, Did};
     use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes};
-    use icn_mesh::{ActualMeshJob as Job, JobId, JobSpec, MeshJobBid as Bid, Resources};
+    use icn_mesh::{ActualMeshJob as Job, JobId, JobKind, JobSpec, MeshJobBid as Bid, Resources};
     use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
     use icn_network::{NetworkMessage, NetworkService};
     use icn_runtime::executor::{JobExecutor, SimpleExecutor};
@@ -41,8 +41,11 @@ mod libp2p_mesh_integration {
         let creator_did =
             Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuias7ux1jEZ6KATp8").unwrap();
         let manifest_cid = Cid::new_v1_dummy(0x71, 0x12, b"dummy_manifest_data");
-        let job_spec = JobSpec::Echo {
-            payload: "hello world".to_string(),
+        let job_spec = JobSpec {
+            kind: JobKind::Echo {
+                payload: "hello world".to_string(),
+            },
+            ..Default::default()
         };
         Job {
             id: job_id,

--- a/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
@@ -9,7 +9,7 @@
 use anyhow::Result;
 use icn_common::{Cid, Did};
 use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes, SigningKey};
-use icn_mesh::{ActualMeshJob as Job, JobId, JobSpec, MeshJobBid as Bid, Resources};
+use icn_mesh::{ActualMeshJob as Job, JobId, JobKind, JobSpec, MeshJobBid as Bid, Resources};
 use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
 use icn_network::{NetworkMessage, NetworkService};
 use icn_runtime::executor::{JobExecutor, SimpleExecutor};
@@ -121,8 +121,11 @@ pub fn create_test_job(config: &TestJobConfig) -> Job {
     let job_id_cid = Cid::new_v1_dummy(0x55, 0x13, config.id_suffix.as_bytes());
     let job_id = JobId::from(job_id_cid);
     let manifest_cid = Cid::new_v1_dummy(0x71, 0x12, b"dummy_manifest_data");
-    let job_spec = JobSpec::Echo {
-        payload: config.payload.clone(),
+    let job_spec = JobSpec {
+        kind: JobKind::Echo {
+            payload: config.payload.clone(),
+        },
+        ..Default::default()
     };
 
     Job {

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1501,7 +1501,7 @@ mod tests {
         let job = ActualMeshJob {
             id: job_id.clone(),
             manifest_cid: wasm_cid.clone(),
-            spec: JobSpec::GenericPlaceholder,
+            spec: JobSpec::default(),
             creator_did: ctx.current_identity.clone(),
             cost_mana: 0,
             max_execution_wait_ms: None,

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -6,7 +6,7 @@ use icn_identity::{
     SignatureBytes, /* Removed , generate_ed25519_keypair */
     SigningKey,
 };
-use icn_mesh::{ActualMeshJob, JobSpec /* ... other mesh types ... */};
+use icn_mesh::{ActualMeshJob, JobKind, JobSpec /* ... other mesh types ... */};
 use log::info; // Removed error
 use std::time::SystemTime;
 
@@ -50,12 +50,12 @@ impl JobExecutor for SimpleExecutor {
         );
         let start_time = SystemTime::now();
 
-        let result_bytes = match &job.spec {
-            JobSpec::Echo { payload } => {
+        let result_bytes = match &job.spec.kind {
+            JobKind::Echo { payload } => {
                 info!("[SimpleExecutor] Executing echo job: {:?}", job.id);
                 format!("Echo: {}", payload).into_bytes()
             }
-            JobSpec::GenericPlaceholder => {
+            JobKind::GenericPlaceholder => {
                 info!(
                     "[SimpleExecutor] Executing hash job (placeholder): {:?}",
                     job.id
@@ -226,9 +226,12 @@ mod tests {
         let job = ActualMeshJob {
             id: job_id.clone(),
             manifest_cid,
-            spec: JobSpec::Echo {
-                payload: "Hello Echo Test".to_string(),
-            }, // Corrected JobSpec usage
+            spec: JobSpec {
+                kind: JobKind::Echo {
+                    payload: "Hello Echo Test".to_string(),
+                },
+                ..Default::default()
+            },
             creator_did: Did::from_str("did:example:jobcreator").unwrap(),
             cost_mana: 10,
             max_execution_wait_ms: None,
@@ -258,8 +261,11 @@ mod tests {
         let job = ActualMeshJob {
             id: dummy_cid_for_executor_test("job1"),
             manifest_cid: dummy_cid_for_executor_test("manifest1"),
-            spec: JobSpec::Echo {
-                payload: "hello".to_string(),
+            spec: JobSpec {
+                kind: JobKind::Echo {
+                    payload: "hello".to_string(),
+                },
+                ..Default::default()
             },
             creator_did: Did::from_str("did:example:jobcreator").unwrap(),
             cost_mana: 10,

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -15,7 +15,7 @@ mod runtime_host_abi_tests {
     use anyhow::Result;
     use icn_common::{Cid, Did};
     use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt};
-    use icn_mesh::{ActualMeshJob, JobSpec};
+    use icn_mesh::{ActualMeshJob, JobKind, JobSpec};
     use icn_network::{NetworkMessage, NetworkService};
     use icn_runtime::context::RuntimeContext;
     use icn_runtime::{host_anchor_receipt, host_submit_mesh_job, ReputationUpdater};
@@ -63,8 +63,11 @@ mod runtime_host_abi_tests {
         let job = ActualMeshJob {
             id: job_id,
             manifest_cid,
-            spec: JobSpec::Echo {
-                payload: payload.to_string(),
+            spec: JobSpec {
+                kind: JobKind::Echo {
+                    payload: payload.to_string(),
+                },
+                ..Default::default()
             },
             creator_did: creator_did.clone(),
             cost_mana,

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -15,7 +15,7 @@ mod cross_node_tests {
     use icn_runtime::executor::{SimpleExecutor, JobExecutor};
     use icn_common::{Did, Cid};
     use icn_identity::{SignatureBytes, generate_ed25519_keypair};
-    use icn_mesh::{ActualMeshJob, MeshJobBid, JobSpec, Resources};
+    use icn_mesh::{ActualMeshJob, JobKind, MeshJobBid, JobSpec, Resources};
     use icn_network::{NetworkMessage, NetworkService};
     use std::str::FromStr;
     use std::sync::Arc;
@@ -31,7 +31,10 @@ mod cross_node_tests {
         ActualMeshJob {
             id: job_id,
             manifest_cid,
-            spec: JobSpec::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+            spec: JobSpec {
+                kind: JobKind::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+                ..Default::default()
+            },
             creator_did: creator_did.clone(),
             cost_mana,
             max_execution_wait_ms: None,

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -37,7 +37,7 @@ async fn wasm_executor_runs_wasm() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x11, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -159,7 +159,7 @@ async fn test_wasm_executor_with_ccl() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -54,7 +54,7 @@ async fn wasm_executor_runs_compiled_ccl() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,
@@ -97,7 +97,7 @@ async fn wasm_executor_runs_compiled_addition() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"jobadd"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,
@@ -140,7 +140,7 @@ async fn wasm_executor_fails_without_run() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job2"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,

--- a/tests/integration/job_pipeline.rs
+++ b/tests/integration/job_pipeline.rs
@@ -7,7 +7,7 @@ use icn_runtime::{
     context::{RuntimeContext, StubSigner, StubMeshNetworkService, RuntimeStubDagStore}, // Corrected: RuntimeStubDagStore
     host_submit_mesh_job,
 };
-use icn_mesh::{JobSpec, JobState}; // Added JobState
+use icn_mesh::{JobKind, JobSpec, JobState}; // Added JobState
 use serde_json::json;
 use tokio::time::sleep;
 use tokio::sync::Mutex;
@@ -31,7 +31,10 @@ async fn end_to_end_mesh_job_execution() {
     ctx.spawn_mesh_job_manager().await;
 
     // 2. Submit a basic Echo job
-    let job_spec = JobSpec::Echo { payload: "hello world".to_owned() }; // Assumes JobSpec::Echo variant
+    let job_spec = JobSpec {
+        kind: JobKind::Echo { payload: "hello world".to_owned() },
+        ..Default::default()
+    };
     let manifest_cid = "bafybeigdyrzt7dpbrm3kmhgtr5mk6yzqq3wj7owxsbs2hlkzbfio4ilv5e"; // any CID string
     
     // Constructing the JSON payload for ActualMeshJob as expected by host_submit_mesh_job

--- a/tests/integration/multi_node_libp2p.rs
+++ b/tests/integration/multi_node_libp2p.rs
@@ -5,7 +5,7 @@ mod multi_node_libp2p {
     use icn_runtime::executor::{SimpleExecutor, JobExecutor};
     use icn_common::{Did, Cid};
     use icn_identity::{SignatureBytes, generate_ed25519_keypair};
-    use icn_mesh::{ActualMeshJob, MeshJobBid, JobSpec, Resources};
+    use icn_mesh::{ActualMeshJob, JobKind, MeshJobBid, JobSpec, Resources};
     use icn_network::{NetworkMessage, NetworkService};
     use libp2p::{Multiaddr, PeerId as Libp2pPeerId};
     use std::str::FromStr;
@@ -19,7 +19,10 @@ mod multi_node_libp2p {
         ActualMeshJob {
             id: job_id,
             manifest_cid,
-            spec: JobSpec::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+            spec: JobSpec {
+                kind: JobKind::Echo { payload: format!("Cross-node test job {}", job_id_suffix) },
+                ..Default::default()
+            },
             creator_did: creator_did.clone(),
             cost_mana,
             max_execution_wait_ms: None,


### PR DESCRIPTION
## Summary
- add `JobKind` and expand `JobSpec` with resources and timeout
- update runtime executor for new `JobKind`
- adjust job submission/use across runtime, network and node tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings` *(failed: could not compile `icn-cli`)*
- `cargo test --all-features --workspace` *(failed to execute)*

------
https://chatgpt.com/codex/tasks/task_e_68516a4f93c08324beb913ae88e5ec05