### PR TITLE
[icn-node] support env config for tls and api key

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -440,6 +440,22 @@ async fn main() {
         NodeConfig::default()
     };
     config.apply_cli_overrides(&cli, &matches);
+    // Allow configuring API key and TLS paths via environment variables if
+    // they are not provided through CLI or config file.
+    if config.api_key.is_none() {
+        if let Ok(key) = std::env::var("ICN_HTTP_API_KEY") {
+            config.api_key = Some(key);
+        }
+    }
+    if config.tls_cert_path.is_none() && config.tls_key_path.is_none() {
+        if let (Ok(cert), Ok(key)) = (
+            std::env::var("ICN_TLS_CERT_PATH"),
+            std::env::var("ICN_TLS_KEY_PATH"),
+        ) {
+            config.tls_cert_path = Some(cert.into());
+            config.tls_key_path = Some(key.into());
+        }
+    }
     if let Err(e) = config.prepare_paths() {
         error!("Failed to prepare config directories: {}", e);
     }

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -15,6 +15,14 @@ icn-node --storage-backend memory --http-listen-addr 127.0.0.1:7845 \
 Providing certificate and key paths makes the server listen on HTTPS instead of HTTP.
 
 A sample TOML configuration is in `configs/single_node.toml`.
+You can also supply these values via configuration or environment variables:
+
+```toml
+http_listen_addr = "127.0.0.1:7845"
+api_key = "mylocalkey"
+tls_cert_path = "./cert.pem"
+tls_key_path = "./key.pem"
+```
 
 ## Small Federation
 
@@ -29,3 +37,14 @@ icn-node --storage-backend sqlite --storage-path ./icn_data/node1.sqlite \
 ```
 
 See `configs/small_federation.toml` for an example configuration file.
+A configuration file might contain:
+
+```toml
+http_listen_addr = "0.0.0.0:7845"
+storage_backend = "sqlite"
+storage_path = "./icn_data/node1.sqlite"
+bootstrap_peers = ["/ip4/1.2.3.4/tcp/7000/p2p/QmPeer"]
+api_key = "node1secret"
+tls_cert_path = "./cert.pem"
+tls_key_path = "./key.pem"
+```

--- a/icn-devnet/docker-compose.yml
+++ b/icn-devnet/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
       - ICN_ENABLE_P2P=true
       - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-a-key
+      - ICN_TLS_CERT_PATH=/app/certs/cert.pem
+      - ICN_TLS_KEY_PATH=/app/certs/key.pem
       - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
     ports:
       - "5001:7845"  # HTTP API
@@ -22,6 +25,7 @@ services:
       - icn-federation
     volumes:
       - node-a-data:/app/data
+      - ./certs:/app/certs:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7845/info"]
       interval: 30s
@@ -43,6 +47,9 @@ services:
       - ICN_ENABLE_P2P=true
       - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001/p2p/12D3KooWMihHnheYawaboC67SA9ZTG71DPfTiC8BphXz8PcojDdz
       - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-b-key
+      - ICN_TLS_CERT_PATH=/app/certs/cert.pem
+      - ICN_TLS_KEY_PATH=/app/certs/key.pem
       - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
     ports:
       - "5002:7845"  # HTTP API
@@ -51,6 +58,7 @@ services:
       - icn-federation
     volumes:
       - node-b-data:/app/data
+      - ./certs:/app/certs:ro
     depends_on:
       - icn-node-a
     healthcheck:
@@ -74,6 +82,9 @@ services:
       - ICN_ENABLE_P2P=true
       - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001/p2p/12D3KooWMihHnheYawaboC67SA9ZTG71DPfTiC8BphXz8PcojDdz
       - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-c-key
+      - ICN_TLS_CERT_PATH=/app/certs/cert.pem
+      - ICN_TLS_KEY_PATH=/app/certs/key.pem
       - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
     ports:
       - "5003:7845"  # HTTP API
@@ -82,6 +93,7 @@ services:
       - icn-federation
     volumes:
       - node-c-data:/app/data
+      - ./certs:/app/certs:ro
     depends_on:
       - icn-node-a
     healthcheck:


### PR DESCRIPTION
## Summary
- allow icn-node to read TLS certificate paths and API key from environment variables
- document secure mode with TLS in deployment guide
- show secure configuration in devnet docker-compose

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-node --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test -p icn-node` *(failed: tests could not run due to sled lock)*

------
https://chatgpt.com/codex/tasks/task_e_685fc01901c483249542a9fee7b8acda