### PR TITLE
[runtime] enable sled reputation store

### DIFF
--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -16,14 +16,7 @@ mod libp2p_mesh_integration {
     use anyhow::Result;
     use icn_common::{Cid, Did};
     use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes};
-    use icn_mesh::{
-        ActualMeshJob as Job,
-        JobId,
-        JobKind,
-        JobSpec,
-        MeshJobBid as Bid,
-        Resources,
-    };
+    use icn_mesh::{ActualMeshJob as Job, JobId, JobKind, JobSpec, MeshJobBid as Bid, Resources};
     use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
     use icn_network::{NetworkMessage, NetworkService};
     use icn_runtime::executor::{JobExecutor, SimpleExecutor};

--- a/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
@@ -9,14 +9,7 @@
 use anyhow::Result;
 use icn_common::{Cid, Did};
 use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes, SigningKey};
-use icn_mesh::{
-    ActualMeshJob as Job,
-    JobId,
-    JobKind,
-    JobSpec,
-    MeshJobBid as Bid,
-    Resources,
-};
+use icn_mesh::{ActualMeshJob as Job, JobId, JobKind, JobSpec, MeshJobBid as Bid, Resources};
 use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
 use icn_network::{NetworkMessage, NetworkService};
 use icn_runtime::executor::{JobExecutor, SimpleExecutor};

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -43,7 +43,7 @@ serial_test = { version = "3", features = ["async"] }
 [features]
 default = []
 enable-libp2p = ["dep:libp2p"]
-persist-sled = ["icn-governance/persist-sled"]
+persist-sled = ["icn-governance/persist-sled", "icn-reputation/persist-sled"]
 
 # Integration tests for cross-node functionality
 [[test]]

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -7,9 +7,9 @@ use icn_identity::{
     SignatureBytes, /* Removed , generate_ed25519_keypair */
     SigningKey,
 };
-use icn_mesh::{ActualMeshJob, JobKind};
 #[cfg(test)]
 use icn_mesh::JobSpec; /* ... other mesh types ... */
+use icn_mesh::{ActualMeshJob, JobKind};
 use log::info; // Removed error
 use std::time::SystemTime;
 


### PR DESCRIPTION
## Summary
- use `icn-reputation` sled backend when `persist-sled` is enabled
- format imports in network tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-reputation --all-targets --all-features -- -D warnings`
- `cargo check --all-features`

------
https://chatgpt.com/codex/tasks/task_e_685224bde8e883249b94ab4741269b13