### PR TITLE
[runtime] add Wasmtime memory wrappers

### DIFF
--- a/crates/icn-network/tests/federation_sync.rs
+++ b/crates/icn-network/tests/federation_sync.rs
@@ -3,7 +3,8 @@
     clippy::clone_on_copy,
     clippy::uninlined_format_args,
     clippy::field_reassign_with_default,
-    dead_code
+    dead_code,
+    unexpected_cfgs
 )]
 
 #[cfg(all(feature = "libp2p", feature = "federation"))]

--- a/crates/icn-network/tests/libp2p.rs
+++ b/crates/icn-network/tests/libp2p.rs
@@ -19,7 +19,7 @@ mod libp2p_tests {
         let peer_a = node_a.local_peer_id();
 
         let config_b = NetworkConfig {
-            bootstrap_peers: vec![(peer_a, addr)],
+            bootstrap_peers: vec![(*peer_a, addr)],
             ..NetworkConfig::default()
         };
         let node_b = Libp2pNetworkService::new(config_b)

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -34,7 +34,7 @@ use icn_identity::{
     did_key_from_verifying_key, generate_ed25519_keypair,
     ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes,
 };
-use icn_mesh::ActualMeshJob;
+use icn_mesh::{ActualMeshJob, JobSpec};
 use icn_network::NetworkService;
 use icn_runtime::context::{
     RuntimeContext, StubDagStore as RuntimeStubDagStore, StubMeshNetworkService,
@@ -1520,7 +1520,7 @@ mod tests {
         use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
         use icn_runtime::executor::WasmExecutor;
 
-        let (app, ctx) = app_router_with_options(None, None, None).await;
+        let (app, ctx) = app_router_with_options(None, None, None, None).await;
 
         // Compile a tiny CCL contract
         let (wasm, _) =

--- a/crates/icn-node/tests/identity.rs
+++ b/crates/icn-node/tests/identity.rs
@@ -1,6 +1,5 @@
 use icn_node::config::NodeConfig;
 use icn_node::node::load_or_generate_identity;
-use std::path::PathBuf;
 use tempfile::tempdir;
 
 #[tokio::test]

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -15,7 +15,7 @@ mod runtime_host_abi_tests {
     use anyhow::Result;
     use icn_common::{Cid, Did};
     use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt};
-    use icn_mesh::{ActualMeshJob, JobSpec};
+    use icn_mesh::{ActualMeshJob, JobKind, JobSpec};
     use icn_network::{NetworkMessage, NetworkService};
     use icn_runtime::context::RuntimeContext;
     use icn_runtime::{host_anchor_receipt, host_submit_mesh_job, ReputationUpdater};

--- a/crates/icn-runtime/tests/wasm_host_api.rs
+++ b/crates/icn-runtime/tests/wasm_host_api.rs
@@ -1,0 +1,159 @@
+use icn_common::Cid;
+use icn_identity::{
+    did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt, SignatureBytes,
+};
+use icn_mesh::{ActualMeshJob, JobSpec};
+use icn_runtime::context::RuntimeContext;
+use icn_runtime::{
+    wasm_host_account_get_mana, wasm_host_account_spend_mana, wasm_host_anchor_receipt,
+    wasm_host_get_pending_mesh_jobs, wasm_host_submit_mesh_job,
+};
+use std::str::FromStr;
+use wasmtime::{Engine, Linker, Module, Store};
+
+#[tokio::test]
+async fn wasm_host_api_functions() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostTest", 50);
+    let engine = Engine::default();
+    let module_wat = r#"(module
+        (import "icn" "wasm_host_submit_mesh_job" (func $submit (param i32 i32)))
+        (import "icn" "wasm_host_get_pending_mesh_jobs" (func $get_jobs (param i32 i32) (result i32)))
+        (import "icn" "wasm_host_account_get_mana" (func $get_mana (param i32 i32) (result i64)))
+        (import "icn" "wasm_host_account_spend_mana" (func $spend (param i32 i32 i64)))
+        (import "icn" "wasm_host_anchor_receipt" (func $anchor (param i32 i32)))
+        (memory (export "memory") 1)
+        (func (export "submit") (param i32 i32) (local.get 0) (local.get 1) call $submit)
+        (func (export "get_jobs") (param i32 i32) (result i32) (local.get 0) (local.get 1) call $get_jobs)
+        (func (export "get_mana") (param i32 i32) (result i64) (local.get 0) (local.get 1) call $get_mana)
+        (func (export "spend") (param i32 i32 i64) (local.get 0) (local.get 1) (local.get 2) call $spend)
+        (func (export "anchor") (param i32 i32) (local.get 0) (local.get 1) call $anchor)
+    )"#;
+    let module_bytes = wat::parse_str(module_wat).unwrap();
+    let module = Module::new(&engine, module_bytes).unwrap();
+
+    let mut linker = Linker::new(&engine);
+
+    linker
+        .func_wrap(
+            "icn",
+            "wasm_host_submit_mesh_job",
+            wasm_host_submit_mesh_job,
+        )
+        .unwrap();
+    linker
+        .func_wrap(
+            "icn",
+            "wasm_host_get_pending_mesh_jobs",
+            wasm_host_get_pending_mesh_jobs,
+        )
+        .unwrap();
+    linker
+        .func_wrap(
+            "icn",
+            "wasm_host_account_get_mana",
+            wasm_host_account_get_mana,
+        )
+        .unwrap();
+    linker
+        .func_wrap(
+            "icn",
+            "wasm_host_account_spend_mana",
+            wasm_host_account_spend_mana,
+        )
+        .unwrap();
+    linker
+        .func_wrap("icn", "wasm_host_anchor_receipt", wasm_host_anchor_receipt)
+        .unwrap();
+
+    let mut store = Store::new(&engine, ctx.clone());
+    let instance = linker.instantiate(&mut store, &module).unwrap();
+    let memory = instance.get_memory(&mut store, "memory").unwrap();
+
+    // Prepare job JSON in memory
+    let job = ActualMeshJob {
+        id: Cid::new_v1_sha256(0x55, b"job"),
+        manifest_cid: Cid::new_v1_sha256(0x71, b"wasm"),
+        spec: JobSpec::default(),
+        creator_did: ctx.current_identity.clone(),
+        cost_mana: 10,
+        max_execution_wait_ms: None,
+        signature: SignatureBytes(vec![]),
+    };
+    let job_json = serde_json::to_string(&job).unwrap();
+    memory.write(&mut store, 0, job_json.as_bytes()).unwrap();
+
+    // Submit job via wasm
+    let submit = instance
+        .get_typed_func::<(i32, i32), ()>(&mut store, "submit")
+        .unwrap();
+    submit.call(&mut store, (0, job_json.len() as i32)).unwrap();
+
+    // DID string for mana calls
+    let did_str = ctx.current_identity.to_string();
+    memory.write(&mut store, 1000, did_str.as_bytes()).unwrap();
+    let get_mana = instance
+        .get_typed_func::<(i32, i32), i64>(&mut store, "get_mana")
+        .unwrap();
+    let mana_before = get_mana
+        .call(&mut store, (1000, did_str.len() as i32))
+        .unwrap();
+    assert_eq!(mana_before, 40); // mana deducted by submit
+
+    let spend = instance
+        .get_typed_func::<(i32, i32, i64), ()>(&mut store, "spend")
+        .unwrap();
+    spend
+        .call(&mut store, (1000, did_str.len() as i32, 5))
+        .unwrap();
+    let mana_after = get_mana
+        .call(&mut store, (1000, did_str.len() as i32))
+        .unwrap();
+    assert_eq!(mana_after, 35);
+
+    // Build and anchor receipt
+    let pending = ctx.pending_mesh_jobs.lock().await;
+    let job_id = pending[0].id.clone();
+    drop(pending);
+
+    let (_sk, vk) = generate_ed25519_keypair();
+    let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+    let mut receipt = ExecutionReceipt {
+        job_id,
+        executor_did: node_did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"res"),
+        cpu_ms: 1,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    };
+    let mut msg = Vec::new();
+    msg.extend_from_slice(receipt.job_id.to_string().as_bytes());
+    msg.extend_from_slice(node_did.to_string().as_bytes());
+    msg.extend_from_slice(receipt.result_cid.to_string().as_bytes());
+    msg.extend_from_slice(&receipt.cpu_ms.to_le_bytes());
+    msg.push(receipt.success as u8);
+    receipt.sig = SignatureBytes(ctx.signer.sign(&msg).unwrap());
+    let receipt_json = serde_json::to_string(&receipt).unwrap();
+    memory
+        .write(&mut store, 2000, receipt_json.as_bytes())
+        .unwrap();
+    let anchor = instance
+        .get_typed_func::<(i32, i32), ()>(&mut store, "anchor")
+        .unwrap();
+    anchor
+        .call(&mut store, (2000, receipt_json.len() as i32))
+        .unwrap();
+
+    // reputation updated
+    assert!(ctx.reputation_store.get_reputation(&node_did) > 0);
+
+    // get pending jobs via wasm
+    let get_jobs = instance
+        .get_typed_func::<(i32, i32), i32>(&mut store, "get_jobs")
+        .unwrap();
+    let buf_ptr = 3000i32;
+    let written = get_jobs.call(&mut store, (buf_ptr, 1024)).unwrap();
+    let mut buf = vec![0u8; written as usize];
+    memory.read(&mut store, buf_ptr as usize, &mut buf).unwrap();
+    let jobs: Vec<ActualMeshJob> = serde_json::from_slice(&buf).unwrap();
+    assert!(!jobs.is_empty());
+}


### PR DESCRIPTION
## Summary
- add wasm wrappers for host ABI functions using memory helpers
- include new test exercising host API via Wasm
- fix clippy warnings in network/node tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68522c051eb08324a6fb6daf99346d0c