### PR TITLE
[governance] add execution callbacks and tally command

### DIFF
--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -123,6 +123,11 @@ enum GovernanceCommands {
         #[clap(help = "Vote casting request as a JSON string (ApiCastVoteRequest format)")]
         vote_request_json: String,
     },
+    /// Tally votes and close a proposal
+    Tally {
+        #[clap(help = "ID of the proposal to tally and close")]
+        id: String,
+    },
     /// List all proposals
     Proposals,
     /// Get a specific proposal by its ID
@@ -211,6 +216,7 @@ async fn run_command(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
             GovernanceCommands::Vote { vote_request_json } => {
                 handle_gov_vote(cli, client, vote_request_json).await?
             }
+            GovernanceCommands::Tally { id } => handle_gov_tally(cli, client, id).await?,
             GovernanceCommands::Proposals => handle_gov_list_proposals(cli, client).await?,
             GovernanceCommands::Proposal { id } => handle_gov_get_proposal(cli, client, id).await?,
         },
@@ -395,6 +401,17 @@ async fn handle_gov_vote(
         "Vote response: {}",
         serde_json::to_string_pretty(&response)?
     );
+    Ok(())
+}
+
+async fn handle_gov_tally(
+    cli: &Cli,
+    client: &Client,
+    proposal_id: &str,
+) -> Result<(), anyhow::Error> {
+    let req = serde_json::json!({ "proposal_id": proposal_id });
+    let status: String = post_request(&cli.api_url, client, "/governance/close", &req).await?;
+    println!("Tally result: {}", status);
     Ok(())
 }
 

--- a/crates/icn-cli/tests/cli.rs
+++ b/crates/icn-cli/tests/cli.rs
@@ -140,5 +140,24 @@ async fn governance_endpoints() {
     .await
     .unwrap();
 
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base_tally = format!("http://{addr}");
+    let pid_for_tally = pid.clone();
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args([
+                "--api-url",
+                &base_tally,
+                "governance",
+                "tally",
+                &pid_for_tally,
+            ])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("Accepted"));
+    })
+    .await
+    .unwrap();
+
     server.abort();
 }

--- a/crates/icn-governance/tests/callback.rs
+++ b/crates/icn-governance/tests/callback.rs
@@ -1,0 +1,42 @@
+use icn_common::Did;
+use icn_governance::{GovernanceModule, ProposalStatus, ProposalType, VoteOption};
+use std::str::FromStr;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+#[test]
+fn callback_runs_on_execute() {
+    let executed = Arc::new(AtomicBool::new(false));
+    let mut gov = GovernanceModule::new();
+    let flag = executed.clone();
+    gov.set_callback(move |_p| {
+        flag.store(true, Ordering::SeqCst);
+        Ok(())
+    });
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.set_quorum(2);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("hi".into()),
+            "test".into(),
+            60,
+        )
+        .unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:bob").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    assert_eq!(
+        gov.close_voting_period(&pid).unwrap(),
+        ProposalStatus::Accepted
+    );
+    gov.execute_proposal(&pid).unwrap();
+    assert!(executed.load(Ordering::SeqCst));
+}


### PR DESCRIPTION
## Summary
- extend governance module with proposal execution callbacks
- hook icn-node to apply `open_rate_limit` changes on accepted proposals
- expose `/governance/close` and `/governance/execute` endpoints
- add CLI `tally` command
- test callback execution

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build dependencies missing)*
- `cargo test --all-features --workspace` *(fails: build dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685fe81bcddc832490bafd96371231e0