### PR TITLE
[icn-node] add bearer token auth

### DIFF
--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -77,6 +77,7 @@ Useful CLI flags include:
 * `--bootstrap-peers <LIST>` – comma-separated list of bootstrap peer multiaddrs
 * `--enable-p2p` – enable libp2p networking (requires `with-libp2p` feature)
 * `--api-key <KEY>` – require this key via the `x-api-key` header for all requests
+* `auth_token` / `auth_token_path` – set a bearer token string or file and require `Authorization: Bearer <token>`
 * `--open-rate-limit <N>` – allowed unauthenticated requests per minute when no API key is set
 * `--tls-cert-path <PATH>` – PEM certificate file to enable HTTPS
 * `--tls-key-path <PATH>` – PEM private key file to enable HTTPS

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -41,6 +41,10 @@ pub struct NodeConfig {
     pub bootstrap_peers: Option<Vec<String>>,
     pub enable_p2p: bool,
     pub api_key: Option<String>,
+    /// Optional bearer token for Authorization header auth.
+    pub auth_token: Option<String>,
+    /// Path to read the bearer token from if not provided inline.
+    pub auth_token_path: Option<std::path::PathBuf>,
     pub open_rate_limit: u64,
     /// TLS certificate path for HTTPS. Requires `tls_key_path` as well.
     pub tls_cert_path: Option<std::path::PathBuf>,
@@ -66,6 +70,8 @@ impl Default for NodeConfig {
             bootstrap_peers: None,
             enable_p2p: false,
             api_key: None,
+            auth_token: None,
+            auth_token_path: None,
             open_rate_limit: 60,
             tls_cert_path: None,
             tls_key_path: None,
@@ -163,6 +169,11 @@ impl NodeConfig {
         }
         if let Some(parent) = self.node_private_key_path.parent() {
             fs::create_dir_all(parent)?;
+        }
+        if let Some(path) = &self.auth_token_path {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
         }
         Ok(())
     }

--- a/crates/icn-node/tests/auth.rs
+++ b/crates/icn-node/tests/auth.rs
@@ -4,7 +4,8 @@ use tokio::task;
 
 #[tokio::test]
 async fn api_key_required_for_requests() {
-    let (router, _ctx) = app_router_with_options(Some("secret".into()), None, None, None).await;
+    let (router, _ctx) =
+        app_router_with_options(Some("secret".into()), None, None, None, None, None).await;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = task::spawn(async move {
@@ -28,6 +29,41 @@ async fn api_key_required_for_requests() {
     let resp = client
         .get(&url)
         .header("x-api-key", "secret")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn bearer_token_required_for_requests() {
+    let (router, _ctx) =
+        app_router_with_options(None, Some("s3cr3t".into()), None, None, None, None).await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let client = Client::new();
+    let url = format!("http://{addr}/info");
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let resp = client
+        .get(&url)
+        .header("Authorization", "Bearer wrong")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let resp = client
+        .get(&url)
+        .header("Authorization", "Bearer s3cr3t")
         .send()
         .await
         .unwrap();

--- a/crates/icn-node/tests/governance_persistence.rs
+++ b/crates/icn-node/tests/governance_persistence.rs
@@ -13,6 +13,7 @@ async fn governance_persists_between_restarts() {
     let (_router, ctx) = app_router_with_options(
         None,
         None,
+        None,
         Some(ledger_path.clone()),
         Some(gov_path.clone()),
         None,
@@ -44,6 +45,7 @@ async fn governance_persists_between_restarts() {
     drop(_router);
 
     let (_router2, ctx2) = app_router_with_options(
+        None,
         None,
         None,
         Some(ledger_path.clone()),

--- a/crates/icn-node/tests/ledger.rs
+++ b/crates/icn-node/tests/ledger.rs
@@ -9,13 +9,13 @@ async fn ledger_persists_between_restarts() {
     let ledger_path = dir.path().join("mana.sled");
 
     let (_router, ctx) =
-        app_router_with_options(None, None, Some(ledger_path.clone()), None, None).await;
+        app_router_with_options(None, None, None, Some(ledger_path.clone()), None, None).await;
     let did = Did::from_str("did:example:alice").unwrap();
     ctx.mana_ledger.set_balance(&did, 42).expect("set balance");
 
     drop(_router);
 
     let (_router2, ctx2) =
-        app_router_with_options(None, None, Some(ledger_path.clone()), None, None).await;
+        app_router_with_options(None, None, None, Some(ledger_path.clone()), None, None).await;
     assert_eq!(ctx2.mana_ledger.get_balance(&did), 42);
 }

--- a/crates/icn-node/tests/reputation.rs
+++ b/crates/icn-node/tests/reputation.rs
@@ -12,6 +12,7 @@ async fn reputation_persists_between_restarts() {
     let (_router, ctx) = app_router_with_options(
         None,
         None,
+        None,
         Some(ledger_path.clone()),
         None,
         Some(rep_path.clone()),
@@ -23,6 +24,7 @@ async fn reputation_persists_between_restarts() {
     drop(_router);
 
     let (_router2, ctx2) = app_router_with_options(
+        None,
         None,
         None,
         Some(ledger_path.clone()),


### PR DESCRIPTION
## Summary
- support bearer token in `NodeConfig` and app state
- allow reading bearer token from file
- enforce `Authorization: Bearer <token>` if configured
- document bearer token usage
- update integration tests for API keys and tokens

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test --all-features --workspace` *(failed: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685f5b04b49c8324a030b63ef55248d9