### PR TITLE
[icn-economics] gate sled ledger feature

### DIFF
--- a/crates/icn-economics/src/ledger.rs
+++ b/crates/icn-economics/src/ledger.rs
@@ -135,6 +135,7 @@ impl crate::ManaLedger for FileManaLedger {
 
 // --- Persistent Sled-based Mana Ledger ---
 
+#[cfg(feature = "persist-sled")]
 #[derive(Debug)]
 pub struct SledManaLedger {
     tree: sled::Tree,
@@ -150,6 +151,7 @@ pub mod rocksdb;
 #[cfg(feature = "persist-rocksdb")]
 pub use rocksdb::RocksdbManaLedger;
 
+#[cfg(feature = "persist-sled")]
 impl SledManaLedger {
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let db = sled::open(path)
@@ -189,6 +191,7 @@ impl SledManaLedger {
     }
 }
 
+#[cfg(feature = "persist-sled")]
 impl crate::ManaLedger for SledManaLedger {
     fn get_balance(&self, did: &Did) -> u64 {
         self.read_balance(did).unwrap_or(0)

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -7,11 +7,13 @@
 
 use icn_common::{CommonError, Did, NodeInfo};
 mod ledger;
+pub use ledger::FileManaLedger;
 #[cfg(feature = "persist-rocksdb")]
 pub use ledger::RocksdbManaLedger;
+#[cfg(feature = "persist-sled")]
+pub use ledger::SledManaLedger;
 #[cfg(feature = "persist-sqlite")]
 pub use ledger::SqliteManaLedger;
-pub use ledger::{FileManaLedger, SledManaLedger};
 
 /// Errors that can occur during mana accounting operations.
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- gate `SledManaLedger` behind `persist-sled` feature
- avoid exposing sled-based ledger unless the feature is enabled

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build took too long)*
- `cargo test --all-features --workspace` *(failed: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_685ff363cdfc8324913dc3a17f7c3856