### PR TITLE
[runtime] execute CCL WASM jobs

### DIFF
--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -776,7 +776,9 @@ impl RuntimeContext {
         states.insert(job.id.clone(), JobState::Pending);
         println!("[CONTEXT] Queued mesh job: id={:?}, state=Pending", job.id);
 
-        if self.manifest_is_ccl_wasm(&job.manifest_cid).await {
+        if matches!(job.spec.kind, icn_mesh::JobKind::CclWasm)
+            || self.manifest_is_ccl_wasm(&job.manifest_cid).await
+        {
             let signer = self.signer.clone();
             let ctx_clone = Arc::clone(self);
             let job_clone = job.clone();


### PR DESCRIPTION
## Summary
- detect `JobKind::CclWasm` jobs and execute with `WasmExecutor`
- add integration test for submitting a compiled CCL contract over libp2p

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: timeout or environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686026cf50048324bdc9ebbb41f6ce01