### PR TITLE
[docs] summarize phases and document HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,38 +133,16 @@ All interactions within this project are governed by our [Code of Conduct](CODE_
 
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
 
-## Next Milestones
+## Completed Phases & Next Steps
 
-The following are high-level milestones for the development of ICN Core. These are subject to change and community input.
+Development has progressed through several major phases:
 
-1.  **Foundation & Basic APIs (Q1-Q2 202X)**
-    *   Solidify `icn-common` with core data types (DIDs, CIDs, robust errors).
-    *   Implement initial JSON-RPC/gRPC skeletons in `icn-api` for basic node interaction (e.g., status, identity query).
-    *   Develop basic DID management in `icn-identity` (generation, simple resolution).
-    *   Set up basic node persistence for configuration and identity keys in `icn-node`.
+1. **Phase&nbsp;1 – libp2p Integration**: real networking replaced the early stubs and `RuntimeContext` gained methods for joining the mesh.
+2. **Phase&nbsp;2A – Multi‑Node CLI**: nodes can be launched with libp2p enabled and discovered via bootstrap peers.
+3. **Phase&nbsp;2B – Cross‑Node Mesh Jobs**: distributed job execution is verified with cryptographically signed receipts.
+4. **Phase&nbsp;3 – HTTP Gateway**: all runtime functionality is accessible over REST endpoints.
+5. **Phase&nbsp;4 – Federation Devnet**: containerized devnet demonstrating a three‑node federation.
 
-2.  **Networking & Basic DAG (Q2-Q3 202X)**
-    *   Wire up basic libp2p stack in `icn-network` (peer discovery, basic pub/sub or request-response).
-    *   Implement initial in-memory `icn-dag` store with put/get operations for CIDs.
-    *   `icn-node` can connect to a bootstrap peer and exchange basic messages.
-    *   `icn-cli` can make basic API calls to a running node over the network (local for now).
-
-3.  **Core Protocols - Governance & Economics (Q3-Q4 202X)**
-    *   Define and implement basic proposal submission and voting logic in `icn-governance`.
-    *   Define basic token structures and transfer logic in `icn-economics` (in-memory ledger initially).
-    *   Integrate governance and economics actions into `icn-api` and `icn-node`.
-
-4.  **Runtime & Mesh (Q4 202X - Q1 202Y)**
-    *   Integrate a WASM runtime into `icn-runtime`.
-    *   Define initial host functions for WASM contracts to interact with node services (DAG, identity, economics).
-    *   Basic job definition and local execution PoC in `icn-mesh`.
-
-5.  **Federation & Advanced Features (202Y Onwards)**
-    *   Implement initial federation sync protocols in `icn-network` and `icn-protocol`.
-    *   Advanced DAG features (e.g., selectors, sharding considerations).
-    *   More sophisticated governance and economic models.
-    *   Full `icn-mesh` job scheduling and distributed execution.
-
-This roadmap will be refined into more detailed issues on GitHub. Community feedback is highly encouraged!
-
-For an up-to-date list of outstanding tasks, see the [open issues](https://github.com/InterCooperative/icn-core/issues) on GitHub. Contributions are welcome!
+Future planning and outstanding tasks are tracked on the
+[issue tracker](https://github.com/InterCooperative/icn-core/issues).
+Community feedback and contributions are always welcome!

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -16,9 +16,9 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
 *   **DAG Operations:**
     *   `icn-cli dag put <DAG_BLOCK_JSON_STRING>`: Submits a new DagBlock to the node. The block data must be provided as a complete JSON string.
     *   `icn-cli dag get <CID_JSON_STRING>`: Retrieves a DagBlock from the node by its CID. The CID must be provided as a JSON string.
-*   **Network Operations (Stubbed):**
-    *   `icn-cli network discover-peers`: Simulates peer discovery through the connected node. (Currently uses a stubbed network service).
-    *   `icn-cli network send-message <PEER_ID> <MESSAGE_JSON>`: Simulates sending a `NetworkMessage` to a specified peer. The peer ID is a string, and the message is a JSON representation of a `NetworkMessage` variant (e.g., `RequestBlock`, `AnnounceBlock`). (Currently uses a stubbed network service).
+*   **Network Operations:**
+    *   `icn-cli network discover-peers`: Query the connected node for peers. With the `with-libp2p` feature enabled the node will perform real discovery via libp2p.
+    *   `icn-cli network send-message <PEER_ID> <MESSAGE_JSON>`: Send a `NetworkMessage` to a specified peer. Requires the node to run with libp2p networking.
 *   **Miscellaneous:**
     *   `icn-cli hello`: A simple command to check if the CLI is responsive.
     *   `icn-cli help` or `icn-cli --help`: Displays usage information.

--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -1,7 +1,7 @@
 # ICN Network (`icn-network`)
 
 This crate manages peer-to-peer (P2P) networking aspects for the InterCooperative Network (ICN).
-It defines the core networking abstractions, message types, and service interfaces. The initial implementation includes a stubbed network service for testing and development, with plans to integrate a full P2P stack (e.g., using libp2p) under a feature flag.
+It defines the core networking abstractions, message types, and service interfaces. A lightweight stub service is available for tests, while production builds enable a libp2p-based implementation via the `libp2p` feature.
 
 ## Purpose
 
@@ -54,11 +54,11 @@ discovery via the DHT.
 
 ## Public API Style
 
-This crate provides: 
+This crate provides:
 *   Data structures (`PeerId`, `NetworkMessage`).
 *   A core trait (`NetworkService`) for P2P interactions.
-*   A concrete stub implementation (`StubNetworkService`) for testing and initial development.
-*   With the `libp2p` feature enabled, DHT record APIs (`get_kademlia_record` and `put_kademlia_record`) for storing service advertisements and DID documents.
+*   A concrete stub implementation (`StubNetworkService`) for testing.
+*   With the `libp2p` feature enabled, a full `Libp2pNetworkService` and DHT record APIs (`get_kademlia_record` and `put_kademlia_record`).
 
 The API aims for modularity, allowing different P2P backends to be integrated by implementing the `NetworkService` trait.
 
@@ -67,7 +67,7 @@ The API aims for modularity, allowing different P2P backends to be integrated by
 Please refer to the main `CONTRIBUTING.md` in the root of the `icn-core` repository.
 
 Key areas for future contributions:
-*   Implementing a `Libp2pNetworkService` that utilizes the `libp2p` stack (under the `libp2p` feature).
+*   Extending the existing `Libp2pNetworkService` and refining peer discovery.
 *   Defining and implementing robust peer discovery mechanisms.
 *   Implementing secure and efficient message serialization and transport.
 *   Adding support for various transport protocols.

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -21,11 +21,10 @@ The `main.rs` in this crate currently serves as a demonstration of integrating a
 
 1.  **Node Information & Status:** Calls `icn-api` functions (`get_node_info`, `get_node_status`) to retrieve and display node details. It demonstrates handling both successful calls and simulated error conditions (e.g., node offline).
 2.  **DAG Operations:** Demonstrates submitting a sample `DagBlock` to the local DAG store (via `icn-api` which uses `icn-dag`) and then retrieving it.
-3.  **Network Operations (Stubbed):**
-    *   Initializes a `StubNetworkService` from the `icn-network` crate.
-    *   Simulates peer discovery by calling `discover_peers`.
-    *   Simulates submitting another `DagBlock` and then broadcasting its announcement using `broadcast_message`.
-    *   Demonstrates sending a direct `RequestBlock` message to a (discovered) stubbed peer using `send_message`.
+3.  **Network Operations:**
+    *   When built with `with-libp2p`, the node spawns a real `Libp2pNetworkService` and discovers peers via bootstrap addresses.
+    *   Demonstrates submitting another `DagBlock` and broadcasting its announcement using `broadcast_message`.
+    *   Demonstrates sending a direct `RequestBlock` message to a discovered peer using `send_message`.
 
 All operations show how results and errors from the API and underlying services are handled and printed to the console.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,24 @@
+# ICN HTTP API
+
+The ICN node exposes a REST interface. All endpoints require the configured `x-api-key` header if an API key is set. If an `auth_token` is configured, requests must also include `Authorization: Bearer <token>`. When no API key is set the `--open-rate-limit` option controls the number of unauthenticated requests allowed per minute.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/info` | Node metadata including version and name |
+| GET | `/status` | Current node health and peer connectivity |
+| POST | `/dag/put` | Store a content-addressed block |
+| POST | `/dag/get` | Retrieve a block by CID |
+| POST | `/transaction/submit` | Submit a transaction to be processed |
+| POST | `/data/query` | Query stored data |
+| POST | `/governance/submit` | Submit a governance proposal |
+| POST | `/governance/vote` | Cast a vote on a proposal |
+| GET | `/governance/proposals` | List all proposals |
+| GET | `/governance/proposal/:id` | Fetch a specific proposal |
+| POST | `/mesh/submit` | Submit a mesh job for distributed execution |
+| GET | `/mesh/jobs` | List all mesh jobs |
+| GET | `/mesh/jobs/:job_id` | Get the status of a job |
+| POST | `/mesh/receipts` | Submit an execution receipt |
+| POST | `/contracts` | Upload or update a WASM contract |
+| GET | `/federation/peers` | List known federation peers |
+| POST | `/federation/peers` | Add a federation peer |
+

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -226,7 +226,7 @@ This section provides examples for all major `icn-cli` commands. Ensure an `icn-
       cargo run -p icn-cli -- governance proposal "did:example:proposer123:Increase ma:1678886400"
       ```
 
-(Note: The old network examples are removed as they were stubbed and not part of the core HTTP API requirements in the prompt.)
+(Note: Early examples relied on a stub network service. These were removed once real libp2p networking became available.)
 
 ### 3.6. Example `icn-node` Configuration with TLS and API Keys
 
@@ -332,7 +332,7 @@ The system now has a foundational HTTP API and CLI client.
 Immediate next steps from the original prompt include:
 
 *   **Persistence Backends:** While `icn-node` supports a file backend for `DagStorageService`, implementing a `sled` backend is a next step. `GovernanceModule` currently uses in-memory storage; this needs a pluggable persistence strategy similar to `DagStorageService`.
-*   **Real Networking (Libp2p):** The current focus was on the HTTP API. Integrating `libp2p` for true P2P federation remains a larger goal.
+*   **Networking (Libp2p):** libp2p support is now available. Future work focuses on refining peer discovery and federation protocols.
 *   **Configuration:** Advanced configuration file support for `icn-node` (beyond CLI args).
 *   **Identity Implementation:** Further flesh out DID methods and cryptographic primitives in `icn-identity`.
 *   **Testing:** Enhance test coverage, especially integration tests for the node-cli interaction and endpoint tests for `icn-node`.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -2,6 +2,8 @@
 
 This guide provides minimal examples for launching `icn-node` in common scenarios.
 
+For details on the HTTP API exposed by the node see [API.md](API.md).
+
 ## Single Node Local
 
 This mode runs a standalone node for development or testing.


### PR DESCRIPTION
## Summary
- update main README to describe completed milestones
- clarify networking notes in various READMEs
- create `docs/API.md` enumerating HTTP endpoints
- link API reference from deployment guide
- remove outdated stub references in onboarding guide

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not compile `icn-dag`)*
- `cargo test --all-features --workspace` *(terminated after long build time)*

------
https://chatgpt.com/codex/tasks/task_e_685fe8173a44832489b0677e6d70e568