### PR TITLE
[tests] add libp2p job pipeline integration test

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,6 +7,10 @@ edition.workspace = true
 name = "federation"
 path = "integration/federation.rs"
 
+[[test]]
+name = "libp2p_job_pipeline"
+path = "integration/libp2p_job_pipeline.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true

--- a/tests/integration/federation.rs
+++ b/tests/integration/federation.rs
@@ -6,15 +6,15 @@ use serde_json::Value;
 // Integration test for ICN federation devnet
 // This test assumes the federation is running via docker-compose
 
-const NODE_A_URL: &str = "http://localhost:5001";
-const NODE_B_URL: &str = "http://localhost:5002"; 
-const NODE_C_URL: &str = "http://localhost:5003";
+pub const NODE_A_URL: &str = "http://localhost:5001";
+pub const NODE_B_URL: &str = "http://localhost:5002";
+pub const NODE_C_URL: &str = "http://localhost:5003";
 const MAX_RETRIES: u32 = 20;
 const RETRY_DELAY: Duration = Duration::from_secs(3);
 
 static DEVNET_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
 
-struct DevnetGuard {
+pub struct DevnetGuard {
     _guard: tokio::sync::OwnedMutexGuard<()>,
 }
 
@@ -26,7 +26,7 @@ impl Drop for DevnetGuard {
     }
 }
 
-async fn ensure_devnet() -> Option<DevnetGuard> {
+pub async fn ensure_devnet() -> Option<DevnetGuard> {
     if std::env::var("ICN_DEVNET_RUNNING").is_ok() {
         wait_for_federation_ready().await.ok();
         return None;

--- a/tests/integration/libp2p_job_pipeline.rs
+++ b/tests/integration/libp2p_job_pipeline.rs
@@ -1,0 +1,119 @@
+#[path = "federation.rs"]
+mod federation;
+
+#[cfg(feature = "enable-libp2p")]
+mod libp2p_job_pipeline {
+    use super::federation::{ensure_devnet, NODE_A_URL, NODE_B_URL, NODE_C_URL};
+    use reqwest::Client;
+    use serde_json::Value;
+    use tokio::time::{sleep, Duration};
+
+    const RETRY_DELAY: Duration = Duration::from_secs(3);
+    const MAX_RETRIES: u32 = 20;
+
+    async fn extract_did(client: &Client, url: &str) -> String {
+        let info: Value = client
+            .get(&format!("{}/info", url))
+            .send()
+            .await
+            .expect("info request")
+            .json()
+            .await
+            .expect("info json");
+        let status = info["status_message"].as_str().unwrap_or("");
+        status
+            .trim_start_matches("Node DID: ")
+            .split(',')
+            .next()
+            .unwrap_or("")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn job_exec_across_nodes() {
+        let _devnet = ensure_devnet().await;
+        let client = Client::new();
+
+        let node_a_did = extract_did(&client, NODE_A_URL).await;
+        let node_b_did = extract_did(&client, NODE_B_URL).await;
+        let node_c_did = extract_did(&client, NODE_C_URL).await;
+
+        let job_request = serde_json::json!({
+            "manifest_cid": "cidv1-libp2p-test-manifest",
+            "spec_json": { "Echo": { "payload": "libp2p pipeline test" } },
+            "cost_mana": 50
+        });
+
+        let submit_res: Value = client
+            .post(&format!("{}/mesh/submit", NODE_A_URL))
+            .header("Content-Type", "application/json")
+            .json(&job_request)
+            .send()
+            .await
+            .expect("submit job")
+            .json()
+            .await
+            .expect("submit json");
+
+        let job_id = submit_res["job_id"].as_str().expect("job_id").to_string();
+
+        let mut final_status: Value = Value::Null;
+        for _ in 0..MAX_RETRIES {
+            let resp = client
+                .get(&format!("{}/mesh/jobs/{}", NODE_A_URL, job_id))
+                .send()
+                .await
+                .expect("status");
+            if resp.status().is_success() {
+                final_status = resp.json().await.expect("status json");
+                if final_status["status"]["status"] == "completed" {
+                    break;
+                }
+            }
+            sleep(RETRY_DELAY).await;
+        }
+
+        assert_eq!(final_status["status"]["status"], "completed");
+        let executor = final_status["status"]["executor"]
+            .as_str()
+            .expect("executor");
+        assert_ne!(executor, node_a_did);
+
+        let executor_url = if executor == node_b_did {
+            NODE_B_URL
+        } else if executor == node_c_did {
+            NODE_C_URL
+        } else {
+            panic!("executor DID not recognized: {}", executor);
+        };
+
+        let exec_status: Value = client
+            .get(&format!("{}/mesh/jobs/{}", executor_url, job_id))
+            .send()
+            .await
+            .expect("executor status")
+            .json()
+            .await
+            .expect("executor status json");
+        assert_eq!(exec_status["status"]["status"], "completed");
+
+        let result_cid = exec_status["status"]["result_cid"]
+            .as_str()
+            .expect("result_cid");
+
+        let dag_res = client
+            .post(&format!("{}/dag/get", NODE_A_URL))
+            .json(&serde_json::json!({ "cid": result_cid }))
+            .send()
+            .await
+            .expect("dag get");
+        assert!(dag_res.status().is_success());
+    }
+}
+
+#[cfg(not(feature = "enable-libp2p"))]
+#[tokio::test]
+async fn libp2p_feature_disabled_stub() {
+    println!("libp2p feature disabled; skipping libp2p job pipeline test");
+}
+


### PR DESCRIPTION
## 📌 What does this PR do?

Add an integration test that exercises mesh job execution across the federation via libp2p networking.

---

### ✅ Checklist
- [ ] I rebased onto **develop** and squashed fixups
- [ ] All tests (`cargo test --all-features`) pass locally
- [ ] `cargo fmt --all` and `cargo clippy --all-targets -- -D warnings` are clean
- [ ] Docs added/updated (`///`, `README`, or `docs/`)
- [ ] Linked issues: Closes #____ / Relates #____
- [ ] I've added an entry to `CHANGELOG.md` (Unreleased section)

### 📝 Notes for the reviewer
Adds new test `tests/integration/libp2p_job_pipeline.rs` that boots the devnet using `ensure_devnet()` and verifies that a submitted job on Node A completes on a different node with receipt anchored.

------
https://chatgpt.com/codex/tasks/task_e_6851fef78f0c832493ff3a9e447f82e3