### PR TITLE
[node] persist reputation store

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -14,6 +14,7 @@ icn-governance = { path = "../icn-governance", features = ["serde"] }
 icn-runtime = { path = "../icn-runtime" }
 icn-identity = { path = "../icn-identity" }
 icn-mesh = { path = "../icn-mesh" }
+icn-reputation = { path = "../icn-reputation" }
 icn-ccl = { path = "../../icn-ccl" }
 log = "0.4"
 env_logger = "0.10"

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -204,6 +204,6 @@ async fn wasm_executor_host_anchor_receipt_json() {
     let rec_bytes = serde_json::to_vec(&receipt).unwrap();
     let expected = Cid::new_v1_sha256(0x71, &rec_bytes);
     let store = ctx.dag_store.lock().await;
-    assert!(store.all().contains_key(&expected));
+    assert!(store.get(&expected).unwrap().is_some());
     assert!(ctx.reputation_store.get_reputation(&executor_did) > 0);
 }

--- a/tests/integration/reputation_persistence.rs
+++ b/tests/integration/reputation_persistence.rs
@@ -1,0 +1,62 @@
+#[cfg(feature = "persist-sled")]
+mod reputation_persistence {
+    use icn_common::{Cid, Did};
+    use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+    use icn_mesh::{select_executor, MeshJobBid, JobSpec, Resources, SelectionPolicy};
+    use icn_reputation::sled_store::SledReputationStore;
+    use icn_reputation::ReputationStore;
+    use icn_runtime::context::SimpleManaLedger;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn persisted_reputation_influences_selection() {
+        let dir = tempdir().unwrap();
+        let rep_path = dir.path().join("rep.sled");
+        let mana_path = dir.path().join("mana.sled");
+
+        let ledger = SimpleManaLedger::new(mana_path);
+        let store = SledReputationStore::new(rep_path.clone()).unwrap();
+
+        let (_ska, vka) = generate_ed25519_keypair();
+        let did_a = Did::from_str(&did_key_from_verifying_key(&vka)).unwrap();
+        let (_skb, vkb) = generate_ed25519_keypair();
+        let did_b = Did::from_str(&did_key_from_verifying_key(&vkb)).unwrap();
+
+        ledger.set_balance(&did_a, 100).unwrap();
+        ledger.set_balance(&did_b, 100).unwrap();
+
+        store.record_execution(&did_a, true, 1000);
+        drop(store);
+
+        let reopened = SledReputationStore::new(rep_path).unwrap();
+
+        let job_id = Cid::new_v1_sha256(0x55, b"rep_job");
+        let bid_a = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: did_a.clone(),
+            price_mana: 10,
+            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            signature: SignatureBytes(Vec::new()),
+        };
+        let bid_b = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: did_b.clone(),
+            price_mana: 10,
+            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            signature: SignatureBytes(Vec::new()),
+        };
+
+        let selected = select_executor(
+            &job_id,
+            &JobSpec::Echo { payload: "persist".into() },
+            vec![bid_a, bid_b],
+            &SelectionPolicy::default(),
+            &reopened,
+            &ledger,
+        )
+        .expect("executor selected");
+
+        assert_eq!(selected, did_a);
+    }
+}


### PR DESCRIPTION
## Summary
- load `SledReputationStore` whenever node is started with `--reputation-db-path`
- choose executors using the runtime's persistent reputation store
- test that persisted reputation influences executor selection

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685f95422b3c8324b0c628ea62e1c508