### PR TITLE
[tests] verify receipt propagation over libp2p

### DIFF
--- a/tests/integration/libp2p_job_pipeline.rs
+++ b/tests/integration/libp2p_job_pipeline.rs
@@ -101,13 +101,19 @@ mod libp2p_job_pipeline {
             .as_str()
             .expect("result_cid");
 
-        let dag_res = client
-            .post(&format!("{}/dag/get", NODE_A_URL))
-            .json(&serde_json::json!({ "cid": result_cid }))
-            .send()
-            .await
-            .expect("dag get");
-        assert!(dag_res.status().is_success());
+        for url in [NODE_A_URL, NODE_B_URL, NODE_C_URL] {
+            let dag_res = client
+                .post(&format!("{}/dag/get", url))
+                .json(&serde_json::json!({ "cid": result_cid }))
+                .send()
+                .await
+                .expect("dag get");
+            assert!(
+                dag_res.status().is_success(),
+                "dag get failed on {}",
+                url
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- extend `libp2p_job_pipeline` integration test
- ensure receipt is reachable from every federation node

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: aborted due to ctrl-c)*
- `cargo test --all-features --workspace` *(fails: aborted due to ctrl-c)*

------
https://chatgpt.com/codex/tasks/task_e_685f63cdd08c8324bb10c388aed997a2