### PR TITLE
[icn-identity] add did web fetching and peer did

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ license = "Apache-2.0"
 
 # Dependencies for integration tests
 [workspace.dependencies]
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json", "blocking"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -19,6 +19,7 @@ multibase      = "0.9"          # base-58btc ("z...") encoder/decoder
 # tiny crate that just exposes the unsigned-varint impl used by multicodec
 unsigned-varint = { version = "0.7", default-features = false } 
 serde_bytes = "0.11" # For SignatureBytes serialization
+reqwest.workspace = true
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version
@@ -28,4 +29,5 @@ serde_bytes = "0.11" # For SignatureBytes serialization
 
 [dev-dependencies]
 # rand is still useful for general tests if needed, but OsRng from rand_core is for dalek
-rand = "0.8" 
+rand = "0.8"
+serde_json = "1.0"

--- a/crates/icn-identity/README.md
+++ b/crates/icn-identity/README.md
@@ -21,6 +21,17 @@ The API style emphasizes:
 *   **Interoperability:** Adherence to established standards for DIDs and VCs to ensure compatibility with other systems.
 *   **Usability:** Clear interfaces for managing identities and credentials.
 
+## DID Methods
+
+* **`did:key`** – deterministic key-based identifiers with helper functions for
+  creation and resolving to verifying keys.
+* **`did:web`** – identifiers served from standard `did.json` documents. The
+  [`WebDidResolver`] can fetch these documents over HTTPS at runtime to obtain
+  the public key.
+* **`did:peer`** – basic support for [algorithm 0](https://identity.foundation/peer-did-method-spec/).
+  Keys can be encoded with [`did_peer_from_verifying_key`] and resolved with
+  [`verifying_key_from_did_peer`].
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.


### PR DESCRIPTION
## Summary
- support HTTP retrieval in `WebDidResolver`
- add `did:peer` helper functions and resolver
- document supported DID methods
- tests for `did:peer` and HTTP-based `did:web`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686033e8f904832494030544e0007049