### PR TITLE
[runtime] add sqlite and rocksdb persistence

### DIFF
--- a/crates/icn-economics/Cargo.toml
+++ b/crates/icn-economics/Cargo.toml
@@ -15,6 +15,8 @@ thiserror = "1.0" # Added thiserror
 serde_json = "1.0"
 sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
+rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
+rocksdb = { version = "0.21", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"
@@ -24,4 +26,6 @@ bincode = "1.3"
 [features]
 default = ["persist-sled"]
 persist-sled = ["dep:sled", "dep:bincode"]
+persist-sqlite = ["dep:rusqlite"]
+persist-rocksdb = ["dep:rocksdb", "dep:bincode"]
 # Example feature: enable-advanced-accounting = []

--- a/crates/icn-economics/src/ledger.rs
+++ b/crates/icn-economics/src/ledger.rs
@@ -140,6 +140,16 @@ pub struct SledManaLedger {
     tree: sled::Tree,
 }
 
+#[cfg(feature = "persist-sqlite")]
+pub mod sqlite;
+#[cfg(feature = "persist-sqlite")]
+pub use sqlite::SqliteManaLedger;
+
+#[cfg(feature = "persist-rocksdb")]
+pub mod rocksdb;
+#[cfg(feature = "persist-rocksdb")]
+pub use rocksdb::RocksdbManaLedger;
+
 impl SledManaLedger {
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let db = sled::open(path)
@@ -209,3 +219,13 @@ impl crate::ManaLedger for SledManaLedger {
             .map_err(|e| EconError::AdapterError(format!("{e}")))
     }
 }
+
+#[cfg(feature = "persist-sqlite")]
+pub mod sqlite;
+#[cfg(feature = "persist-sqlite")]
+pub use sqlite::SqliteManaLedger;
+
+#[cfg(feature = "persist-rocksdb")]
+pub mod rocksdb;
+#[cfg(feature = "persist-rocksdb")]
+pub use rocksdb::RocksdbManaLedger;

--- a/crates/icn-economics/src/ledger/rocksdb.rs
+++ b/crates/icn-economics/src/ledger/rocksdb.rs
@@ -1,0 +1,72 @@
+use crate::EconError;
+use icn_common::{CommonError, Did};
+use rocksdb::DB;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct RocksdbManaLedger {
+    db: DB,
+}
+
+impl RocksdbManaLedger {
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let db = DB::open_default(path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open rocksdb: {e}")))?;
+        Ok(Self { db })
+    }
+
+    fn write_balance(&self, account: &Did, amount: u64) -> Result<(), CommonError> {
+        let encoded = bincode::serialize(&amount).map_err(|e| {
+            CommonError::SerializationError(format!("Failed to serialize balance: {e}"))
+        })?;
+        self.db
+            .put(account.to_string(), encoded)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to store balance: {e}")))?;
+        self.db
+            .flush()
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to flush ledger: {e}")))?;
+        Ok(())
+    }
+
+    fn read_balance(&self, account: &Did) -> Result<u64, CommonError> {
+        if let Some(val) = self
+            .db
+            .get(account.to_string())
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to read balance: {e}")))?
+        {
+            let amt: u64 = bincode::deserialize(&val).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to deserialize balance: {e}"))
+            })?;
+            Ok(amt)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+impl crate::ManaLedger for RocksdbManaLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        self.read_balance(did).unwrap_or(0)
+    }
+
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        self.write_balance(did, amount)
+    }
+
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), EconError> {
+        let current = self.read_balance(did)?;
+        if current < amount {
+            return Err(EconError::InsufficientBalance(format!(
+                "Insufficient mana for DID {did}"
+            )));
+        }
+        self.write_balance(did, current - amount)?;
+        Ok(())
+    }
+
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), EconError> {
+        let current = self.read_balance(did)?;
+        self.write_balance(did, current + amount)?;
+        Ok(())
+    }
+}

