### PR TITLE
[network] periodic discovery & federation handshake

### DIFF
--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -10,13 +10,16 @@ The `icn-network` crate is responsible for:
 *   **P2P Communication:** Establishing and managing connections between ICN nodes.
 *   **Transport Protocols:** Abstracting underlying transport mechanisms (e.g., TCP, QUIC).
 *   **Peer Discovery:** Finding and connecting to other peers in the network.
+    The `Libp2pNetworkService` performs periodic discovery using Kademlia with
+    a configurable `peer_discovery_interval` and will retry dialing configured
+    bootstrap peers.
 *   **Message Definition & Routing:** Defining common network message types and handling their exchange between peers.
 *   **Federation Synchronization:** Potentially handling specific protocols for data synchronization between federated ICN clusters.
 
 ## Key Components
 
 *   **`PeerId`**: A struct representing a unique identifier for a network peer. Currently a simple string wrapper, but intended to be compatible with underlying P2P library IDs (e.g., libp2p `PeerId`).
-*   **`NetworkMessage`**: An enum defining the various types of messages that can be exchanged between ICN nodes. This includes messages for block announcements (`AnnounceBlock`), block requests (`RequestBlock`), generic gossip messages (`GossipSub`), and federation sync requests (`FederationSyncRequest`). This enum derives `Serialize` and `Deserialize` for network transmission.
+*   **`NetworkMessage`**: An enum defining the various types of messages that can be exchanged between ICN nodes. This includes messages for block announcements (`AnnounceBlock`), block requests (`RequestBlock`), generic gossip messages (`GossipSub`), federation sync requests (`FederationSyncRequest`), and federation join handshakes (`FederationJoinRequest`/`FederationJoinResponse`). This enum derives `Serialize` and `Deserialize` for network transmission.
 *   **`NetworkService` Trait**: An abstraction defining the core functionalities a network service provider must implement. This includes methods like `discover_peers`, `send_message`, and `broadcast_message`. Methods return `Result<_, CommonError>` using specific error variants like `PeerNotFound`, `MessageSendError`, etc.
 *   **`StubNetworkService`**: A default implementation of `NetworkService` that simulates network interactions by logging actions to the console and returning predefined data. It's used for development and testing of higher-level crates without requiring a live P2P network. It demonstrates returning specific `CommonError` variants for simulated network issues.
 

--- a/crates/icn-protocol/README.md
+++ b/crates/icn-protocol/README.md
@@ -8,6 +8,7 @@ The `icn-protocol` crate is responsible for:
 
 *   **Message Serialization:** Defining the structure and serialization/deserialization (e.g., using Protobuf, Serde, CBOR) of messages exchanged between ICN nodes.
 *   **Protocol Definitions:** Specifying the state machines, interaction patterns, and rules for various ICN sub-protocols (e.g., for data synchronization, consensus, governance actions).
+*   **Federation Membership:** Structures like `FederationJoinRequest` and `FederationJoinResponse` enable handshake-style membership negotiation between nodes.
 *   **CCL Helpers (if applicable):** If ICN uses a Cooperative Contract Language, this crate might contain compiler utilities, AST definitions, or interpreter components for it.
 *   **Version Negotiation:** Handling different versions of protocols or message formats to ensure backward and forward compatibility.
 

--- a/crates/icn-protocol/src/lib.rs
+++ b/crates/icn-protocol/src/lib.rs
@@ -4,7 +4,9 @@
 //! This crate defines core message formats and protocol definitions for the ICN,
 //! ensuring interoperability between different components and nodes.
 
+use icn_common::Did;
 use icn_common::{CommonError, NodeInfo};
+use serde::{Deserialize, Serialize};
 
 /// Placeholder function demonstrating use of common types for protocol messages.
 pub fn serialize_protocol_message(
@@ -16,6 +18,24 @@ pub fn serialize_protocol_message(
         message_type, info.name, info.version
     );
     Ok(msg_string.into_bytes())
+}
+
+/// Message sent when a node requests to join a federation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationJoinRequest {
+    /// DID of the requesting node
+    pub node: Did,
+    /// Identifier of the federation to join
+    pub federation_id: String,
+}
+
+/// Response to a [`FederationJoinRequest`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationJoinResponse {
+    /// DID of the node requesting membership
+    pub node: Did,
+    /// Whether the request was accepted
+    pub accepted: bool,
 }
 
 #[cfg(test)]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,6 +23,10 @@ path = "integration/persistence.rs"
 name = "icn_node_end_to_end"
 path = "integration/icn_node_end_to_end.rs"
 
+[[test]]
+name = "peer_discovery"
+path = "integration/peer_discovery.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true

--- a/tests/integration/peer_discovery.rs
+++ b/tests/integration/peer_discovery.rs
@@ -1,0 +1,41 @@
+#[cfg(feature = "enable-libp2p")]
+mod peer_discovery {
+    use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
+    use icn_network::NetworkService;
+    use libp2p::PeerId as Libp2pPeerId;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn nodes_discover_each_other() {
+        env_logger::try_init().ok();
+        let mut cfg_a = NetworkConfig::default();
+        cfg_a.peer_discovery_interval = Duration::from_secs(2);
+        let node_a = Libp2pNetworkService::new(cfg_a).await.expect("a start");
+        sleep(Duration::from_secs(1)).await;
+        let addr_a = node_a.listening_addresses()[0].clone();
+        let peer_a = node_a.local_peer_id().clone();
+
+        let mut cfg_b = NetworkConfig::default();
+        cfg_b.bootstrap_peers = vec![(peer_a, addr_a.clone())];
+        cfg_b.peer_discovery_interval = Duration::from_secs(2);
+        cfg_b.bootstrap_interval = Duration::from_secs(2);
+        let node_b = Libp2pNetworkService::new(cfg_b).await.expect("b start");
+
+        sleep(Duration::from_secs(6)).await;
+
+        let peers = node_b
+            .discover_peers(Some(peer_a.to_string()))
+            .await
+            .expect("discover");
+        assert!(peers.iter().any(|p| p.0 == peer_a.to_string()));
+
+        node_a.shutdown().await.unwrap();
+        node_b.shutdown().await.unwrap();
+    }
+}
+
+#[cfg(not(feature = "enable-libp2p"))]
+#[tokio::test]
+async fn libp2p_disabled_discovery_stub() {
+    println!("libp2p feature disabled; skipping discovery test");
+}


### PR DESCRIPTION
## Summary
- extend `NetworkConfig` with `peer_discovery_interval`
- support bootstrap peer retries and regular discovery in `Libp2pNetworkService`
- add federation join request/response messages
- document updated messages and config in README files
- new integration test for multi-node peer discovery

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation timed out)*
- `cargo test --all-features --workspace` *(failed: compilation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686033ec0810832499c5c2e5c303fad2