### PR TITLE
[icn-node] add TLS auth tests and env docs

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -41,7 +41,8 @@ persist-sled = ["icn-dag/persist-sled"]
 persist-rocksdb = ["icn-dag/persist-rocksdb"]
 
 [dev-dependencies]
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["full"] }
 tempfile = "3"
 icn-ccl = { path = "../../icn-ccl" }
+rcgen = "0.9"

--- a/crates/icn-node/tests/auth.rs
+++ b/crates/icn-node/tests/auth.rs
@@ -1,5 +1,7 @@
 use icn_node::app_router_with_options;
+use rcgen::generate_simple_self_signed;
 use reqwest::Client;
+use tempfile::NamedTempFile;
 use tokio::task;
 
 #[tokio::test]
@@ -64,6 +66,70 @@ async fn bearer_token_required_for_requests() {
     let resp = client
         .get(&url)
         .header("Authorization", "Bearer s3cr3t")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn tls_api_key_and_bearer_token() {
+    let cert = generate_simple_self_signed(["localhost".to_string()]).unwrap();
+    let cert_pem = cert.serialize_pem().unwrap();
+    let key_pem = cert.serialize_private_key_pem();
+
+    let cert_file = NamedTempFile::new().unwrap();
+    let key_file = NamedTempFile::new().unwrap();
+    std::fs::write(cert_file.path(), cert_pem).unwrap();
+    std::fs::write(key_file.path(), key_pem).unwrap();
+
+    let (router, _ctx) = app_router_with_options(
+        Some("secret".into()),
+        Some("token".into()),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = std_listener.local_addr().unwrap();
+    let tls_config =
+        axum_server::tls_rustls::RustlsConfig::from_pem_file(cert_file.path(), key_file.path())
+            .await
+            .unwrap();
+    let server = task::spawn(async move {
+        axum_server::tls_rustls::from_tcp_rustls(std_listener, tls_config)
+            .serve(router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    let client = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+    let url = format!("https://{addr}/info");
+
+    let resp = client.get(&url).send().await.unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let resp = client
+        .get(&url)
+        .header("x-api-key", "secret")
+        .header("Authorization", "Bearer wrong")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let resp = client
+        .get(&url)
+        .header("x-api-key", "secret")
+        .header("Authorization", "Bearer token")
         .send()
         .await
         .unwrap();

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -270,6 +270,24 @@ server {
 This secures the HTTP API with TLS and passes the required `x-api-key` header to
 `icn-node`.
 
+### 3.7. Environment Variables
+
+`icn-node` can also read certain settings from the environment. This is useful
+when deploying in containerized environments or CI systems.
+
+* `ICN_HTTP_API_KEY` – sets the API key required in the `x-api-key` header.
+* `ICN_TLS_CERT_PATH` – path to a PEM encoded TLS certificate.
+* `ICN_TLS_KEY_PATH` – path to the matching PEM private key.
+
+Example usage:
+
+```bash
+export ICN_HTTP_API_KEY=mysecretkey
+export ICN_TLS_CERT_PATH=/etc/ssl/certs/icn.pem
+export ICN_TLS_KEY_PATH=/etc/ssl/private/icn.key
+cargo run -p icn-node
+```
+
 ## 4. Understanding the Codebase
 
 *   **Workspace Root (`Cargo.toml`):** Defines the workspace members (all the crates).


### PR DESCRIPTION
## Summary
- ensure reqwest supports TLS in icn-node tests
- verify API key and bearer token over HTTPS
- document ICN_HTTP_API_KEY, ICN_TLS_CERT_PATH and ICN_TLS_KEY_PATH

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: the workspace does not compile with all features)*
- `cargo test -p icn-node --all-features -- --nocapture` *(failed to complete due to build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685fe818b0d0832482750cc5eff2d4d2