### PR TITLE
[tests] automate devnet integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,23 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --all-features --workspace --exclude icn-integration-tests
 
       - name: Run icn-cli integration tests
         run: cargo test --all-features -p icn-cli
+
+      - name: Start devnet (nightly only)
+        if: matrix.rust == 'nightly'
+        run: |
+          ./icn-devnet/launch_federation.sh --start-only
+      - name: Run integration tests (nightly only)
+        if: matrix.rust == 'nightly'
+        env:
+          ICN_DEVNET_RUNNING: "true"
+        run: cargo test --all-features -p icn-integration-tests -- --nocapture
+      - name: Stop devnet (nightly only)
+        if: matrix.rust == 'nightly'
+        run: docker-compose -f icn-devnet/docker-compose.yml down --volumes --remove-orphans
 
       - name: Build release (nightly only, for early detection of issues)
         if: matrix.rust == 'nightly'

--- a/icn-devnet/launch_federation.sh
+++ b/icn-devnet/launch_federation.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Start-only mode for CI/integration tests
+START_ONLY=false
+if [ "$1" = "--start-only" ]; then
+    START_ONLY=true
+fi
+
 # ICN Federation Launch Script
 # Starts a 3-node federation and tests cross-node mesh job execution
 
@@ -226,13 +232,18 @@ main() {
     
     # Wait for network convergence
     wait_for_network_convergence
-    
+
+    if [ "$START_ONLY" = true ]; then
+        success "Federation started (start-only mode)"
+        return 0
+    fi
+
     # Test mesh job execution
     test_mesh_job_execution
-    
+
     # Show final status
     show_federation_status
-    
+
     success "🎉 ICN Federation is now running!"
     echo ""
     echo -e "${GREEN}Access points:${NC}"
@@ -258,7 +269,7 @@ cleanup() {
     fi
 }
 
-trap cleanup EXIT
+trap 'cleanup $?' EXIT
 
 # Run main function
 main "$@" 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,4 +10,5 @@ path = "integration/federation.rs"
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true
-tokio.workspace = true 
+tokio.workspace = true
+once_cell = "1"


### PR DESCRIPTION
## Summary
- remove `#[ignore]` from integration tests
- auto-start the devnet in test helpers
- add `once_cell` for global state in tests
- allow `launch_federation.sh` to run in start-only mode
- extend CI to run devnet tests nightly

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: environment limitations)*
- `cargo test --all-features --workspace` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68516a4f02c0832489c12bfb9d69ef2e