### PR TITLE
[icn-common] multibase CID utilities

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -504,8 +504,8 @@ mod tests {
     async fn test_submit_and_retrieve_dag_block_api() {
         let storage = new_test_storage();
         let data = b"api test block data for error refinement".to_vec();
-        let cid = Cid::new_v1_dummy(0x71, 0x12, &data); // Use more specific data for test CID
-        let link_cid = Cid::new_v1_dummy(0x71, 0x12, b"api link for error refinement");
+        let cid = Cid::new_v1_sha256(0x71, &data); // Use more specific data for test CID
+        let link_cid = Cid::new_v1_sha256(0x71, b"api link for error refinement");
         let link = DagLink {
             cid: link_cid,
             name: "apilink_error_refine".to_string(),
@@ -536,7 +536,7 @@ mod tests {
 
         // Test retrieving non-existent block
         let non_existent_data = b"non-existent-api-error-refine";
-        let non_existent_cid = Cid::new_v1_dummy(0x71, 0x12, non_existent_data);
+        let non_existent_cid = Cid::new_v1_sha256(0x71, non_existent_data);
         let non_existent_cid_json = serde_json::to_string(&non_existent_cid).unwrap();
         match retrieve_dag_block(Arc::clone(&storage), non_existent_cid_json).await {
             Ok(None) => { /* Expected: block not found, API returns Ok(None) */ }
@@ -671,7 +671,7 @@ mod tests {
     async fn test_send_network_message_api_peer_not_found() {
         // Made async
         let peer_id_str = "unknown_peer_id".to_string(); // StubNetworkService simulates error for this peer
-        let dummy_cid = Cid::new_v1_dummy(0x55, 0x12, b"test_cid_for_req_block");
+        let dummy_cid = Cid::new_v1_sha256(0x55, b"test_cid_for_req_block");
         let message_to_send = NetworkMessage::RequestBlock(dummy_cid); // Corrected to tuple variant
         let message_json = serde_json::to_string(&message_to_send).unwrap();
 

--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+icn-ccl = { path = "../../icn-ccl" }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -41,7 +41,7 @@ async fn submit_transaction_and_query_data() {
 
     // Put a DAG block then query it
     let block = DagBlock {
-        cid: Cid::new_v1_dummy(0x71, 0x12, b"data"),
+        cid: Cid::new_v1_sha256(0x71, b"data"),
         data: b"data".to_vec(),
         links: vec![],
     };

--- a/crates/icn-common/Cargo.toml
+++ b/crates/icn-common/Cargo.toml
@@ -15,6 +15,9 @@ thiserror = "1.0" # For idiomatic error definitions
 sha2 = "0.10"
 ed25519-dalek = { version = "2.0.0-pre.3", features = ["rand_core"] }
 serde_bytes = "0.11"
+multibase = "0.9"
+multicodec = "0.1"
+unsigned-varint = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 rand_core = { version = "0.6", features = ["getrandom"] }

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
     // Helper function to create a test block
     fn create_test_block(id_str: &str) -> DagBlock {
         let data = format!("data for {id_str}").into_bytes();
-        let cid = Cid::new_v1_dummy(0x71, 0x12, id_str.as_bytes());
+        let cid = Cid::new_v1_sha256(0x71, id_str.as_bytes());
         DagBlock {
             cid,
             data,
@@ -336,7 +336,7 @@ mod tests {
         // Test deleting non-existent block (should be Ok)
         assert!(store.delete(&block2.cid).is_ok()); // block2 was never put after block1 deletion test context
                                                     // Or, more robustly, use a fresh CID not in the store
-        let non_existent_cid_for_delete = Cid::new_v1_dummy(0x55, 0x12, b"non_existent_for_delete");
+        let non_existent_cid_for_delete = Cid::new_v1_sha256(0x55, b"non_existent_for_delete");
         assert!(store.delete(&non_existent_cid_for_delete).is_ok());
 
         // Put block2 back for further tests if any or ensure clean state for next use of suite
@@ -478,7 +478,7 @@ mod tests {
             Err(e) => panic!("store.get returned an error: {e:?}"),
         }
 
-        let non_existent_cid = Cid::new_v1_dummy(0x55, 0x12, b"non_existent_global");
+        let non_existent_cid = Cid::new_v1_sha256(0x55, b"non_existent_global");
         match store.get(&non_existent_cid) {
             Ok(None) => { /* Expected */ }
             Ok(Some(_)) => panic!("Found non-existent block in store"),

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -361,9 +361,9 @@ mod tests {
 
     // Helper to create a dummy Cid for tests
     fn dummy_cid_for_test(s: &str) -> Cid {
-        // Using raw codec (0x55) and SHA2-256 (multihash code 0x12) as example parameters for new_v1_dummy.
+        // Using raw codec (0x55) and SHA2-256 (multihash code 0x12) as example parameters for new_v1_sha256.
         // These values might need adjustment based on specific requirements for dummy CIDs in ICN.
-        icn_common::Cid::new_v1_dummy(0x55, 0x12, s.as_bytes())
+        icn_common::Cid::new_v1_sha256(0x55, s.as_bytes())
     }
 
     #[test]

--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -491,7 +491,7 @@ mod tests {
 
     // Helper to create a dummy Cid for tests
     fn dummy_cid(s: &str) -> Cid {
-        Cid::new_v1_dummy(0x55, 0x12, s.as_bytes())
+        Cid::new_v1_sha256(0x55, s.as_bytes())
     }
 
     #[test]

--- a/crates/icn-network/tests/federation_sync.rs
+++ b/crates/icn-network/tests/federation_sync.rs
@@ -6,7 +6,7 @@
     dead_code
 )]
 
-#[cfg(all(feature = "libp2p", feature = "federation"))]
+#[cfg(feature = "libp2p")]
 mod federation_sync {
     use icn_common::Did;
     use icn_governance::request_federation_sync;

--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -36,11 +36,11 @@ mod libp2p_mesh_integration {
     }
 
     fn generate_dummy_job(id_str: &str) -> Job {
-        let job_id_cid = Cid::new_v1_dummy(0x55, 0x13, id_str.as_bytes());
+        let job_id_cid = Cid::new_v1_sha256(0x55, id_str.as_bytes());
         let job_id = JobId::from(job_id_cid);
         let creator_did =
             Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuias7ux1jEZ6KATp8").unwrap();
-        let manifest_cid = Cid::new_v1_dummy(0x71, 0x12, b"dummy_manifest_data");
+        let manifest_cid = Cid::new_v1_sha256(0x71, b"dummy_manifest_data");
         let job_spec = JobSpec::Echo {
             payload: "hello world".to_string(),
         };
@@ -78,7 +78,7 @@ mod libp2p_mesh_integration {
     fn mock_anchor_receipt_to_dag(receipt: &ExecutionReceipt) -> Result<Cid, anyhow::Error> {
         // Create a mock CID for the anchored receipt
         let receipt_data = format!("receipt_for_job_{}", receipt.job_id);
-        Ok(Cid::new_v1_dummy(0x71, 0x12, receipt_data.as_bytes()))
+        Ok(Cid::new_v1_sha256(0x71, receipt_data.as_bytes()))
     }
 
     #[tokio::test]

--- a/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
@@ -118,9 +118,9 @@ pub async fn setup_connected_nodes() -> Result<(TestNode, TestNode)> {
 
 /// Creates a test job with the given configuration
 pub fn create_test_job(config: &TestJobConfig) -> Job {
-    let job_id_cid = Cid::new_v1_dummy(0x55, 0x13, config.id_suffix.as_bytes());
+    let job_id_cid = Cid::new_v1_sha256(0x55, config.id_suffix.as_bytes());
     let job_id = JobId::from(job_id_cid);
-    let manifest_cid = Cid::new_v1_dummy(0x71, 0x12, b"dummy_manifest_data");
+    let manifest_cid = Cid::new_v1_sha256(0x71, b"dummy_manifest_data");
     let job_spec = JobSpec::Echo {
         payload: config.payload.clone(),
     };
@@ -209,5 +209,5 @@ where
 /// Mock function to anchor receipt to DAG
 pub fn mock_anchor_receipt_to_dag(receipt: &ExecutionReceipt) -> Result<Cid> {
     let receipt_data = format!("receipt_for_job_{}", receipt.job_id);
-    Ok(Cid::new_v1_dummy(0x71, 0x12, receipt_data.as_bytes()))
+    Ok(Cid::new_v1_sha256(0x71, receipt_data.as_bytes()))
 }

--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -39,3 +39,4 @@ persist-sqlite = ["icn-dag/persist-sqlite"]
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 tempfile = "3"
+icn-ccl = { path = "../../icn-ccl" }

--- a/crates/icn-node/tests/identity.rs
+++ b/crates/icn-node/tests/identity.rs
@@ -1,6 +1,5 @@
 use icn_node::config::NodeConfig;
 use icn_node::node::load_or_generate_identity;
-use std::path::PathBuf;
 use tempfile::tempdir;
 
 #[tokio::test]

--- a/crates/icn-reputation/src/lib.rs
+++ b/crates/icn-reputation/src/lib.rs
@@ -68,9 +68,9 @@ mod tests {
         let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
 
         let receipt = ExecutionReceipt {
-            job_id: icn_common::Cid::new_v1_dummy(0x55, 0x12, b"r"),
+            job_id: icn_common::Cid::new_v1_sha256(0x55, b"r"),
             executor_did: did.clone(),
-            result_cid: icn_common::Cid::new_v1_dummy(0x55, 0x12, b"r"),
+            result_cid: icn_common::Cid::new_v1_sha256(0x55, b"r"),
             cpu_ms: 0,
             success: true,
             sig: icn_identity::SignatureBytes(vec![]),

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1016,7 +1016,7 @@ impl RuntimeContext {
         })?;
 
         let block = DagBlock {
-            cid: Cid::new_v1_dummy(0x71, 0x12, &final_receipt_bytes),
+            cid: Cid::new_v1_sha256(0x71, &final_receipt_bytes),
             data: final_receipt_bytes,
             links: vec![],
         };
@@ -1441,7 +1441,7 @@ impl HostEnvironment for ConcreteHostEnvironment {
         let cid = rt.block_on(async {
             ctx.spend_mana(&ctx.current_identity, job.cost_mana).await?;
             let job_id_val = NEXT_JOB_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            let cid = Cid::new_v1_dummy(0x55, 0x13, format!("job_cid_{job_id_val}").as_bytes());
+            let cid = Cid::new_v1_sha256(0x55, format!("job_cid_{job_id_val}").as_bytes());
             job.id = cid.clone();
             job.creator_did = ctx.current_identity.clone();
             ctx.internal_queue_mesh_job(job).await?;
@@ -1770,8 +1770,8 @@ mod tests {
         };
 
         let job = ActualMeshJob {
-            id: Cid::new_v1_dummy(0x55, 0x13, b"job"),
-            manifest_cid: Cid::new_v1_dummy(0x55, 0x12, b"manifest"),
+            id: Cid::new_v1_sha256(0x55, b"job"),
+            manifest_cid: Cid::new_v1_sha256(0x55, b"manifest"),
             spec: icn_mesh::JobSpec::default(),
             creator_did: ctx.current_identity.clone(),
             cost_mana: 10,
@@ -1884,8 +1884,8 @@ mod tests {
             .expect("stub network");
 
         let job = ActualMeshJob {
-            id: Cid::new_v1_dummy(0x55, 0x13, b"job_update"),
-            manifest_cid: Cid::new_v1_dummy(0x55, 0x12, b"man"),
+            id: Cid::new_v1_sha256(0x55, b"job_update"),
+            manifest_cid: Cid::new_v1_sha256(0x55, b"man"),
             spec: icn_mesh::JobSpec::default(),
             creator_did: Did::from_str("did:icn:test:creator").unwrap(),
             cost_mana: 5,
@@ -1896,7 +1896,7 @@ mod tests {
         let receipt = IdentityExecutionReceipt {
             job_id: job.id.clone(),
             executor_did: ctx.current_identity.clone(),
-            result_cid: Cid::new_v1_dummy(0x55, 0x13, b"res"),
+            result_cid: Cid::new_v1_sha256(0x55, b"res"),
             cpu_ms: 1,
             success: true,
             sig: icn_identity::SignatureBytes(Vec::new()),

--- a/crates/icn-runtime/src/error.rs
+++ b/crates/icn-runtime/src/error.rs
@@ -101,7 +101,7 @@ impl From<HostAbiError> for MeshJobError {
                 reason: msg,
             },
             HostAbiError::JobSubmissionFailed(reason) => MeshJobError::ProcessingFailure {
-                job_id: Cid::new_v1_dummy(0, 0, b"host_abi_failure"),
+                job_id: Cid::new_v1_sha256(0, b"host_abi_failure"),
                 reason: format!("Job submission failed via host ABI: {}", reason),
             },
             HostAbiError::DagOperationFailed(reason) => MeshJobError::DagOperationFailed {

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -72,7 +72,7 @@ impl JobExecutor for SimpleExecutor {
             }
         };
 
-        let result_cid = Cid::new_v1_dummy(0x55, 0x12, &result_bytes);
+        let result_cid = Cid::new_v1_sha256(0x55, &result_bytes);
         let cpu_ms = start_time.elapsed().unwrap_or_default().as_millis() as u64;
 
         let unsigned_receipt = IdentityExecutionReceipt {
@@ -179,7 +179,7 @@ impl JobExecutor for WasmExecutor {
         let cpu_ms = start_time.elapsed().unwrap_or_default().as_millis() as u64;
 
         let result_bytes = result.to_le_bytes();
-        let result_cid = Cid::new_v1_dummy(0x55, 0x12, &result_bytes);
+        let result_cid = Cid::new_v1_sha256(0x55, &result_bytes);
 
         let unsigned_receipt = IdentityExecutionReceipt {
             job_id: job.id.clone(),
@@ -209,7 +209,7 @@ mod tests {
                            // Removed unused: serde_json::json, std::convert::TryInto, std::sync::Arc
 
     fn dummy_cid_for_executor_test(s: &str) -> Cid {
-        Cid::new_v1_dummy(0x55, 0x12, s.as_bytes())
+        Cid::new_v1_sha256(0x55, s.as_bytes())
     }
 
     #[tokio::test]

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -99,7 +99,7 @@ pub async fn host_submit_mesh_job(
     let job_id_val = context::NEXT_JOB_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     // Create a dummy CID for the JobId for now.
     // In a real scenario, this might be derived from the job content or other unique inputs.
-    let job_id_cid = Cid::new_v1_dummy(0x55, 0x13, format!("job_cid_{}", job_id_val).as_bytes());
+    let job_id_cid = Cid::new_v1_sha256(0x55, format!("job_cid_{}", job_id_val).as_bytes());
 
     job_to_submit.id = job_id_cid.clone();
     job_to_submit.creator_did = ctx.current_identity.clone();
@@ -368,8 +368,8 @@ mod tests {
     // Helper function to create a test ActualMeshJob with all required fields
     fn create_test_mesh_job(cost_mana: u64) -> ActualMeshJob {
         ActualMeshJob {
-            id: Cid::new_v1_dummy(0x55, 0x13, b"test_job_id"),
-            manifest_cid: Cid::new_v1_dummy(0x55, 0x12, b"test_manifest"),
+            id: Cid::new_v1_sha256(0x55, b"test_job_id"),
+            manifest_cid: Cid::new_v1_sha256(0x55, b"test_manifest"),
             spec: JobSpec::default(),
             creator_did: Did::from_str(TEST_IDENTITY_DID_STR).unwrap(),
             cost_mana,

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -55,10 +55,8 @@ mod runtime_host_abi_tests {
         cost_mana: u64,
         payload: &str,
     ) -> String {
-        let job_id =
-            Cid::new_v1_dummy(0x55, 0x13, format!("runtime_job_{}", job_suffix).as_bytes());
-        let manifest_cid =
-            Cid::new_v1_dummy(0x55, 0x14, format!("manifest_{}", job_suffix).as_bytes());
+        let job_id = Cid::new_v1_sha256(0x55, format!("runtime_job_{}", job_suffix).as_bytes());
+        let manifest_cid = Cid::new_v1_sha256(0x55, format!("manifest_{}", job_suffix).as_bytes());
 
         let job = ActualMeshJob {
             id: job_id,
@@ -319,8 +317,8 @@ mod runtime_host_abi_tests {
         let executor_did = runtime_ctx.current_identity.clone();
 
         // Create a dummy job ID
-        let job_id = Cid::new_v1_dummy(0x55, 0x13, b"test_receipt_job");
-        let result_cid = Cid::new_v1_dummy(0x55, 0x14, b"test_result_data");
+        let job_id = Cid::new_v1_sha256(0x55, b"test_receipt_job");
+        let result_cid = Cid::new_v1_sha256(0x55, b"test_result_data");
 
         let receipt = ExecutionReceipt {
             job_id: job_id.clone(),

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -25,8 +25,8 @@ mod cross_node_tests {
 
     /// Helper to create a test job with proper structure
     fn create_test_job(job_id_suffix: &str, creator_did: &Did, cost_mana: u64) -> ActualMeshJob {
-        let job_id = Cid::new_v1_dummy(0x55, 0x13, format!("test_job_{}", job_id_suffix).as_bytes());
-        let manifest_cid = Cid::new_v1_dummy(0x55, 0x14, format!("manifest_{}", job_id_suffix).as_bytes());
+        let job_id = Cid::new_v1_sha256(0x55, format!("test_job_{}", job_id_suffix).as_bytes());
+        let manifest_cid = Cid::new_v1_sha256(0x55, format!("manifest_{}", job_id_suffix).as_bytes());
 
         ActualMeshJob {
             id: job_id,

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -30,7 +30,7 @@ use tokio::time::{sleep, Duration};
 // Helper to create a test ActualMeshJob with all required fields
 fn create_test_mesh_job(manifest_cid: Cid, cost_mana: u64, creator_did: Did) -> ActualMeshJob {
     ActualMeshJob {
-        id: Cid::new_v1_dummy(0x55, 0x13, b"test_job_id"),
+        id: Cid::new_v1_sha256(0x55, b"test_job_id"),
         manifest_cid,
         spec: JobSpec::default(),
         creator_did,
@@ -157,7 +157,7 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let job_manager_dag_store = get_dag_store(&arc_ctx_job_manager);
 
     // 1. SUBMISSION - Test the job submission flow
-    let manifest_cid = Cid::new_v1_dummy(0x55, 0x13, b"manifest_happy");
+    let manifest_cid = Cid::new_v1_sha256(0x55, b"manifest_happy");
     let job_cost = 20u64;
     let test_job = create_test_mesh_job(manifest_cid.clone(), job_cost, submitter_did.clone());
     let job_json_payload = serde_json::to_string(&test_job).unwrap();
@@ -246,7 +246,7 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     );
 
     // 4. Test receipt processing
-    let result_cid = Cid::new_v1_dummy(0x55, 0x13, b"result_happy");
+    let result_cid = Cid::new_v1_sha256(0x55, b"result_happy");
     let ctx_executor_for_signing = create_test_context(executor_did_str, 0);
 
     // Create the receipt and sign it using the public API
@@ -305,7 +305,7 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let receipt_bytes =
         serde_json::to_vec(&retrieved_receipt).expect("Failed to serialize receipt");
     let block = DagBlock {
-        cid: Cid::new_v1_dummy(0x71, 0x12, &receipt_bytes),
+        cid: Cid::new_v1_sha256(0x71, &receipt_bytes),
         data: receipt_bytes,
         links: vec![],
     };
@@ -332,7 +332,7 @@ async fn test_mesh_job_timeout_and_refund() {
     let arc_ctx_job_manager = create_test_context("did:icn:test:job_manager_node_timeout", 0);
 
     // 1. Submit job
-    let manifest_cid = Cid::new_v1_dummy(0x55, 0x13, b"manifest_timeout");
+    let manifest_cid = Cid::new_v1_sha256(0x55, b"manifest_timeout");
     let test_job = create_test_mesh_job(manifest_cid.clone(), job_cost, submitter_did.clone());
     let job_json_payload = serde_json::to_string(&test_job).unwrap();
 
@@ -417,7 +417,7 @@ async fn test_invalid_receipt_wrong_executor() {
     let arc_ctx_job_manager = create_test_context("did:icn:test:job_manager_invalid_receipt", 0);
 
     // 1. Submit job
-    let manifest_cid = Cid::new_v1_dummy(0x55, 0x13, b"test_job_manifest_for_invalid_receipt");
+    let manifest_cid = Cid::new_v1_sha256(0x55, b"test_job_manifest_for_invalid_receipt");
     let test_job = create_test_mesh_job(manifest_cid.clone(), job_cost, submitter_did.clone());
     let job_json_payload = serde_json::to_string(&test_job).unwrap();
 
@@ -437,7 +437,7 @@ async fn test_invalid_receipt_wrong_executor() {
     let forged_receipt = IdentityExecutionReceipt {
         job_id: submitted_job_id.clone(),
         executor_did: wrong_executor_did.clone(), // Wrong executor DID
-        result_cid: Cid::new_v1_dummy(0x55, 0x13, b"result_invalid_executor"),
+        result_cid: Cid::new_v1_sha256(0x55, b"result_invalid_executor"),
         cpu_ms: 50,
         success: true,
         sig: SignatureBytes(signature_bytes),
@@ -477,7 +477,7 @@ async fn test_invalid_receipt_wrong_executor() {
     let correct_receipt = IdentityExecutionReceipt {
         job_id: submitted_job_id.clone(),
         executor_did: correct_executor_ctx.current_identity.clone(),
-        result_cid: Cid::new_v1_dummy(0x55, 0x13, b"result_invalid_executor"),
+        result_cid: Cid::new_v1_sha256(0x55, b"result_invalid_executor"),
         cpu_ms: 50,
         success: true,
         sig: SignatureBytes(correct_signature_bytes),
@@ -578,7 +578,7 @@ fn new_mesh_test_context_with_two_executors() -> (
 /// Convenience helper to create a simple test job JSON payload with a given
 /// cost and submitter.
 fn create_test_job_payload_and_cost(submitter: &Did, job_cost: u64) -> (String, u64) {
-    let manifest_cid = Cid::new_v1_dummy(0x55, 0x13, b"test_job_manifest");
+    let manifest_cid = Cid::new_v1_sha256(0x55, b"test_job_manifest");
     let test_job = create_test_mesh_job(manifest_cid, job_cost, submitter.clone());
     let job_json_payload = serde_json::to_string(&test_job).unwrap();
     (job_json_payload, job_cost)
@@ -711,7 +711,7 @@ async fn test_submit_mesh_job_with_custom_timeout() {
     let ctx = create_test_context("did:icn:test:timeout_custom", 50);
     let submitter_did = ctx.current_identity.clone();
 
-    let manifest_cid = Cid::new_v1_dummy(0x55, 0x13, b"manifest_timeout_field");
+    let manifest_cid = Cid::new_v1_sha256(0x55, b"manifest_timeout_field");
     let mut job = create_test_mesh_job(manifest_cid, 10, submitter_did.clone());
     job.max_execution_wait_ms = Some(1234);
     let job_json = serde_json::to_string(&job).unwrap();
@@ -735,7 +735,7 @@ async fn forge_execution_receipt(
     let receipt = IdentityExecutionReceipt {
         job_id: job_id.clone(),                                      // JobId is a Cid
         executor_did: forging_executor_ctx.current_identity.clone(), // Forger's DID
-        result_cid: Cid::new_v1_dummy(0x55, 0x13, result_cid_val),
+        result_cid: Cid::new_v1_sha256(0x55, result_cid_val),
         cpu_ms: 50,
         success: true,
         sig: SignatureBytes(Vec::new()), // Will be filled by the forger's context

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -24,8 +24,8 @@ async fn anchor_receipt_updates_reputation() {
         Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         std::path::PathBuf::from("./mana_ledger.sled"),
     );
-    let job_id = Cid::new_v1_dummy(0x55, 0x13, b"rep_job");
-    let result_cid = Cid::new_v1_dummy(0x55, 0x14, b"res");
+    let job_id = Cid::new_v1_sha256(0x55, b"rep_job");
+    let result_cid = Cid::new_v1_sha256(0x55, b"res");
 
     let receipt = ExecutionReceipt {
         job_id: job_id.clone(),
@@ -61,9 +61,9 @@ fn reputation_updater_increments_store() {
     let updater = ReputationUpdater::new();
     let did = icn_common::Did::new("key", "tester");
     let receipt = ExecutionReceipt {
-        job_id: Cid::new_v1_dummy(0x55, 0x15, b"rep"),
+        job_id: Cid::new_v1_sha256(0x55, b"rep"),
         executor_did: did.clone(),
-        result_cid: Cid::new_v1_dummy(0x55, 0x15, b"res"),
+        result_cid: Cid::new_v1_sha256(0x55, b"res"),
         cpu_ms: 1000,
         success: true,
         sig: SignatureBytes(Vec::new()),

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -24,7 +24,7 @@ async fn wasm_executor_runs_wasm() {
     )"#;
     let wasm_bytes = wat::parse_str(wasm).unwrap();
     let block = DagBlock {
-        cid: Cid::new_v1_dummy(0x71, 0x11, &wasm_bytes),
+        cid: Cid::new_v1_sha256(0x71, &wasm_bytes),
         data: wasm_bytes,
         links: vec![],
     };
@@ -35,7 +35,7 @@ async fn wasm_executor_runs_wasm() {
     let cid = block.cid.clone();
 
     let job = ActualMeshJob {
-        id: Cid::new_v1_dummy(0x55, 0x11, b"job"),
+        id: Cid::new_v1_sha256(0x55, b"job"),
         manifest_cid: cid,
         spec: JobSpec::GenericPlaceholder,
         creator_did: node_did.clone(),

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -142,7 +142,7 @@ async fn test_wasm_executor_with_ccl() {
 
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 10);
     let block = DagBlock {
-        cid: Cid::new_v1_dummy(0x71, 0x12, &wasm),
+        cid: Cid::new_v1_sha256(0x71, &wasm),
         data: wasm.clone(),
         links: vec![],
     };
@@ -157,7 +157,7 @@ async fn test_wasm_executor_with_ccl() {
     let node_did = icn_common::Did::from_str(&node_did).unwrap();
 
     let job = ActualMeshJob {
-        id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
+        id: Cid::new_v1_sha256(0x55, b"job"),
         manifest_cid: cid,
         spec: JobSpec::GenericPlaceholder,
         creator_did: node_did.clone(),

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -52,7 +52,7 @@ async fn wasm_executor_runs_compiled_ccl() {
     let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
 
     let job = ActualMeshJob {
-        id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
+        id: Cid::new_v1_sha256(0x55, b"job"),
         manifest_cid: cid,
         spec: JobSpec::GenericPlaceholder,
         creator_did: node_did.clone(),
@@ -69,7 +69,7 @@ async fn wasm_executor_runs_compiled_ccl() {
     });
     let receipt = handle.join().unwrap().unwrap();
     assert_eq!(receipt.executor_did, node_did);
-    let expected_cid = Cid::new_v1_dummy(0x55, 0x12, &6i64.to_le_bytes());
+    let expected_cid = Cid::new_v1_sha256(0x55, &6i64.to_le_bytes());
     assert_eq!(receipt.result_cid, expected_cid);
 }
 
@@ -95,7 +95,7 @@ async fn wasm_executor_runs_compiled_addition() {
     let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
 
     let job = ActualMeshJob {
-        id: Cid::new_v1_dummy(0x55, 0x12, b"jobadd"),
+        id: Cid::new_v1_sha256(0x55, b"jobadd"),
         manifest_cid: cid,
         spec: JobSpec::GenericPlaceholder,
         creator_did: node_did.clone(),
@@ -112,7 +112,7 @@ async fn wasm_executor_runs_compiled_addition() {
     });
     let receipt = handle.join().unwrap().unwrap();
     assert_eq!(receipt.executor_did, node_did);
-    let expected_cid = Cid::new_v1_dummy(0x55, 0x12, &42i64.to_le_bytes());
+    let expected_cid = Cid::new_v1_sha256(0x55, &42i64.to_le_bytes());
     assert_eq!(receipt.result_cid, expected_cid);
 }
 
@@ -138,7 +138,7 @@ async fn wasm_executor_fails_without_run() {
     let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
 
     let job = ActualMeshJob {
-        id: Cid::new_v1_dummy(0x55, 0x12, b"job2"),
+        id: Cid::new_v1_sha256(0x55, b"job2"),
         manifest_cid: cid,
         spec: JobSpec::GenericPlaceholder,
         creator_did: node_did.clone(),

--- a/tests/integration/multi_node_libp2p.rs
+++ b/tests/integration/multi_node_libp2p.rs
@@ -14,8 +14,8 @@ mod multi_node_libp2p {
     use log::info;
 
     fn create_test_job(job_id_suffix: &str, creator_did: &Did, cost_mana: u64) -> ActualMeshJob {
-        let job_id = Cid::new_v1_dummy(0x55, 0x13, format!("test_job_{}", job_id_suffix).as_bytes());
-        let manifest_cid = Cid::new_v1_dummy(0x55, 0x14, format!("manifest_{}", job_id_suffix).as_bytes());
+        let job_id = Cid::new_v1_sha256(0x55, format!("test_job_{}", job_id_suffix).as_bytes());
+        let manifest_cid = Cid::new_v1_sha256(0x55, format!("manifest_{}", job_id_suffix).as_bytes());
         ActualMeshJob {
             id: job_id,
             manifest_cid,


### PR DESCRIPTION
## Summary
- implement `Cid::from_bytes` and `Cid::to_string`
- update CID parsing to use multibase and multicodec
- replace old dummy CID helpers across crates
- add icn-ccl as dependency where needed
- fix build issues in node and network tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: submit_transaction_and_query_data)*

------
https://chatgpt.com/codex/tasks/task_e_68516a4c9e0483249bee137ad6baf2e3