### PR TITLE
[icn-ccl] export memory for wasm modules

### DIFF
--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -640,7 +640,10 @@ impl RuntimeContext {
         false
     }
 
-    pub async fn internal_queue_mesh_job(self: &Arc<Self>, job: ActualMeshJob) -> Result<(), HostAbiError> {
+    pub async fn internal_queue_mesh_job(
+        self: &Arc<Self>,
+        job: ActualMeshJob,
+    ) -> Result<(), HostAbiError> {
         let mut queue = self.pending_mesh_jobs.lock().await;
         queue.push_back(job.clone());
         let mut states = self.job_states.lock().await;
@@ -1794,6 +1797,7 @@ impl MeshNetworkService for StubMeshNetworkService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use icn_identity::KeyDidResolver;
     use std::path::PathBuf;
     use std::sync::Arc;
     use tokio::sync::Mutex as TokioMutex;
@@ -1820,7 +1824,8 @@ mod tests {
         let result = env.env_submit_mesh_job(&ctx_arc, ptr, len);
         assert!(result.is_ok());
 
-        let mana_after = futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
+        let mana_after =
+            futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
         assert_eq!(mana_after, 90);
         let pending_len =
             futures::executor::block_on(async { ctx_arc.pending_mesh_jobs.lock().await.len() });
@@ -1853,7 +1858,8 @@ mod tests {
         let len = did_bytes.len() as u32;
         let result = env.env_account_spend_mana(&ctx_arc, ptr, len, 10);
         assert!(result.is_ok());
-        let mana = futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
+        let mana =
+            futures::executor::block_on(ctx_arc.get_mana(&ctx_arc.current_identity)).unwrap();
         assert_eq!(mana, 10);
     }
 

--- a/icn-ccl/src/wasm_backend.rs
+++ b/icn-ccl/src/wasm_backend.rs
@@ -23,6 +23,14 @@ impl WasmBackend {
         let mut codes = CodeSection::new();
         let mut exports = ExportSection::new();
         let mut export_names = Vec::new();
+        let mut memories = wasm_encoder::MemorySection::new();
+        memories.memory(wasm_encoder::MemoryType {
+            minimum: 1,
+            maximum: None,
+            memory64: false,
+            shared: false,
+            page_size_log2: None,
+        });
 
         let policy_items = match ast {
             AstNode::Policy(items) => items,
@@ -78,6 +86,11 @@ impl WasmBackend {
         }
         if functions.len() > 0 {
             module.section(&functions);
+        }
+        if memories.len() > 0 {
+            module.section(&memories);
+            exports.export("memory", ExportKind::Memory, 0);
+            export_names.push("memory".to_string());
         }
         if exports.len() > 0 {
             module.section(&exports);

--- a/icn-ccl/tests/contracts/example.ccl
+++ b/icn-ccl/tests/contracts/example.ccl
@@ -1,0 +1,3 @@
+fn run() -> Integer {
+    return 11;
+}


### PR DESCRIPTION
## Summary
- ensure icn-ccl WASM backend exports a default memory
- add example contract file for tests
- test running example contract through WasmExecutor
- fix missing `KeyDidResolver` import in runtime tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p icn-ccl --test integration_tests -- --test-threads=1`
- `cargo test -p icn-runtime --test wasm_executor -- --test-threads=1` *(fails: Cannot start a runtime from within a runtime)*

------
https://chatgpt.com/codex/tasks/task_e_685fc017e5d08324b64fb932607f71c1