### PR TITLE
[mesh] add timeout field to JobSpec

### DIFF
--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -156,6 +156,9 @@ pub struct JobSpec {
     /// Minimum resources required for the job.
     #[serde(default)]
     pub required_resources: Resources,
+    /// Optional upper bound on job execution time in milliseconds.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
 }
 
 impl Default for JobSpec {
@@ -165,6 +168,7 @@ impl Default for JobSpec {
             inputs: Vec::new(),
             outputs: Vec::new(),
             required_resources: Resources::default(),
+            timeout_ms: None,
         }
     }
 }

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1230,7 +1230,9 @@ mod tests {
         let job_req = SubmitJobRequest {
             manifest_cid: Cid::new_v1_dummy(0x55, 0x14, b"test_manifest").to_string(),
             spec_json: serde_json::to_value(&icn_mesh::JobSpec {
-                kind: icn_mesh::JobKind::Echo { payload: "hello".into() },
+                kind: icn_mesh::JobKind::Echo {
+                    payload: "hello".into(),
+                },
                 ..Default::default()
             })
             .unwrap(),
@@ -1267,7 +1269,9 @@ mod tests {
         let job_req = SubmitJobRequest {
             manifest_cid: Cid::new_v1_dummy(0x55, 0x14, b"pipeline_test_manifest").to_string(),
             spec_json: serde_json::to_value(&icn_mesh::JobSpec {
-                kind: icn_mesh::JobKind::Echo { payload: "HTTP pipeline test".into() },
+                kind: icn_mesh::JobKind::Echo {
+                    payload: "HTTP pipeline test".into(),
+                },
                 ..Default::default()
             })
             .unwrap(),
@@ -1403,7 +1407,9 @@ mod tests {
         let job_req = SubmitJobRequest {
             manifest_cid: Cid::new_v1_dummy(0x55, 0x14, b"simple_test").to_string(),
             spec_json: serde_json::to_value(&icn_mesh::JobSpec {
-                kind: icn_mesh::JobKind::Echo { payload: "simple test".into() },
+                kind: icn_mesh::JobKind::Echo {
+                    payload: "simple test".into(),
+                },
                 ..Default::default()
             })
             .unwrap(),

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -645,9 +645,13 @@ impl RuntimeContext {
             "[JobManagerDetail] Waiting for receipt for job {:?} from executor {:?}",
             job.id, assigned_executor_did
         );
-        // Determine how long to wait for the execution receipt.
+        // Determine how long to wait for the execution receipt. Precedence:
+        // 1. Explicit job-level override.
+        // 2. Timeout specified in the job spec.
+        // 3. Runtime default.
         let timeout_ms = job
             .max_execution_wait_ms
+            .or(job.spec.timeout_ms)
             .unwrap_or(self.default_receipt_wait_ms);
         let receipt_timeout = StdDuration::from_millis(timeout_ms);
 

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -1,12 +1,13 @@
 //! This module provides executor-side functionality for running mesh jobs.
 
+use crate::context::RuntimeContext;
 use icn_common::{Cid, CommonError, Did};
 use icn_identity::{
     ExecutionReceipt as IdentityExecutionReceipt,
     SignatureBytes, /* Removed , generate_ed25519_keypair */
     SigningKey,
 };
-use icn_mesh::{ActualMeshJob, JobSpec /* ... other mesh types ... */};
+use icn_mesh::{ActualMeshJob, JobKind, JobSpec /* ... other mesh types ... */};
 use log::info; // Removed error
 use std::time::SystemTime;
 

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -713,7 +713,7 @@ async fn test_submit_mesh_job_with_custom_timeout() {
 
     let manifest_cid = Cid::new_v1_dummy(0x55, 0x13, b"manifest_timeout_field");
     let mut job = create_test_mesh_job(manifest_cid, 10, submitter_did.clone());
-    job.max_execution_wait_ms = Some(1234);
+    job.spec.timeout_ms = Some(1234);
     let job_json = serde_json::to_string(&job).unwrap();
 
     let _job_id = host_submit_mesh_job(&ctx, &job_json)
@@ -722,7 +722,7 @@ async fn test_submit_mesh_job_with_custom_timeout() {
 
     let pending_jobs = host_get_pending_mesh_jobs(&ctx).unwrap();
     assert_eq!(pending_jobs.len(), 1);
-    assert_eq!(pending_jobs[0].max_execution_wait_ms, Some(1234));
+    assert_eq!(pending_jobs[0].spec.timeout_ms, Some(1234));
 }
 
 // Helper to create a plausible (but potentially invalidly signed) ExecutionReceipt for testing.

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -159,7 +159,7 @@ async fn test_wasm_executor_with_ccl() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -54,7 +54,7 @@ async fn wasm_executor_runs_compiled_ccl() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,
@@ -97,7 +97,7 @@ async fn wasm_executor_runs_compiled_addition() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"jobadd"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,
@@ -140,7 +140,7 @@ async fn wasm_executor_fails_without_run() {
     let job = ActualMeshJob {
         id: Cid::new_v1_dummy(0x55, 0x12, b"job2"),
         manifest_cid: cid,
-        spec: JobSpec::GenericPlaceholder,
+        spec: JobSpec::default(),
         creator_did: node_did.clone(),
         cost_mana: 0,
         max_execution_wait_ms: None,


### PR DESCRIPTION
## Summary
- extend `JobSpec` with `timeout_ms`
- use the `timeout_ms` hint when waiting for mesh execution receipts
- fix imports in runtime executor
- adjust mesh timeout test and update CCL integration tests
- minor formatting updates in `icn-node`

## Testing
- `cargo clippy -p icn-mesh --all-targets --all-features -- -D warnings`
- `cargo test -p icn-mesh --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68516d6cab10832484b98a027ebd5024