### PR TITLE
[icn-node] config layering with env overrides

### DIFF
--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -62,6 +62,35 @@ To start the node using this configuration:
 
 Any CLI option provided will override the value from the file.
 
+### Nested Configuration & Environment Variables
+
+Configuration files may organize settings into sections. The following is
+equivalent to the flat example above:
+
+```toml
+[storage]
+backend = "rocksdb"
+path = "./icn_data/node_store"
+
+[http]
+listen_addr = "127.0.0.1:8080"
+
+[identity]
+node_did_path = "./icn_data/node_did.txt"
+node_private_key_path = "./icn_data/node_sk.bs58"
+```
+
+Every option can also be set via environment variables prefixed with `ICN_`.
+For example:
+
+```bash
+ICN_HTTP_LISTEN_ADDR=0.0.0.0:9000 ICN_STORAGE_BACKEND=sqlite \
+    ./target/debug/icn-node --config ./node_config.toml
+```
+
+Environment variables override file values but are in turn overridden by CLI
+flags.
+
 Useful CLI flags include:
 
 * `--node-did-path <PATH>` – location to read/write the node DID string

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -561,23 +561,8 @@ async fn main() {
     } else {
         NodeConfig::default()
     };
+    config.apply_env_overrides();
     config.apply_cli_overrides(&cli, &matches);
-    // Allow configuring API key and TLS paths via environment variables if
-    // they are not provided through CLI or config file.
-    if config.api_key.is_none() {
-        if let Ok(key) = std::env::var("ICN_HTTP_API_KEY") {
-            config.api_key = Some(key);
-        }
-    }
-    if config.tls_cert_path.is_none() && config.tls_key_path.is_none() {
-        if let (Ok(cert), Ok(key)) = (
-            std::env::var("ICN_TLS_CERT_PATH"),
-            std::env::var("ICN_TLS_KEY_PATH"),
-        ) {
-            config.tls_cert_path = Some(cert.into());
-            config.tls_key_path = Some(key.into());
-        }
-    }
     if let Err(e) = config.prepare_paths() {
         error!("Failed to prepare config directories: {}", e);
     }

--- a/crates/icn-node/tests/config_merge.rs
+++ b/crates/icn-node/tests/config_merge.rs
@@ -1,0 +1,49 @@
+use clap::{CommandFactory, FromArgMatches};
+use icn_node::config::{NodeConfig, StorageBackendType};
+use icn_node::node::Cli;
+use std::fs;
+use tempfile::NamedTempFile;
+
+#[test]
+fn merge_file_env_cli() {
+    // create a temp config file with nested sections
+    let file = NamedTempFile::new().unwrap();
+    fs::write(
+        &file,
+        r#"[storage]
+backend = "file"
+path = "file_path"
+[http]
+listen_addr = "1.2.3.4:1111"
+"#,
+    )
+    .unwrap();
+
+    // set env vars overriding some values
+    std::env::set_var("ICN_STORAGE_BACKEND", "sqlite");
+    std::env::set_var("ICN_HTTP_LISTEN_ADDR", "5.6.7.8:2222");
+
+    // CLI overrides storage_path
+    let args = [
+        "icn-node",
+        "--storage-path",
+        "cli_path",
+        "--config",
+        file.path().to_str().unwrap(),
+    ];
+    let cmd = Cli::command();
+    let matches = cmd.get_matches_from(args);
+    let cli = Cli::from_arg_matches(&matches).unwrap();
+
+    let mut cfg = NodeConfig::from_file(file.path()).unwrap();
+    cfg.apply_env_overrides();
+    cfg.apply_cli_overrides(&cli, &matches);
+
+    assert_eq!(cfg.storage_backend, StorageBackendType::Sqlite);
+    assert_eq!(cfg.storage_path.to_str().unwrap(), "cli_path");
+    assert_eq!(cfg.http_listen_addr, "5.6.7.8:2222");
+
+    // cleanup
+    std::env::remove_var("ICN_STORAGE_BACKEND");
+    std::env::remove_var("ICN_HTTP_LISTEN_ADDR");
+}

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -272,20 +272,18 @@ This secures the HTTP API with TLS and passes the required `x-api-key` header to
 
 ### 3.7. Environment Variables
 
-`icn-node` can also read certain settings from the environment. This is useful
-when deploying in containerized environments or CI systems.
-
-* `ICN_HTTP_API_KEY` – sets the API key required in the `x-api-key` header.
-* `ICN_TLS_CERT_PATH` – path to a PEM encoded TLS certificate.
-* `ICN_TLS_KEY_PATH` – path to the matching PEM private key.
+`icn-node` can read any configuration value from environment variables using the
+`ICN_` prefix. Variable names mirror the keys found in the configuration file.
+For example, `ICN_HTTP_LISTEN_ADDR` sets `http_listen_addr` and
+`ICN_STORAGE_BACKEND` sets `storage_backend`. These environment values override
+those loaded from a file but are overridden by CLI flags.
 
 Example usage:
 
 ```bash
-export ICN_HTTP_API_KEY=mysecretkey
-export ICN_TLS_CERT_PATH=/etc/ssl/certs/icn.pem
-export ICN_TLS_KEY_PATH=/etc/ssl/private/icn.key
-cargo run -p icn-node
+export ICN_HTTP_LISTEN_ADDR=0.0.0.0:9000
+export ICN_STORAGE_BACKEND=rocksdb
+cargo run -p icn-node --config node_config.toml
 ```
 
 ## 4. Understanding the Codebase


### PR DESCRIPTION
## Summary
- support nested sections in NodeConfig::from_file
- add environment variable overrides
- document config layering in README and onboarding docs
- test merging of file, env, and CLI settings

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: build hang)*

------
https://chatgpt.com/codex/tasks/task_e_686033e752588324bef51c5bdbc1ccac