### PR TITLE
[economics] deduplicate ledger persistence mods

### DIFF
--- a/crates/icn-economics/src/ledger.rs
+++ b/crates/icn-economics/src/ledger.rs
@@ -140,16 +140,6 @@ pub struct SledManaLedger {
     tree: sled::Tree,
 }
 
-#[cfg(feature = "persist-sqlite")]
-pub mod sqlite;
-#[cfg(feature = "persist-sqlite")]
-pub use sqlite::SqliteManaLedger;
-
-#[cfg(feature = "persist-rocksdb")]
-pub mod rocksdb;
-#[cfg(feature = "persist-rocksdb")]
-pub use rocksdb::RocksdbManaLedger;
-
 impl SledManaLedger {
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let db = sled::open(path)


### PR DESCRIPTION
## Summary
- remove duplicate `sqlite` and `rocksdb` mod declarations
- keep single feature-gated exports for each persistence backend

## Testing
- `cargo fmt --all -- --check`
- ❌ `cargo clippy --all-targets --all-features -- -D warnings`
- ❌ `cargo test --all-features --workspace`

------
https://chatgpt.com/codex/tasks/task_e_685ff3646e2c832484a0daa8d14e0eea