### PR TITLE
[icn-economics] fix sled ledger deserialization

### DIFF
--- a/crates/icn-economics/src/ledger.rs
+++ b/crates/icn-economics/src/ledger.rs
@@ -179,7 +179,7 @@ impl SledManaLedger {
             .get(account.to_string())
             .map_err(|e| CommonError::DatabaseError(format!("Failed to read balance: {e}")))?
         {
-            let amt: u64 = bincode::deserialize(&val).map_err(|e| {
+            let amt: u64 = bincode::deserialize(val.as_ref()).map_err(|e| {
                 CommonError::DeserializationError(format!("Failed to deserialize balance: {e}"))
             })?;
             Ok(amt)


### PR DESCRIPTION
## Summary
- fix sled ledger deserialization with `val.as_ref()`

## Testing
- `cargo check -p icn-economics --no-default-features --features persist-sled`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not complete within resource limits)*
- `cargo test --all-features --workspace` *(failed: could not complete within resource limits)*

------
https://chatgpt.com/codex/tasks/task_e_685ff361f1d483249b461e580aa3de60