### PR TITLE
[node] add sled ledger backend selection

### DIFF
--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -20,7 +20,7 @@ The API style prioritizes:
 *   **Composability:** Allowing different DAG-based data structures to be built on top.
 *   **Performance:** Efficient handling of DAG operations, especially for large graphs.
 *   **Flexibility:** Supporting different codecs and storage backends where appropriate.
-*   **Pluggable Persistence:** Includes in-memory, file-based, and optional `sled` backends via the `persist-sled` feature.
+*   **Pluggable Persistence:** Includes in-memory, file-based, and optional `sled` backends via the `persist-sled` feature. When enabled, `SledDagStore` provides durable storage on disk.
 
 ## Contributing
 

--- a/crates/icn-governance/README.md
+++ b/crates/icn-governance/README.md
@@ -22,6 +22,7 @@ The API style emphasizes:
 *   **Fairness:** Ensuring that voting and proposal mechanisms are equitable.
 *   **Flexibility:** Allowing for different governance models or parameters to be configured.
 *   **Interoperability:** Providing clear interfaces for other crates (e.g., `icn-cli`, `icn-node`) to interact with governance functions.
+*   **Persistence:** With the `persist-sled` feature, proposals and votes are stored using `Sled`, enabling recovery across restarts.
 
 ## Federation Sync
 

--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -11,7 +11,7 @@ icn-api = { path = "../icn-api", default-features = false, features = ["types-on
 icn-network = { path = "../icn-network", default-features = false }
 icn-dag = { path = "../icn-dag" }
 icn-governance = { path = "../icn-governance", features = ["serde"] }
-icn-runtime = { path = "../icn-runtime" }
+icn-runtime = { path = "../icn-runtime", features = ["cli"] }
 icn-identity = { path = "../icn-identity" }
 icn-mesh = { path = "../icn-mesh" }
 icn-reputation = { path = "../icn-reputation" }

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -68,6 +68,7 @@ Useful CLI flags include:
 * `--node-private-key-path <PATH>` – location to read/write the node private key
 * `--storage-backend <memory|file|sqlite|rocksdb>` – choose the DAG storage backend
 * `--storage-path <PATH>` – directory for the file or SQLite backends
+* `--mana-ledger-backend <file|sled|sqlite|rocksdb>` – choose ledger persistence
 * `--mana-ledger-path <PATH>` – location of the mana ledger database
 * `--governance-db-path <PATH>` – location to persist governance proposals and votes
 * `--http-listen-addr <ADDR>` – HTTP server bind address (default `127.0.0.1:7845`)

--- a/crates/icn-node/tests/auth.rs
+++ b/crates/icn-node/tests/auth.rs
@@ -7,7 +7,7 @@ use tokio::task;
 #[tokio::test]
 async fn api_key_required_for_requests() {
     let (router, _ctx) =
-        app_router_with_options(Some("secret".into()), None, None, None, None, None).await;
+        app_router_with_options(Some("secret".into()), None, None, None, None, None, None).await;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = task::spawn(async move {
@@ -42,7 +42,7 @@ async fn api_key_required_for_requests() {
 #[tokio::test]
 async fn bearer_token_required_for_requests() {
     let (router, _ctx) =
-        app_router_with_options(None, Some("s3cr3t".into()), None, None, None, None).await;
+        app_router_with_options(None, Some("s3cr3t".into()), None, None, None, None, None).await;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = task::spawn(async move {
@@ -88,6 +88,7 @@ async fn tls_api_key_and_bearer_token() {
     let (router, _ctx) = app_router_with_options(
         Some("secret".into()),
         Some("token".into()),
+        None,
         None,
         None,
         None,

--- a/crates/icn-node/tests/governance_persistence.rs
+++ b/crates/icn-node/tests/governance_persistence.rs
@@ -14,6 +14,7 @@ async fn governance_persists_between_restarts() {
         None,
         None,
         None,
+        None,
         Some(ledger_path.clone()),
         Some(gov_path.clone()),
         None,
@@ -45,6 +46,7 @@ async fn governance_persists_between_restarts() {
     drop(_router);
 
     let (_router2, ctx2) = app_router_with_options(
+        None,
         None,
         None,
         None,

--- a/crates/icn-node/tests/ledger.rs
+++ b/crates/icn-node/tests/ledger.rs
@@ -8,14 +8,30 @@ async fn ledger_persists_between_restarts() {
     let dir = tempdir().unwrap();
     let ledger_path = dir.path().join("mana.sled");
 
-    let (_router, ctx) =
-        app_router_with_options(None, None, None, Some(ledger_path.clone()), None, None).await;
+    let (_router, ctx) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(ledger_path.clone()),
+        None,
+        None,
+    )
+    .await;
     let did = Did::from_str("did:example:alice").unwrap();
     ctx.mana_ledger.set_balance(&did, 42).expect("set balance");
 
     drop(_router);
 
-    let (_router2, ctx2) =
-        app_router_with_options(None, None, None, Some(ledger_path.clone()), None, None).await;
+    let (_router2, ctx2) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(ledger_path.clone()),
+        None,
+        None,
+    )
+    .await;
     assert_eq!(ctx2.mana_ledger.get_balance(&did), 42);
 }

--- a/crates/icn-node/tests/reputation.rs
+++ b/crates/icn-node/tests/reputation.rs
@@ -13,6 +13,7 @@ async fn reputation_persists_between_restarts() {
         None,
         None,
         None,
+        None,
         Some(ledger_path.clone()),
         None,
         Some(rep_path.clone()),
@@ -24,6 +25,7 @@ async fn reputation_persists_between_restarts() {
     drop(_router);
 
     let (_router2, ctx2) = app_router_with_options(
+        None,
         None,
         None,
         None,

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -30,6 +30,7 @@ wasmtime = { version = "15", features = ["async"] }
 bincode = "1.3"
 once_cell = "1.21"
 prometheus-client = "0.22"
+clap = { version = "4.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.75"
@@ -48,6 +49,7 @@ enable-libp2p = ["dep:libp2p"]
 persist-sled = ["icn-governance/persist-sled", "icn-reputation/persist-sled"]
 persist-sqlite = ["icn-governance/persist-sled", "icn-reputation/persist-sqlite", "icn-economics/persist-sqlite"]
 persist-rocksdb = ["icn-governance/persist-sled", "icn-reputation/persist-rocksdb", "icn-economics/persist-rocksdb"]
+cli = ["dep:clap"]
 
 # Integration tests for cross-node functionality
 [[test]]

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -100,7 +100,9 @@ The project uses `cargo fmt` for code formatting and `cargo clippy` for linting.
     ```
     You can specify the listen address and storage backend:
     ```bash
-    cargo run -p icn-node -- --listen-addr 0.0.0.0:8000 --storage-backend file --storage-path ./my_node_data
+    cargo run -p icn-node -- --listen-addr 0.0.0.0:8000 \
+        --storage-backend file --storage-path ./my_node_data \
+        --mana-ledger-backend sled --mana-ledger-path ./ledger.sled
     ```
     The server will print a message indicating it's listening and then run until stopped (e.g., with Ctrl+C).
 


### PR DESCRIPTION
## Summary
- add runtime LedgerBackend enum with sled option
- allow choosing mana ledger backend in NodeConfig and CLI
- wire new ledger backend through runtime init and tests
- document options in node README and onboarding guide
- mention sled persistence in DAG and governance READMEs

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686033e713f48324a00327884278d415