### PR TITLE
[runtime] improve wasm memory helpers

### DIFF
--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -318,7 +318,7 @@ pub fn wasm_host_submit_mesh_job(
     ptr: u32,
     len: u32,
 ) {
-    if let Ok(job_json) = memory::read_string(&mut caller, ptr, len) {
+    if let Ok(job_json) = memory::read_guest_string(&mut caller, ptr, len) {
         let handle = tokio::runtime::Handle::current();
         let _ = handle.block_on(host_submit_mesh_job(caller.data(), &job_json));
     }
@@ -344,7 +344,7 @@ pub fn wasm_host_get_pending_mesh_jobs(
     };
     let bytes = json.as_bytes();
     let copy_len = bytes.len().min(len as usize);
-    if memory::write_bytes(&mut caller, ptr, &bytes[..copy_len]).is_ok() {
+    if memory::write_guest_bytes(&mut caller, ptr, &bytes[..copy_len]).is_ok() {
         copy_len as u32
     } else {
         0
@@ -357,7 +357,7 @@ pub fn wasm_host_anchor_receipt(
     ptr: u32,
     len: u32,
 ) {
-    if let Ok(json) = memory::read_string(&mut caller, ptr, len) {
+    if let Ok(json) = memory::read_guest_string(&mut caller, ptr, len) {
         let handle = tokio::runtime::Handle::current();
         let rep = ReputationUpdater::new();
         let _ = handle.block_on(host_anchor_receipt(caller.data(), &json, &rep));
@@ -371,7 +371,7 @@ pub fn wasm_host_account_get_mana(
     ptr: u32,
     len: u32,
 ) -> u64 {
-    if let Ok(did) = memory::read_string(&mut caller, ptr, len) {
+    if let Ok(did) = memory::read_guest_string(&mut caller, ptr, len) {
         let handle = tokio::runtime::Handle::current();
         handle
             .block_on(host_account_get_mana(caller.data(), &did))
@@ -389,7 +389,7 @@ pub fn wasm_host_account_spend_mana(
     len: u32,
     amount: u64,
 ) {
-    if let Ok(did) = memory::read_string(&mut caller, ptr, len) {
+    if let Ok(did) = memory::read_guest_string(&mut caller, ptr, len) {
         let handle = tokio::runtime::Handle::current();
         let _ = handle.block_on(host_account_spend_mana(caller.data(), &did, amount));
     }

--- a/crates/icn-runtime/src/memory.rs
+++ b/crates/icn-runtime/src/memory.rs
@@ -25,6 +25,15 @@ pub fn read_bytes(
     Ok(buf)
 }
 
+/// Convenience alias for [`read_bytes`].
+pub fn read_guest_bytes(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    len: u32,
+) -> Result<Vec<u8>, HostAbiError> {
+    read_bytes(caller, ptr, len)
+}
+
 /// Reads a UTF-8 string from guest memory.
 pub fn read_string(
     caller: &mut Caller<'_, Arc<RuntimeContext>>,
@@ -34,6 +43,15 @@ pub fn read_string(
     let bytes = read_bytes(caller, ptr, len)?;
     String::from_utf8(bytes)
         .map_err(|e| HostAbiError::InvalidParameters(format!("utf8 error: {e}")))
+}
+
+/// Convenience alias for [`read_string`].
+pub fn read_guest_string(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    len: u32,
+) -> Result<String, HostAbiError> {
+    read_string(caller, ptr, len)
 }
 
 /// Writes bytes into guest memory at the given pointer.
@@ -48,6 +66,15 @@ pub fn write_bytes(
         .map_err(|e| HostAbiError::InvalidParameters(format!("memory write failed: {e}")))
 }
 
+/// Convenience alias for [`write_bytes`].
+pub fn write_guest_bytes(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    data: &[u8],
+) -> Result<(), HostAbiError> {
+    write_bytes(caller, ptr, data)
+}
+
 /// Writes a UTF-8 string into guest memory at the given pointer.
 pub fn write_string(
     caller: &mut Caller<'_, Arc<RuntimeContext>>,
@@ -55,4 +82,13 @@ pub fn write_string(
     data: &str,
 ) -> Result<(), HostAbiError> {
     write_bytes(caller, ptr, data.as_bytes())
+}
+
+/// Convenience alias for [`write_string`].
+pub fn write_guest_string(
+    caller: &mut Caller<'_, Arc<RuntimeContext>>,
+    ptr: u32,
+    data: &str,
+) -> Result<(), HostAbiError> {
+    write_string(caller, ptr, data)
 }

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -5,6 +5,11 @@ use icn_mesh::{ActualMeshJob, JobSpec};
 use icn_runtime::context::RuntimeContext;
 use icn_runtime::executor::{JobExecutor, WasmExecutor};
 use std::str::FromStr;
+use serde_json;
+
+fn bytes_to_wat_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("\\{:02x}", b)).collect()
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn wasm_executor_runs_wasm() {
@@ -44,4 +49,75 @@ async fn wasm_executor_runs_wasm() {
     let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn wasm_executor_host_calls_with_json() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zExecJson", 80);
+    let (sk, vk) = generate_ed25519_keypair();
+    let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+
+    let submit_job = ActualMeshJob {
+        id: Cid::new_v1_sha256(0x55, b"sjob"),
+        manifest_cid: Cid::new_v1_sha256(0x71, b"man"),
+        spec: JobSpec::default(),
+        creator_did: node_did.clone(),
+        cost_mana: 5,
+        max_execution_wait_ms: Some(10),
+        signature: SignatureBytes(vec![]),
+    };
+    let job_json = serde_json::to_string(&submit_job).unwrap();
+
+    let mut receipt = icn_identity::ExecutionReceipt {
+        job_id: Cid::new_v1_sha256(0x55, b"rid"),
+        executor_did: node_did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"res"),
+        cpu_ms: 2,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    };
+    let mut msg = Vec::new();
+    msg.extend_from_slice(receipt.job_id.to_string().as_bytes());
+    msg.extend_from_slice(node_did.to_string().as_bytes());
+    msg.extend_from_slice(receipt.result_cid.to_string().as_bytes());
+    msg.extend_from_slice(&receipt.cpu_ms.to_le_bytes());
+    msg.push(receipt.success as u8);
+    receipt.sig = SignatureBytes(ctx.signer.sign(&msg).unwrap());
+    let receipt_json = serde_json::to_string(&receipt).unwrap();
+
+    let job_hex = bytes_to_wat_string(job_json.as_bytes());
+    let receipt_hex = bytes_to_wat_string(receipt_json.as_bytes());
+    let job_len = job_json.len();
+    let receipt_len = receipt_json.len();
+    let receipt_offset = 4096;
+    let module_wat = format!(
+        "(module\n  (import \"icn\" \"host_submit_mesh_job\" (func $s (param i32 i32)))\n  (import \"icn\" \"host_anchor_receipt\" (func $a (param i32 i32)))\n  (memory (export \"memory\") 1)\n  (data (i32.const 0) \"{job_hex}\")\n  (data (i32.const {receipt_offset}) \"{receipt_hex}\")\n  (func (export \"run\") (result i64)\n    i32.const 0\n    i32.const {job_len}\n    call $s\n    i32.const {receipt_offset}\n    i32.const {receipt_len}\n    call $a\n    i64.const 0)\n)",
+        job_hex = job_hex,
+        receipt_hex = receipt_hex,
+        job_len = job_len,
+        receipt_len = receipt_len,
+        receipt_offset = receipt_offset,
+    );
+    let wasm_bytes = wat::parse_str(&module_wat).unwrap();
+    let block = DagBlock { cid: Cid::new_v1_sha256(0x71, &wasm_bytes), data: wasm_bytes, links: vec![] };
+    {
+        let mut store = ctx.dag_store.lock().await;
+        store.put(&block).unwrap();
+    }
+
+    let job = ActualMeshJob {
+        id: Cid::new_v1_sha256(0x55, b"exec"),
+        manifest_cid: block.cid.clone(),
+        spec: JobSpec::default(),
+        creator_did: node_did.clone(),
+        cost_mana: 0,
+        max_execution_wait_ms: None,
+        signature: SignatureBytes(vec![]),
+    };
+
+    let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
+    exec.execute_job(&job).await.unwrap();
+
+    assert!(!ctx.pending_mesh_jobs.lock().await.is_empty());
+    assert!(ctx.reputation_store.get_reputation(&node_did) > 0);
 }


### PR DESCRIPTION
## Summary
- add helper functions for reading/writing guest memory
- refactor wasm host wrappers to use new helpers
- test complex JSON flow through WasmExecutor

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685f2c031fc0832499f16f0941517c0a