### PR TITLE
[docs] expand setup guides

### DIFF
--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -67,6 +67,17 @@ Useful CLI flags include:
 
 * `--node-did-path <PATH>` – location to read/write the node DID string
 * `--node-private-key-path <PATH>` – location to read/write the node private key
+* `--storage-backend <memory|file|sqlite>` – choose the DAG storage backend
+* `--storage-path <PATH>` – directory for the file or SQLite backends
+* `--mana-ledger-path <PATH>` – location of the mana ledger database
+* `--governance-db-path <PATH>` – location to persist governance proposals and votes
+* `--http-listen-addr <ADDR>` – HTTP server bind address (default `127.0.0.1:7845`)
+* `--node-name <NAME>` – human-readable node name for logs
+* `--listen-address <MULTIADDR>` – libp2p listen multiaddr (alias `--p2p-listen-addr`)
+* `--bootstrap-peers <LIST>` – comma-separated list of bootstrap peer multiaddrs
+* `--enable-p2p` – enable libp2p networking (requires `with-libp2p` feature)
+* `--api-key <KEY>` – require this key via the `x-api-key` header for all requests
+* `--open-rate-limit <N>` – allowed unauthenticated requests per minute when no API key is set
 
 When the node starts, it will attempt to load its DID and private key from the
 configured paths. If no key material exists, a new Ed25519 key pair is generated

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -25,6 +25,17 @@ Welcome to the InterCooperative Network (ICN) Core project! This guide will help
     cargo test --all # Run tests for all crates in the workspace
     ```
     This will download all dependencies and compile the project. If all tests pass, your setup is correct.
+3.  **Install Toolchain Components:**
+    ```bash
+    rustup component add clippy rustfmt
+    ```
+    These components are required for linting and formatting checks that run in CI.
+4.  **Install `just` (optional but recommended):**
+    ```bash
+    cargo install just
+    just --list    # Show available development commands
+    ```
+    The `just` command runner provides shortcuts for formatting, linting, testing, and devnet tasks defined in the repository's `justfile`.
 
 ## 3. Building and Running Components
 


### PR DESCRIPTION
## Summary
- expand onboarding setup section with toolchain component instructions
- document node configuration flags

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: command timed out)*
- `cargo test --all-features --workspace` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6851a548e0e08324af2d34f5525d6087