### PR TITLE
[icn-common] extend DagBlock metadata

### DIFF
--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -41,10 +41,17 @@ async fn submit_transaction_and_query_data() {
     assert_eq!(body["tx_id"], "tx-test");
 
     // Put a DAG block then query it
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, b"data"),
+        cid,
         data: b"data".to_vec(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     let put_url = format!("http://{addr}/dag/put");
     let res = client.post(&put_url).json(&block).send().await.unwrap();

--- a/crates/icn-common/tests/signable.rs
+++ b/crates/icn-common/tests/signable.rs
@@ -38,11 +38,24 @@ fn dagblock_sign_verify() {
         size: 5,
     };
     let data = b"parent".to_vec();
-    let cid = compute_merkle_cid(0x71, &data, std::slice::from_ref(&link));
+    let timestamp = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = compute_merkle_cid(
+        0x71,
+        &data,
+        std::slice::from_ref(&link),
+        timestamp,
+        &author,
+        &sig_opt,
+    );
     let block = DagBlock {
         cid,
         data,
         links: vec![link],
+        timestamp,
+        author_did: author,
+        signature: sig_opt,
     };
 
     let sig = block.sign(&sk).unwrap();

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -288,11 +288,17 @@ mod tests {
     // Helper function to create a test block
     fn create_test_block(id_str: &str) -> DagBlock {
         let data = format!("data for {id_str}").into_bytes();
-        let cid = Cid::new_v1_sha256(0x71, id_str.as_bytes());
+        let timestamp = 0u64;
+        let author = Did::new("key", "tester");
+        let sig = None;
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
         DagBlock {
             cid,
             data,
             links: vec![],
+            timestamp,
+            author_did: author,
+            signature: sig,
         }
     }
 
@@ -316,10 +322,17 @@ mod tests {
         // Test put overwrite (assuming implementations overwrite)
         let modified_block1_data =
             format!("modified data for {}", "block1_service_test").into_bytes();
+        let timestamp = 1u64;
+        let author = Did::new("key", "tester");
+        let sig = None;
+        let cid = compute_merkle_cid(0x71, &modified_block1_data, &[], timestamp, &author, &sig);
         let modified_block1 = DagBlock {
-            cid: block1.cid.clone(),
+            cid,
             data: modified_block1_data,
             links: vec![],
+            timestamp,
+            author_did: author,
+            signature: sig,
         };
         assert!(store.put(&modified_block1).is_ok());
         match store.get(&block1.cid) {
@@ -508,11 +521,24 @@ mod tests {
             name: "child".into(),
             size: 0,
         };
-        let parent_cid = compute_merkle_cid(0x71, b"parent", std::slice::from_ref(&link));
+        let timestamp = 0u64;
+        let author = Did::new("key", "tester");
+        let sig = None;
+        let parent_cid = compute_merkle_cid(
+            0x71,
+            b"parent",
+            std::slice::from_ref(&link),
+            timestamp,
+            &author,
+            &sig,
+        );
         let parent = DagBlock {
             cid: parent_cid.clone(),
             data: b"parent".to_vec(),
             links: vec![link],
+            timestamp,
+            author_did: author,
+            signature: sig,
         };
         index.index_block(&child);
         index.index_block(&parent);

--- a/crates/icn-dag/tests/rocks_backend.rs
+++ b/crates/icn-dag/tests/rocks_backend.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "persist-rocksdb")]
 mod tests {
-    use icn_common::{Cid, DagBlock};
+    use icn_common::{compute_merkle_cid, Cid, DagBlock, Did};
     use icn_dag::rocksdb_store::RocksDagStore;
     use icn_dag::StorageService;
     use std::path::PathBuf;
@@ -8,11 +8,17 @@ mod tests {
 
     fn create_block(id: &str) -> DagBlock {
         let data = format!("data {id}").into_bytes();
-        let cid = Cid::new_v1_sha256(0x71, id.as_bytes());
+        let timestamp = 0u64;
+        let author = Did::new("key", "tester");
+        let sig = None;
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
         DagBlock {
             cid,
             data,
             links: vec![],
+            timestamp,
+            author_did: author,
+            signature: sig,
         }
     }
 
@@ -24,10 +30,18 @@ mod tests {
         assert!(!store.contains(&b2.cid).unwrap());
         assert_eq!(store.get(&b1.cid).unwrap().unwrap().cid, b1.cid);
         assert!(store.get(&b2.cid).unwrap().is_none());
+        let mod_data = b"mod".to_vec();
+        let ts = 1u64;
+        let author = Did::new("key", "tester");
+        let sig = None;
+        let mod_cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig);
         let mod_block = DagBlock {
-            cid: b1.cid.clone(),
-            data: b"mod".to_vec(),
+            cid: mod_cid,
+            data: mod_data,
             links: vec![],
+            timestamp: ts,
+            author_did: author,
+            signature: sig,
         };
         assert!(store.put(&mod_block).is_ok());
         assert_eq!(store.get(&b1.cid).unwrap().unwrap().data, b"mod".to_vec());

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -794,10 +794,17 @@ async fn dag_put_handler(
     Json(block): Json<DagBlockPayload>,
 ) -> impl IntoResponse {
     // Use RuntimeContext's dag_store now
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = icn_common::compute_merkle_cid(0x71, &block.data, &[], ts, &author, &sig_opt);
     let dag_block = CoreDagBlock {
-        cid: Cid::new_v1_sha256(0x71, &block.data),
+        cid,
         data: block.data,
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     let mut store = state.runtime_context.dag_store.lock().await;
     match store.put(&dag_block) {
@@ -856,11 +863,17 @@ async fn contracts_post_handler(
         }
     };
 
-    let cid = icn_common::Cid::new_v1_sha256(0x71, &wasm);
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = CoreDagBlock {
         cid: cid.clone(),
         data: wasm,
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
 
     let block_json = match serde_json::to_string(&block) {

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -640,7 +640,10 @@ impl RuntimeContext {
         false
     }
 
-    pub async fn internal_queue_mesh_job(self: &Arc<Self>, job: ActualMeshJob) -> Result<(), HostAbiError> {
+    pub async fn internal_queue_mesh_job(
+        self: &Arc<Self>,
+        job: ActualMeshJob,
+    ) -> Result<(), HostAbiError> {
         let mut queue = self.pending_mesh_jobs.lock().await;
         queue.push_back(job.clone());
         let mut states = self.job_states.lock().await;
@@ -1045,10 +1048,27 @@ impl RuntimeContext {
             HostAbiError::InternalError(format!("Failed to serialize final receipt for DAG: {}", e))
         })?;
 
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let author = self.current_identity.clone();
+        let signature = None;
+        let cid = icn_common::compute_merkle_cid(
+            0x71,
+            &final_receipt_bytes,
+            &[],
+            timestamp,
+            &author,
+            &signature,
+        );
         let block = DagBlock {
-            cid: Cid::new_v1_sha256(0x71, &final_receipt_bytes),
+            cid,
             data: final_receipt_bytes,
             links: vec![],
+            timestamp,
+            author_did: author,
+            signature,
         };
         let mut store = self.dag_store.lock().await;
         store.put(&block).map_err(HostAbiError::Common)?;
@@ -1820,7 +1840,8 @@ mod tests {
         let result = env.env_submit_mesh_job(&ctx_arc, ptr, len);
         assert!(result.is_ok());
 
-        let mana_after = futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
+        let mana_after =
+            futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
         assert_eq!(mana_after, 90);
         let pending_len =
             futures::executor::block_on(async { ctx_arc.pending_mesh_jobs.lock().await.len() });
@@ -1853,7 +1874,8 @@ mod tests {
         let len = did_bytes.len() as u32;
         let result = env.env_account_spend_mana(&ctx_arc, ptr, len, 10);
         assert!(result.is_ok());
-        let mana = futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
+        let mana =
+            futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
         assert_eq!(mana, 10);
     }
 

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -304,10 +304,17 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let dag_store = get_dag_store(&arc_ctx_job_manager);
     let receipt_bytes =
         serde_json::to_vec(&retrieved_receipt).expect("Failed to serialize receipt");
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = compute_merkle_cid(0x71, &receipt_bytes, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &receipt_bytes),
+        cid,
         data: receipt_bytes,
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = dag_store.lock().await;

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -22,10 +22,17 @@ async fn wasm_executor_runs_wasm() {
         )
     )"#;
     let wasm_bytes = wat::parse_str(wasm).unwrap();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &wasm_bytes),
+        cid: cid.clone(),
         data: wasm_bytes,
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -57,10 +64,17 @@ async fn wasm_executor_runs_compiled_ccl_contract() {
 
     let source = "fn run() -> Integer { return 3 + 4; }";
     let (wasm, _) = icn_ccl::compile_ccl_source_to_wasm(source).unwrap();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &wasm),
+        cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -124,10 +138,17 @@ async fn wasm_executor_host_submit_mesh_job_json() {
     );
 
     let wasm_bytes = wat::parse_str(&wasm).unwrap();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &wasm_bytes),
+        cid: cid_calc.clone(),
         data: wasm_bytes,
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -183,10 +204,17 @@ async fn wasm_executor_host_anchor_receipt_json() {
     );
 
     let wasm_bytes = wat::parse_str(&wasm).unwrap();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &wasm_bytes),
+        cid: cid_calc.clone(),
         data: wasm_bytes,
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -219,10 +247,17 @@ async fn submit_compiled_ccl_runs_via_executor() {
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zEndToEnd", 5);
     let source = "fn run() -> Integer { return 9; }";
     let (wasm, _) = icn_ccl::compile_ccl_source_to_wasm(source).unwrap();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &wasm),
+        cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -255,10 +290,17 @@ async fn queued_compiled_ccl_executes() {
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zQueueExec", 5);
     let source = "fn run() -> Integer { return 4; }";
     let (wasm, _) = icn_ccl::compile_ccl_source_to_wasm(source).unwrap();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &wasm),
+        cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -166,10 +166,17 @@ async fn test_wasm_executor_with_ccl() {
     use icn_common::DagBlock;
 
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 10);
+    let ts = 0u64;
+    let author = icn_common::Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
-        cid: Cid::new_v1_sha256(0x71, &wasm),
+        cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -301,11 +308,17 @@ async fn test_wasm_executor_runs_addition() {
     use icn_common::DagBlock;
 
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zAddExecInt", 10);
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[]);
+    let ts = 0u64;
+    let author = icn_common::Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -37,11 +37,17 @@ async fn wasm_executor_runs_compiled_ccl() {
     let (wasm, _) = compile_ccl_source_to_wasm(source).expect("compile ccl");
 
     let ctx = ctx_with_temp_store("did:key:zWasmExec", 10);
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[]);
+    let ts = 0u64;
+    let author = icn_common::Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -81,11 +87,17 @@ async fn wasm_executor_runs_compiled_addition() {
     let (wasm, _) = compile_ccl_source_to_wasm(source).expect("compile ccl");
 
     let ctx = ctx_with_temp_store("did:key:zAddExec", 10);
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[]);
+    let ts = 0u64;
+    let author = icn_common::Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -125,11 +137,17 @@ async fn wasm_executor_fails_without_run() {
     let (wasm, _) = compile_ccl_source_to_wasm(source).expect("compile ccl");
 
     let ctx = ctx_with_temp_store("did:key:zWasmFail", 10);
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[]);
+    let ts = 0u64;
+    let author = icn_common::Did::new("key", "tester");
+    let sig_opt = None;
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -168,11 +186,17 @@ async fn compile_and_execute_simple_contract() {
     assert!(meta.exports.contains(&"run".to_string()));
 
     let ctx = ctx_with_temp_store("did:key:zSimple", 5);
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[]);
+    let ts = 0u64;
+    let author = icn_common::Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
         links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
     };
     {
         let mut store = ctx.dag_store.lock().await;


### PR DESCRIPTION
## Summary
- add timestamp, author DID, and signature to `DagBlock`
- update CID computation and integrity verification to hash these fields
- adjust storage tests for new metadata
- update node, runtime, API, and CLI usages of `DagBlock`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build took too long)*
- `cargo test --all-features --workspace` *(failed: build took too long)*


------
https://chatgpt.com/codex/tasks/task_e_685fc01686108324980ba66bdbd63f09