### PR TITLE
[runtime] add rocksdb persistence

### DIFF
--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -23,7 +23,7 @@ rusqlite = { version = "0.29", optional = false, features = ["bundled"] }
 rocksdb = { version = "0.21", optional = false }
 
 [features]
-default = ["persist-sled"]
+default = ["persist-rocksdb"]
 persist-sled = ["dep:sled", "dep:bincode"]
 persist-sqlite = ["dep:rusqlite"]
 persist-rocksdb = ["dep:rocksdb", "dep:bincode"]

--- a/crates/icn-economics/Cargo.toml
+++ b/crates/icn-economics/Cargo.toml
@@ -24,7 +24,7 @@ sled = { version = "0.34" }
 bincode = "1.3"
 
 [features]
-default = ["persist-sled"]
+default = ["persist-rocksdb"]
 persist-sled = ["dep:sled", "dep:bincode"]
 persist-sqlite = ["dep:rusqlite"]
 persist-rocksdb = ["dep:rocksdb", "dep:bincode"]

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -48,7 +48,7 @@ Below is a minimal example in TOML (the same keys can be used in YAML):
 ```toml
 node_name = "Local Node"
 http_listen_addr = "127.0.0.1:8080"
-storage_backend = "file"
+storage_backend = "rocksdb"
 storage_path = "./icn_data/node_store"
 mana_ledger_path = "./mana_ledger.sled"
 node_did_path = "./icn_data/node_did.txt"
@@ -67,7 +67,7 @@ Useful CLI flags include:
 
 * `--node-did-path <PATH>` – location to read/write the node DID string
 * `--node-private-key-path <PATH>` – location to read/write the node private key
-* `--storage-backend <memory|file|sqlite>` – choose the DAG storage backend
+* `--storage-backend <memory|file|sqlite|rocksdb>` – choose the DAG storage backend
 * `--storage-path <PATH>` – directory for the file or SQLite backends
 * `--mana-ledger-path <PATH>` – location of the mana ledger database
 * `--governance-db-path <PATH>` – location to persist governance proposals and votes

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -239,8 +239,8 @@ Caddy).
 # node_config.toml
 node_name = "Federation Node"
 http_listen_addr = "0.0.0.0:7845"        # Behind a TLS proxy
-storage_backend = "sqlite"
-storage_path = "./icn_data/node.sqlite"
+storage_backend = "rocksdb"
+storage_path = "./icn_data/node.rocks"
 api_key = "mysecretkey"
 open_rate_limit = 0
 ```

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -30,7 +30,7 @@ For a small group of cooperating nodes, each node may use a persistent store and
 bootstrap to known peers.
 
 ```bash
-icn-node --storage-backend sqlite --storage-path ./icn_data/node1.sqlite \
+icn-node --storage-backend rocksdb --storage-path ./icn_data/node1.rocks \
          --bootstrap-peers /ip4/1.2.3.4/tcp/7000/p2p/QmPeer \
          --api-key node1secret --open-rate-limit 0 \
          --tls-cert-path ./cert.pem --tls-key-path ./key.pem
@@ -41,8 +41,8 @@ A configuration file might contain:
 
 ```toml
 http_listen_addr = "0.0.0.0:7845"
-storage_backend = "sqlite"
-storage_path = "./icn_data/node1.sqlite"
+storage_backend = "rocksdb"
+storage_path = "./icn_data/node1.rocks"
 bootstrap_peers = ["/ip4/1.2.3.4/tcp/7000/p2p/QmPeer"]
 api_key = "node1secret"
 tls_cert_path = "./cert.pem"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,6 +15,10 @@ path = "integration/libp2p_job_pipeline.rs"
 name = "network_resilience"
 path = "integration/network_resilience.rs"
 
+[[test]]
+name = "persistence"
+path = "integration/persistence.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true

--- a/tests/integration/persistence.rs
+++ b/tests/integration/persistence.rs
@@ -1,0 +1,66 @@
+#[cfg(feature = "persist-rocksdb")]
+mod persistence_rocksdb {
+    use icn_common::{compute_merkle_cid, DagBlock, Did};
+    use icn_runtime::context::{RuntimeContext, StubMeshNetworkService, StubSigner};
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn sample_block() -> DagBlock {
+        let data = b"hello".to_vec();
+        let timestamp = 0u64;
+        let author = Did::new("key", "tester");
+        let sig = None;
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        DagBlock {
+            cid,
+            data,
+            links: vec![],
+            timestamp,
+            author_did: author,
+            signature: sig,
+        }
+    }
+
+    #[tokio::test]
+    async fn ledger_and_dag_survive_restart() {
+        let dir = tempdir().unwrap();
+        let dag_path = dir.path().join("dag.rocks");
+        let mana_path = dir.path().join("mana.rocks");
+        let rep_path = dir.path().join("rep.rocks");
+
+        let id = Did::new("key", "tester");
+        let ctx1 = RuntimeContext::new_with_paths(
+            id.clone(),
+            Arc::new(StubMeshNetworkService::new()),
+            Arc::new(StubSigner::new()),
+            Arc::new(icn_identity::KeyDidResolver),
+            dag_path.clone(),
+            mana_path.clone(),
+            rep_path.clone(),
+        );
+
+        ctx1.credit_mana(&id, 42).await.unwrap();
+        let block = sample_block();
+        ctx1.dag_store.lock().await.put(&block).unwrap();
+        drop(ctx1);
+
+        let ctx2 = RuntimeContext::new_with_paths(
+            id.clone(),
+            Arc::new(StubMeshNetworkService::new()),
+            Arc::new(StubSigner::new()),
+            Arc::new(icn_identity::KeyDidResolver),
+            dag_path,
+            mana_path,
+            rep_path,
+        );
+
+        assert_eq!(ctx2.mana_ledger.get_balance(&id), 42);
+        assert!(ctx2
+            .dag_store
+            .lock()
+            .await
+            .get(&block.cid)
+            .unwrap()
+            .is_some());
+    }
+}


### PR DESCRIPTION
## Summary
- enable rocksdb by default for `icn-dag` and `icn-economics`
- add `RuntimeContext::new_with_paths` for persistent DAG/ledger
- document rocksdb configuration in docs
- integration test for persistence using rocksdb backend

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build timeout)*
- `cargo test --all-features --workspace persistence -- --nocapture` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685fe815037c8324a7662621f48e3a82