### PR TITLE
[economics] add CommonError conversion

### DIFF
--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -1,4 +1,4 @@
-use icn_common::{Cid, DagBlock, Did, Transaction};
+use icn_common::{compute_merkle_cid, Cid, DagBlock, Did, Transaction};
 use icn_node::app_router;
 use reqwest::StatusCode;
 use tokio::task;

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -282,6 +282,7 @@ pub fn process_dag_related_data(info: &NodeInfo) -> Result<String, CommonError> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use icn_common::Did;
     // For test setup
     use tempfile::tempdir; // For FileDagStore tests
 

--- a/crates/icn-dag/tests/rocks_backend.rs
+++ b/crates/icn-dag/tests/rocks_backend.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "persist-rocksdb")]
 mod tests {
-    use icn_common::{compute_merkle_cid, Cid, DagBlock, Did};
+    use icn_common::{compute_merkle_cid, DagBlock, Did};
     use icn_dag::rocksdb_store::RocksDagStore;
     use icn_dag::StorageService;
     use std::path::PathBuf;

--- a/crates/icn-dag/tests/sled_backend.rs
+++ b/crates/icn-dag/tests/sled_backend.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "persist-sled")]
 mod tests {
-    use icn_common::{compute_merkle_cid, Cid, DagBlock, Did};
+    use icn_common::{compute_merkle_cid, DagBlock, Did};
     use icn_dag::sled_store::SledDagStore;
     use icn_dag::StorageService;
     use tempfile::tempdir;

--- a/crates/icn-dag/tests/sqlite_backend.rs
+++ b/crates/icn-dag/tests/sqlite_backend.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "persist-sqlite")]
 mod tests {
-    use icn_common::{compute_merkle_cid, Cid, DagBlock, Did};
+    use icn_common::{compute_merkle_cid, DagBlock, Did};
     use icn_dag::sqlite_store::SqliteDagStore;
     use icn_dag::StorageService;
     use std::path::PathBuf;

--- a/crates/icn-economics/src/ledger.rs
+++ b/crates/icn-economics/src/ledger.rs
@@ -140,16 +140,6 @@ pub struct SledManaLedger {
     tree: sled::Tree,
 }
 
-#[cfg(feature = "persist-sqlite")]
-pub mod sqlite;
-#[cfg(feature = "persist-sqlite")]
-pub use sqlite::SqliteManaLedger;
-
-#[cfg(feature = "persist-rocksdb")]
-pub mod rocksdb;
-#[cfg(feature = "persist-rocksdb")]
-pub use rocksdb::RocksdbManaLedger;
-
 impl SledManaLedger {
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let db = sled::open(path)

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -21,6 +21,12 @@ pub enum EconError {
     PolicyViolation(String),
 }
 
+impl From<CommonError> for EconError {
+    fn from(err: CommonError) -> Self {
+        EconError::AdapterError(err.to_string())
+    }
+}
+
 /// Abstraction over the persistence layer storing account balances.
 pub trait ManaLedger: Send + Sync {
     /// Retrieve the mana balance for a DID.

--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -113,13 +113,28 @@ enum Backend {
 }
 
 /// Manages governance proposals and voting.
-#[derive(Debug)] // Removed Default, as `new` is now more explicit
 pub struct GovernanceModule {
     backend: Backend,
     members: HashSet<Did>,
     quorum: usize,
     threshold: f32,
+    #[allow(clippy::type_complexity)]
     proposal_callback: Option<Box<dyn Fn(&Proposal) -> Result<(), CommonError> + Send + Sync>>,
+}
+
+impl std::fmt::Debug for GovernanceModule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GovernanceModule")
+            .field("backend", &self.backend)
+            .field("members", &self.members)
+            .field("quorum", &self.quorum)
+            .field("threshold", &self.threshold)
+            .field(
+                "proposal_callback",
+                &self.proposal_callback.as_ref().map(|_| "<callback>"),
+            )
+            .finish()
+    }
 }
 
 impl GovernanceModule {

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -402,9 +402,10 @@ pub async fn app_router_with_options(
             {
                 if param == "open_rate_limit" {
                     if let Some(ref limiter) = rate_opt {
-                        let new_lim: u64 = value
-                            .parse()
-                            .map_err(|e| CommonError::InvalidInputError(e.to_string()))?;
+                        let new_lim: u64 =
+                            value.parse().map_err(|e: std::num::ParseIntError| {
+                                CommonError::InvalidInputError(e.to_string())
+                            })?;
                         handle.block_on(async {
                             let mut data = limiter.lock().await;
                             data.limit = new_lim;
@@ -722,9 +723,10 @@ async fn main() {
             {
                 if param == "open_rate_limit" {
                     if let Some(ref limiter) = rate_opt {
-                        let new_lim: u64 = value
-                            .parse()
-                            .map_err(|e| CommonError::InvalidInputError(e.to_string()))?;
+                        let new_lim: u64 =
+                            value.parse().map_err(|e: std::num::ParseIntError| {
+                                CommonError::InvalidInputError(e.to_string())
+                            })?;
                         handle.block_on(async {
                             let mut data = limiter.lock().await;
                             data.limit = new_lim;

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -16,12 +16,14 @@ use icn_network::{NetworkMessage, NetworkService as ActualNetworkService};
 )))]
 use icn_economics::FileManaLedger;
 #[cfg(feature = "persist-rocksdb")]
+#[allow(unused_imports)]
 use icn_economics::RocksdbManaLedger;
 #[cfg(feature = "persist-sled")]
 use icn_economics::SledManaLedger;
 #[cfg(feature = "persist-sqlite")]
+#[allow(unused_imports)]
 use icn_economics::SqliteManaLedger;
-use icn_economics::{EconError, ManaLedger, ManaRepositoryAdapter};
+use icn_economics::{EconError, ManaRepositoryAdapter};
 use log::{debug, error, info, warn};
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
@@ -75,6 +77,7 @@ pub trait Signer: Send + Sync + std::fmt::Debug {
 }
 
 use icn_dag::StorageService as DagStorageService;
+#[allow(unused_imports)]
 use icn_dag::{rocksdb_store::RocksDagStore, FileDagStore};
 
 // Placeholder for icn_economics::ManaRepository
@@ -2033,7 +2036,7 @@ mod tests {
     async fn test_wait_for_and_process_receipt_updates_mana_and_reputation() {
         let (sk, vk) = generate_ed25519_keypair();
         let did = did_key_from_verifying_key(&vk);
-        let signer = Arc::new(StubSigner::new_with_keys(sk.clone(), vk.clone()));
+        let signer = Arc::new(StubSigner::new_with_keys(sk.clone(), vk));
         let ctx = RuntimeContext::new_with_ledger_path(
             Did::from_str(&did).unwrap(),
             Arc::new(StubMeshNetworkService::new()),

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -6,7 +6,7 @@
 )]
 // crates/icn-runtime/tests/mesh.rs
 
-use icn_common::{Cid, Did};
+use icn_common::{compute_merkle_cid, Cid, Did};
 use icn_dag::StorageService;
 use icn_identity::{ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes};
 use icn_mesh::{ActualMeshJob, JobId, JobSpec, JobState, MeshJobBid, Resources};


### PR DESCRIPTION
## Summary
- convert `CommonError` to `EconError`
- remove duplicate exports in mana ledger
- manually implement `Debug` for `GovernanceModule`
- fix clippy warnings about unused imports
- make unit tests compile by importing helpers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_685ff3632de4832497228e63681a414b