### PR TITLE
[runtime] auto WasmExecutor for CCL jobs

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1727,9 +1727,9 @@ mod tests {
 
         // Execute the job using WasmExecutor and anchor the receipt
         let (sk, vk) = generate_ed25519_keypair();
-        let exec_did = did_key_from_verifying_key(&vk);
-        let exec_did = Did::from_str(&exec_did).unwrap();
-        let executor = WasmExecutor::new(ctx.clone(), exec_did.clone(), sk);
+        let signer = icn_runtime::context::StubSigner::new_with_keys(sk, vk);
+        let exec_did = signer.did();
+        let executor = WasmExecutor::new(ctx.clone(), std::sync::Arc::new(signer));
         let job = ActualMeshJob {
             id: job_id.clone(),
             manifest_cid: wasm_cid.clone(),

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -191,7 +191,8 @@ async fn test_wasm_executor_with_ccl() {
         signature: SignatureBytes(vec![]),
     };
 
-    let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
+    let signer = icn_runtime::context::StubSigner::new_with_keys(sk, vk);
+    let exec = WasmExecutor::new(ctx.clone(), std::sync::Arc::new(signer));
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
 }
@@ -326,7 +327,8 @@ async fn test_wasm_executor_runs_addition() {
         signature: SignatureBytes(vec![]),
     };
 
-    let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
+    let signer = icn_runtime::context::StubSigner::new_with_keys(sk, vk);
+    let exec = WasmExecutor::new(ctx.clone(), std::sync::Arc::new(signer));
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
 }

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -62,7 +62,8 @@ async fn wasm_executor_runs_compiled_ccl() {
         signature: SignatureBytes(vec![]),
     };
 
-    let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
+    let signer = icn_runtime::context::StubSigner::new_with_keys(sk, vk);
+    let exec = WasmExecutor::new(ctx.clone(), std::sync::Arc::new(signer));
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();
@@ -105,7 +106,8 @@ async fn wasm_executor_runs_compiled_addition() {
         signature: SignatureBytes(vec![]),
     };
 
-    let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
+    let signer = icn_runtime::context::StubSigner::new_with_keys(sk, vk);
+    let exec = WasmExecutor::new(ctx.clone(), std::sync::Arc::new(signer));
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();
@@ -148,7 +150,8 @@ async fn wasm_executor_fails_without_run() {
         signature: SignatureBytes(vec![]),
     };
 
-    let exec = WasmExecutor::new(ctx.clone(), node_did, sk);
+    let signer = icn_runtime::context::StubSigner::new_with_keys(sk, vk);
+    let exec = WasmExecutor::new(ctx.clone(), std::sync::Arc::new(signer));
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();
@@ -188,7 +191,8 @@ async fn compile_and_execute_simple_contract() {
         signature: SignatureBytes(vec![]),
     };
 
-    let exec = WasmExecutor::new(ctx.clone(), node_did.clone(), sk);
+    let signer = icn_runtime::context::StubSigner::new_with_keys(sk, vk);
+    let exec = WasmExecutor::new(ctx.clone(), std::sync::Arc::new(signer));
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();


### PR DESCRIPTION
## Summary
- execute compiled CCL jobs immediately using `WasmExecutor`
- store helper to detect CCL wasm modules
- pass signer objects to `WasmExecutor`
- update tests for signer API
- add integration test for automatic execution on job submission

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685f9ca20024832496326fdb75ba94c6