### PR TITLE
[runtime] route host functions through context

### DIFF
--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -1,12 +1,13 @@
 //! This module provides executor-side functionality for running mesh jobs.
 
+use crate::RuntimeContext;
 use icn_common::{Cid, CommonError, Did};
 use icn_identity::{
     ExecutionReceipt as IdentityExecutionReceipt,
     SignatureBytes, /* Removed , generate_ed25519_keypair */
     SigningKey,
 };
-use icn_mesh::{ActualMeshJob, JobSpec /* ... other mesh types ... */};
+use icn_mesh::{ActualMeshJob, JobKind, JobSpec /* ... other mesh types ... */};
 use log::info; // Removed error
 use std::time::SystemTime;
 

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -105,8 +105,8 @@ pub async fn host_submit_mesh_job(
     job_to_submit.id = job_id_cid.clone();
     job_to_submit.creator_did = ctx.current_identity.clone();
 
-    // Call the internal queuing function on RuntimeContext
-    ctx.internal_queue_mesh_job(job_to_submit.clone()).await?; // Await the async call
+    // Queue the job via the RuntimeContext
+    ctx.queue_mesh_job(job_to_submit.clone()).await?;
 
     println!(
         "[RUNTIME_ABI] Job {:?} submitted by {:?} with cost {} was queued successfully.",


### PR DESCRIPTION
## Summary
- route host functions in `abi.rs` through `RuntimeContext`
- add public queue, assignment, and receipt verification helpers
- update executor imports and fix build
- expand mesh integration tests with a complete job flow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: unable to finish in environment)*
- `cargo test --all-features --workspace --no-run` *(failed: unable to finish in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851a5455fe883248d9be0fb41cac28d