--- a/crates/icn-economics/src/ledger/sqlite.rs
+++ b/crates/icn-economics/src/ledger/sqlite.rs
@@ -1,0 +1,75 @@
+use crate::EconError;
+use icn_common::{CommonError, Did};
+use rusqlite::{Connection, OptionalExtension};
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct SqliteManaLedger {
+    path: PathBuf,
+}
+
+impl SqliteManaLedger {
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let conn = Connection::open(&path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS mana_balances (did TEXT PRIMARY KEY, amount INTEGER)",
+            [],
+        )
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to create table: {e}")))?;
+        Ok(Self { path })
+    }
+
+    fn write_balance(&self, account: &Did, amount: u64) -> Result<(), CommonError> {
+        let conn = Connection::open(&self.path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        conn.execute(
+            "INSERT INTO mana_balances(did, amount) VALUES (?1, ?2) \
+             ON CONFLICT(did) DO UPDATE SET amount=excluded.amount",
+            (&account.to_string(), amount as i64),
+        )
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to write balance: {e}")))?;
+        Ok(())
+    }
+
+    fn read_balance(&self, account: &Did) -> Result<u64, CommonError> {
+        let conn = Connection::open(&self.path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        let amt: Option<i64> = conn
+            .query_row(
+                "SELECT amount FROM mana_balances WHERE did=?1",
+                [&account.to_string()],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to read balance: {e}")))?;
+        Ok(amt.unwrap_or(0) as u64)
+    }
+}
+
+impl crate::ManaLedger for SqliteManaLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        self.read_balance(did).unwrap_or(0)
+    }
+
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        self.write_balance(did, amount)
+    }
+
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), EconError> {
+        let current = self.read_balance(did)?;
+        if current < amount {
+            return Err(EconError::InsufficientBalance(format!(
+                "Insufficient mana for DID {did}"
+            )));
+        }
+        self.write_balance(did, current - amount)?;
+        Ok(())
+    }
+
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), EconError> {
+        let current = self.read_balance(did)?;
+        self.write_balance(did, current + amount)?;
+        Ok(())
+    }
+}

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -7,6 +7,10 @@
 
 use icn_common::{CommonError, Did, NodeInfo};
 mod ledger;
+#[cfg(feature = "persist-rocksdb")]
+pub use ledger::RocksdbManaLedger;
+#[cfg(feature = "persist-sqlite")]
+pub use ledger::SqliteManaLedger;
 pub use ledger::{FileManaLedger, SledManaLedger};
 
 /// Errors that can occur during mana accounting operations.

--- a/crates/icn-reputation/Cargo.toml
+++ b/crates/icn-reputation/Cargo.toml
@@ -11,6 +11,8 @@ icn-identity = { path = "../icn-identity" }
 serde = { version = "1.0", features = ["derive"] }
 sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
+rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
+rocksdb = { version = "0.21", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -18,3 +20,5 @@ tempfile = "3"
 [features]
 default = ["persist-sled"]
 persist-sled = ["dep:sled", "dep:bincode"]
+persist-sqlite = ["dep:rusqlite"]
+persist-rocksdb = ["dep:rocksdb", "dep:bincode"]

--- a/crates/icn-reputation/src/lib.rs
+++ b/crates/icn-reputation/src/lib.rs
@@ -10,6 +10,14 @@ use std::sync::Mutex;
 pub mod sled_store;
 #[cfg(feature = "persist-sled")]
 pub use sled_store::SledReputationStore;
+#[cfg(feature = "persist-sqlite")]
+pub mod sqlite_store;
+#[cfg(feature = "persist-sqlite")]
+pub use sqlite_store::SqliteReputationStore;
+#[cfg(feature = "persist-rocksdb")]
+pub mod rocksdb_store;
+#[cfg(feature = "persist-rocksdb")]
+pub use rocksdb_store::RocksdbReputationStore;
 
 /// Store for retrieving and updating executor reputation scores.
 pub trait ReputationStore: Send + Sync {

--- a/crates/icn-reputation/src/rocksdb_store.rs
+++ b/crates/icn-reputation/src/rocksdb_store.rs
@@ -1,0 +1,51 @@
+//! RocksDB-backed implementation of the `ReputationStore` trait.
+
+use crate::ReputationStore;
+use icn_common::{CommonError, Did};
+use rocksdb::DB;
+use std::path::PathBuf;
+
+#[cfg(feature = "persist-rocksdb")]
+pub struct RocksdbReputationStore {
+    db: DB,
+}
+
+#[cfg(feature = "persist-rocksdb")]
+impl RocksdbReputationStore {
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let db = DB::open_default(path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open rocksdb: {e}")))?;
+        Ok(Self { db })
+    }
+
+    fn read_score(&self, did: &Did) -> u64 {
+        if let Ok(Some(bytes)) = self.db.get(did.to_string()) {
+            bincode::deserialize(&bytes).unwrap_or(0)
+        } else {
+            0
+        }
+    }
+
+    fn write_score(&self, did: &Did, score: u64) {
+        if let Ok(encoded) = bincode::serialize(&score) {
+            let _ = self.db.put(did.to_string(), encoded);
+            let _ = self.db.flush();
+        }
+    }
+}
+
+#[cfg(feature = "persist-rocksdb")]
+impl ReputationStore for RocksdbReputationStore {
+    fn get_reputation(&self, did: &Did) -> u64 {
+        self.read_score(did)
+    }
+
+    fn record_execution(&self, executor: &Did, success: bool, cpu_ms: u64) {
+        let current = self.read_score(executor);
+        let base: i64 = if success { 1 } else { -1 };
+        let delta: i64 = base + (cpu_ms / 1000) as i64;
+        let updated = (current as i64) + delta;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        self.write_score(executor, new_score);
+    }
+}

--- a/crates/icn-reputation/src/sqlite_store.rs
+++ b/crates/icn-reputation/src/sqlite_store.rs
@@ -1,0 +1,61 @@
+//! SQLite-backed implementation of the `ReputationStore` trait.
+
+use crate::ReputationStore;
+use icn_common::{CommonError, Did};
+use rusqlite::{Connection, OptionalExtension};
+use std::path::PathBuf;
+
+#[cfg(feature = "persist-sqlite")]
+pub struct SqliteReputationStore {
+    path: PathBuf,
+}
+
+#[cfg(feature = "persist-sqlite")]
+impl SqliteReputationStore {
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let conn = Connection::open(&path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS reputation (did TEXT PRIMARY KEY, score INTEGER)",
+            [],
+        )
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to create table: {e}")))?;
+        Ok(Self { path })
+    }
+
+    fn read_score(&self, did: &Did) -> u64 {
+        let conn = Connection::open(&self.path).expect("open sqlite");
+        conn.query_row(
+            "SELECT score FROM reputation WHERE did=?1",
+            [&did.to_string()],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()
+        .unwrap_or(None)
+        .unwrap_or(0) as u64
+    }
+
+    fn write_score(&self, did: &Did, score: u64) {
+        let conn = Connection::open(&self.path).expect("open sqlite");
+        let _ = conn.execute(
+            "INSERT INTO reputation(did, score) VALUES(?1, ?2) \n             ON CONFLICT(did) DO UPDATE SET score=excluded.score",
+            (&did.to_string(), score as i64),
+        );
+    }
+}
+
+#[cfg(feature = "persist-sqlite")]
+impl ReputationStore for SqliteReputationStore {
+    fn get_reputation(&self, did: &Did) -> u64 {
+        self.read_score(did)
+    }
+
+    fn record_execution(&self, executor: &Did, success: bool, cpu_ms: u64) {
+        let current = self.read_score(executor);
+        let base: i64 = if success { 1 } else { -1 };
+        let delta: i64 = base + (cpu_ms / 1000) as i64;
+        let updated = (current as i64) + delta;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        self.write_score(executor, new_score);
+    }
+}

--- a/crates/icn-reputation/tests/rocksdb.rs
+++ b/crates/icn-reputation/tests/rocksdb.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "persist-rocksdb")]
+mod tests {
+    use icn_common::Did;
+    use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
+    use icn_reputation::rocksdb_store::RocksdbReputationStore;
+    use icn_reputation::ReputationStore;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rocksdb_round_trip() {
+        let dir = tempdir().unwrap();
+        let path: PathBuf = dir.path().join("rep.rocks");
+        let store = RocksdbReputationStore::new(path.clone()).unwrap();
+
+        let (_sk, vk) = generate_ed25519_keypair();
+        let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+
+        store.record_execution(&did, true, 1000);
+        assert_eq!(store.get_reputation(&did), 2);
+
+        drop(store);
+        let reopened = RocksdbReputationStore::new(path).unwrap();
+        assert_eq!(reopened.get_reputation(&did), 2);
+    }
+}

--- a/crates/icn-reputation/tests/sqlite.rs
+++ b/crates/icn-reputation/tests/sqlite.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "persist-sqlite")]
+mod tests {
+    use icn_common::Did;
+    use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
+    use icn_reputation::sqlite_store::SqliteReputationStore;
+    use icn_reputation::ReputationStore;
+    use std::path::PathBuf;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sqlite_round_trip() {
+        let dir = tempdir().unwrap();
+        let path: PathBuf = dir.path().join("rep.sqlite");
+        let store = SqliteReputationStore::new(path.clone()).unwrap();
+
+        let (_sk, vk) = generate_ed25519_keypair();
+        let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+
+        store.record_execution(&did, true, 1000);
+        assert_eq!(store.get_reputation(&did), 2);
+
+        drop(store);
+        let reopened = SqliteReputationStore::new(path).unwrap();
+        assert_eq!(reopened.get_reputation(&did), 2);
+    }
+}

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -46,6 +46,8 @@ serial_test = { version = "3", features = ["async"] }
 default = []
 enable-libp2p = ["dep:libp2p"]
 persist-sled = ["icn-governance/persist-sled", "icn-reputation/persist-sled"]
+persist-sqlite = ["icn-governance/persist-sled", "icn-reputation/persist-sqlite", "icn-economics/persist-sqlite"]
+persist-rocksdb = ["icn-governance/persist-sled", "icn-reputation/persist-rocksdb", "icn-economics/persist-rocksdb"]
 
 # Integration tests for cross-node functionality
 [[test]]

