### PR TITLE
[node] persist ledger and reputation

### DIFF
--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -25,6 +25,8 @@ pub struct NodeConfig {
     pub storage_backend: StorageBackendType,
     pub storage_path: std::path::PathBuf,
     pub mana_ledger_path: std::path::PathBuf,
+    /// Path where executor reputation is persisted via sled.
+    pub reputation_db_path: std::path::PathBuf,
     /// Path where governance proposals and votes are persisted via sled.
     pub governance_db_path: std::path::PathBuf,
     pub http_listen_addr: String,
@@ -52,6 +54,7 @@ impl Default for NodeConfig {
             storage_backend: StorageBackendType::Memory,
             storage_path: "./icn_data/node_store".into(),
             mana_ledger_path: "./mana_ledger.sled".into(),
+            reputation_db_path: "./reputation.sled".into(),
             governance_db_path: "./governance_db".into(),
             http_listen_addr: "127.0.0.1:7845".to_string(),
             node_did: None,
@@ -93,6 +96,9 @@ impl NodeConfig {
         }
         if let Some(v) = &cli.mana_ledger_path {
             self.mana_ledger_path = v.clone();
+        }
+        if let Some(v) = &cli.reputation_db_path {
+            self.reputation_db_path = v.clone();
         }
         if let Some(v) = &cli.governance_db_path {
             self.governance_db_path = v.clone();
@@ -136,5 +142,28 @@ impl NodeConfig {
         if let Some(v) = &cli.tls_key_path {
             self.tls_key_path = Some(v.clone());
         }
+    }
+
+    /// Ensure directories for all configured paths exist.
+    pub fn prepare_paths(&self) -> std::io::Result<()> {
+        if let Some(parent) = self.storage_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if let Some(parent) = self.mana_ledger_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if let Some(parent) = self.reputation_db_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if let Some(parent) = self.governance_db_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if let Some(parent) = self.node_did_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        if let Some(parent) = self.node_private_key_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        Ok(())
     }
 }

--- a/crates/icn-node/tests/governance_persistence.rs
+++ b/crates/icn-node/tests/governance_persistence.rs
@@ -15,6 +15,7 @@ async fn governance_persists_between_restarts() {
         None,
         Some(ledger_path.clone()),
         Some(gov_path.clone()),
+        None,
     )
     .await;
 
@@ -47,6 +48,7 @@ async fn governance_persists_between_restarts() {
         None,
         Some(ledger_path.clone()),
         Some(gov_path.clone()),
+        None,
     )
     .await;
     let gov2 = ctx2.governance_module.lock().await;

--- a/crates/icn-node/tests/ledger.rs
+++ b/crates/icn-node/tests/ledger.rs
@@ -8,13 +8,14 @@ async fn ledger_persists_between_restarts() {
     let dir = tempdir().unwrap();
     let ledger_path = dir.path().join("mana.sled");
 
-    let (_router, ctx) = app_router_with_options(None, None, Some(ledger_path.clone()), None).await;
+    let (_router, ctx) =
+        app_router_with_options(None, None, Some(ledger_path.clone()), None, None).await;
     let did = Did::from_str("did:example:alice").unwrap();
     ctx.mana_ledger.set_balance(&did, 42).expect("set balance");
 
     drop(_router);
 
     let (_router2, ctx2) =
-        app_router_with_options(None, None, Some(ledger_path.clone()), None).await;
+        app_router_with_options(None, None, Some(ledger_path.clone()), None, None).await;
     assert_eq!(ctx2.mana_ledger.get_balance(&did), 42);
 }

--- a/crates/icn-node/tests/reputation.rs
+++ b/crates/icn-node/tests/reputation.rs
@@ -1,0 +1,34 @@
+use icn_common::Did;
+use icn_node::app_router_with_options;
+use std::str::FromStr;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn reputation_persists_between_restarts() {
+    let dir = tempdir().unwrap();
+    let ledger_path = dir.path().join("mana.sled");
+    let rep_path = dir.path().join("rep.sled");
+
+    let (_router, ctx) = app_router_with_options(
+        None,
+        None,
+        Some(ledger_path.clone()),
+        None,
+        Some(rep_path.clone()),
+    )
+    .await;
+    let did = Did::from_str("did:example:alice").unwrap();
+    ctx.reputation_store.record_execution(&did, true, 100);
+
+    drop(_router);
+
+    let (_router2, ctx2) = app_router_with_options(
+        None,
+        None,
+        Some(ledger_path.clone()),
+        None,
+        Some(rep_path.clone()),
+    )
+    .await;
+    assert!(ctx2.reputation_store.get_reputation(&did) > 0);
+}

--- a/crates/icn-runtime/examples/libp2p_demo.rs
+++ b/crates/icn-runtime/examples/libp2p_demo.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         None, // No bootstrap peers for this demo
         std::path::PathBuf::from("./mana_ledger.sled"),
+        std::path::PathBuf::from("./reputation.sled"),
     )
     .await?;
 

--- a/crates/icn-runtime/tests/integration/cross_node_governance.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_governance.rs
@@ -19,6 +19,7 @@ mod cross_node_governance {
             listen,
             bootstrap,
             std::path::PathBuf::from("./mana_ledger.sled"),
+            std::path::PathBuf::from("./reputation.sled"),
         )
         .await?;
         Ok(ctx)

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -55,6 +55,7 @@ mod cross_node_tests {
             listen,
             bootstrap_peers,
             std::path::PathBuf::from("./mana_ledger.sled"),
+            std::path::PathBuf::from("./reputation.sled"),
         )
         .await?;
         

--- a/crates/icn-runtime/tests/integration/libp2p_integration.rs
+++ b/crates/icn-runtime/tests/integration/libp2p_integration.rs
@@ -20,6 +20,7 @@ mod libp2p_integration_tests {
             listen,
             None,  // No bootstrap peers for this simple test
             std::path::PathBuf::from("./mana_ledger.sled"),
+            std::path::PathBuf::from("./reputation.sled"),
         )
         .await;
         
@@ -74,6 +75,7 @@ mod libp2p_integration_tests {
             listen,
             Some(bootstrap_peers),
             std::path::PathBuf::from("./mana_ledger.sled"),
+            std::path::PathBuf::from("./reputation.sled"),
         )
         .await;
         

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -23,6 +23,7 @@ async fn anchor_receipt_updates_reputation() {
         Arc::new(icn_identity::KeyDidResolver),
         Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         std::path::PathBuf::from("./mana_ledger.sled"),
+        std::path::PathBuf::from("./reputation.sled"),
     );
     let job_id = Cid::new_v1_sha256(0x55, b"rep_job");
     let result_cid = Cid::new_v1_sha256(0x55, b"res");

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -23,6 +23,7 @@ fn ctx_with_temp_store(did: &str, mana: u64) -> Arc<RuntimeContext> {
         Arc::new(icn_identity::KeyDidResolver),
         dag_store,
         temp.path().join("mana"),
+        temp.path().join("reputation"),
     );
     ctx.mana_ledger
         .set_balance(&icn_common::Did::from_str(did).unwrap(), mana)

--- a/icn-runtime/tests/ledger_persistence.rs
+++ b/icn-runtime/tests/ledger_persistence.rs
@@ -16,6 +16,7 @@ async fn mana_persists_across_contexts() {
         Arc::new(StubSigner::new()),
         Arc::new(TokioMutex::new(StubDagStore::new())),
         ledger_path.clone(),
+        temp_dir.path().join("rep.sled"),
     );
     ctx1.mana_ledger.set_balance(&did, 42).unwrap();
     drop(ctx1);
@@ -26,6 +27,7 @@ async fn mana_persists_across_contexts() {
         Arc::new(StubSigner::new()),
         Arc::new(TokioMutex::new(StubDagStore::new())),
         ledger_path,
+        temp_dir.path().join("rep.sled"),
     );
     assert_eq!(ctx2.mana_ledger.get_balance(&did), 42);
 }

--- a/tests/integration/multi_node_libp2p.rs
+++ b/tests/integration/multi_node_libp2p.rs
@@ -39,6 +39,7 @@ mod multi_node_libp2p {
             listen,
             bootstrap_peers,
             std::path::PathBuf::from("./mana_ledger.sled"),
+            std::path::PathBuf::from("./reputation.sled"),
         )
         .await?;
         let identity = Did::from_str(&identity_str)?;


### PR DESCRIPTION
## Summary
- allow configuring mana ledger and reputation store paths via `NodeConfig`
- load sled reputation store from config path
- create runtime reputation persistence test
- ensure directories exist when preparing node config

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process was manually terminated)*
- `cargo test --all-features --workspace` *(failed: process was manually terminated)*

------
https://chatgpt.com/codex/tasks/task_e_685f2c03a5bc8324b1fb246696b1ca76