--- a/tests/integration/reputation_persistence.rs
+++ b/tests/integration/reputation_persistence.rs
@@ -60,3 +60,129 @@ mod reputation_persistence {
         assert_eq!(selected, did_a);
     }
 }
+
+#[cfg(feature = "persist-sqlite")]
+mod reputation_persistence_sqlite {
+    use icn_common::{Cid, Did};
+    use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+    use icn_mesh::{select_executor, MeshJobBid, JobSpec, Resources, SelectionPolicy};
+    use icn_reputation::sqlite_store::SqliteReputationStore;
+    use icn_reputation::ReputationStore;
+    use icn_runtime::context::SimpleManaLedger;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn persisted_reputation_influences_selection() {
+        let dir = tempdir().unwrap();
+        let rep_path = dir.path().join("rep.sqlite");
+        let mana_path = dir.path().join("mana.sqlite");
+
+        let ledger = SimpleManaLedger::new(mana_path);
+        let store = SqliteReputationStore::new(rep_path.clone()).unwrap();
+
+        let (_ska, vka) = generate_ed25519_keypair();
+        let did_a = Did::from_str(&did_key_from_verifying_key(&vka)).unwrap();
+        let (_skb, vkb) = generate_ed25519_keypair();
+        let did_b = Did::from_str(&did_key_from_verifying_key(&vkb)).unwrap();
+
+        ledger.set_balance(&did_a, 100).unwrap();
+        ledger.set_balance(&did_b, 100).unwrap();
+
+        store.record_execution(&did_a, true, 1000);
+        drop(store);
+
+        let reopened = SqliteReputationStore::new(rep_path).unwrap();
+
+        let job_id = Cid::new_v1_sha256(0x55, b"rep_job");
+        let bid_a = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: did_a.clone(),
+            price_mana: 10,
+            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            signature: SignatureBytes(Vec::new()),
+        };
+        let bid_b = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: did_b.clone(),
+            price_mana: 10,
+            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            signature: SignatureBytes(Vec::new()),
+        };
+
+        let selected = select_executor(
+            &job_id,
+            &JobSpec::Echo { payload: "persist".into() },
+            vec![bid_a, bid_b],
+            &SelectionPolicy::default(),
+            &reopened,
+            &ledger,
+        )
+        .expect("executor selected");
+
+        assert_eq!(selected, did_a);
+    }
+}
+
+#[cfg(feature = "persist-rocksdb")]
+mod reputation_persistence_rocks {
+    use icn_common::{Cid, Did};
+    use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+    use icn_mesh::{select_executor, MeshJobBid, JobSpec, Resources, SelectionPolicy};
+    use icn_reputation::rocksdb_store::RocksdbReputationStore;
+    use icn_reputation::ReputationStore;
+    use icn_runtime::context::SimpleManaLedger;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn persisted_reputation_influences_selection() {
+        let dir = tempdir().unwrap();
+        let rep_path = dir.path().join("rep.rocks");
+        let mana_path = dir.path().join("mana.rocks");
+
+        let ledger = SimpleManaLedger::new(mana_path);
+        let store = RocksdbReputationStore::new(rep_path.clone()).unwrap();
+
+        let (_ska, vka) = generate_ed25519_keypair();
+        let did_a = Did::from_str(&did_key_from_verifying_key(&vka)).unwrap();
+        let (_skb, vkb) = generate_ed25519_keypair();
+        let did_b = Did::from_str(&did_key_from_verifying_key(&vkb)).unwrap();
+
+        ledger.set_balance(&did_a, 100).unwrap();
+        ledger.set_balance(&did_b, 100).unwrap();
+
+        store.record_execution(&did_a, true, 1000);
+        drop(store);
+
+        let reopened = RocksdbReputationStore::new(rep_path).unwrap();
+
+        let job_id = Cid::new_v1_sha256(0x55, b"rep_job");
+        let bid_a = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: did_a.clone(),
+            price_mana: 10,
+            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            signature: SignatureBytes(Vec::new()),
+        };
+        let bid_b = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: did_b.clone(),
+            price_mana: 10,
+            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            signature: SignatureBytes(Vec::new()),
+        };
+
+        let selected = select_executor(
+            &job_id,
+            &JobSpec::Echo { payload: "persist".into() },
+            vec![bid_a, bid_b],
+            &SelectionPolicy::default(),
+            &reopened,
+            &ledger,
+        )
+        .expect("executor selected");
+
+        assert_eq!(selected, did_a);
+    }
+}


### PR DESCRIPTION
## Summary
- support `persist-sqlite` and `persist-rocksdb` options
- implement `SqliteManaLedger` and `RocksdbManaLedger`
- add matching reputation stores
- allow runtime to select ledger/store backend via features
- extend integration tests for persistence

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: environment build too heavy)*
- `cargo test --all-features --workspace` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685fc016e1a08324966d4d140077351f