### PR TITLE
[tests] add cli integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run icn-cli integration tests
         run: cargo test --all-features -p icn-cli
 
+      - name: Run CLI-node integration tests
+        run: cargo test --all-features -p icn-integration-tests --test cli_node
+
       - name: Start devnet (nightly only)
         if: matrix.rust == 'nightly'
         run: |

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -68,7 +68,7 @@ pub struct NodeConfig {
     pub tls_key_path: Option<std::path::PathBuf>,
 }
 
-fn default_ledger_backend() -> icn_runtime::context::LedgerBackend {
+pub(crate) fn default_ledger_backend() -> icn_runtime::context::LedgerBackend {
     #[cfg(feature = "persist-sled")]
     {
         icn_runtime::context::LedgerBackend::Sled

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -343,7 +343,7 @@ pub async fn app_router_with_options(
         .clone()
         .unwrap_or_else(|| PathBuf::from("./reputation.sled"));
     let ledger_backend =
-        mana_ledger_backend.unwrap_or_else(|| super::config::default_ledger_backend());
+        mana_ledger_backend.unwrap_or_else(super::config::default_ledger_backend);
     let ledger = icn_runtime::context::SimpleManaLedger::new_with_backend(
         mana_ledger_path.unwrap_or_else(|| PathBuf::from("./mana_ledger.sled")),
         ledger_backend,
@@ -1906,7 +1906,7 @@ mod tests {
         use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
         use icn_runtime::executor::WasmExecutor;
 
-        let (app, ctx) = app_router_with_options(None, None, None, None, None, None).await;
+        let (app, ctx) = app_router_with_options(None, None, None, None, None, None, None).await;
 
         // Compile a tiny CCL contract
         let (wasm, _) =

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,8 +27,16 @@ path = "integration/icn_node_end_to_end.rs"
 name = "peer_discovery"
 path = "integration/peer_discovery.rs"
 
+[[test]]
+name = "cli_node"
+path = "integration/cli_node.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 once_cell = "1"
+assert_cmd = "2.0"
+predicates = "3.1"
+axum = { version = "0.7", features = ["json"] }
+icn-node = { path = "../crates/icn-node" }

--- a/tests/integration/cli_node.rs
+++ b/tests/integration/cli_node.rs
@@ -1,0 +1,216 @@
+use assert_cmd::prelude::*;
+use icn_node::app_router;
+use icn_common::{compute_merkle_cid, Cid, DagBlock, Did};
+use std::process::Command;
+use tokio::task;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn dag_storage_via_cli() {
+    let _ = std::fs::remove_dir_all("./mana_ledger.sled");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+    sleep(Duration::from_millis(100)).await;
+
+    let ts = 0u64;
+    let author = Did::new("example", "alice");
+    let sig_opt = None;
+    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt);
+    let block = DagBlock {
+        cid: cid.clone(),
+        data: b"data".to_vec(),
+        links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
+    };
+    let block_json = serde_json::to_string(&block).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let output = task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "dag", "put", &block_json])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(&cid.to_string()));
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base2 = format!("http://{}", addr);
+    let cid_json = serde_json::to_string(&cid).unwrap();
+    let output = task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base2, "dag", "get", &cid_json])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(&cid.to_string()));
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn governance_proposal_via_cli() {
+    let _ = std::fs::remove_dir_all("./mana_ledger.sled");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+    sleep(Duration::from_millis(100)).await;
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let submit_json = serde_json::json!({
+        "proposer_did": "did:example:alice",
+        "proposal": { "type": "GenericText", "data": { "text": "hi" } },
+        "description": "test",
+        "duration_secs": 60
+    })
+    .to_string();
+    let output = task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "governance", "submit", &submit_json])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Successfully submitted proposal"));
+    let start = stdout.find('"').unwrap();
+    let end = stdout[start + 1..].find('"').unwrap() + start + 1;
+    let pid = stdout[start + 1..end].to_string();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let pid_clone = pid.clone();
+    task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "governance", "proposals"])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains(&pid_clone));
+    })
+    .await
+    .unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let pid_owned = pid.clone();
+    task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "governance", "proposal", &pid_owned])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains(&pid_owned));
+    })
+    .await
+    .unwrap();
+
+    let vote_json = serde_json::json!({
+        "voter_did": "did:example:bob",
+        "proposal_id": pid,
+        "vote_option": "yes"
+    })
+    .to_string();
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "governance", "vote", &vote_json])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("Vote response"));
+    })
+    .await
+    .unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let pid_for_tally = pid.clone();
+    task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "governance", "tally", &pid_for_tally])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("Accepted"));
+    })
+    .await
+    .unwrap();
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn mesh_job_via_cli() {
+    let _ = std::fs::remove_dir_all("./mana_ledger.sled");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+    sleep(Duration::from_millis(100)).await;
+
+    let job_req = serde_json::json!({
+        "manifest_cid": "bafytestmanifest",
+        "spec_json": { "Echo": { "payload": "hello" } },
+        "cost_mana": 10
+    })
+    .to_string();
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let output = task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "submit-job", &job_req])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let body: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let job_id = body["job_id"].as_str().unwrap().to_string();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let job_id_clone = job_id.clone();
+    task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "mesh", "jobs"])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains(&job_id_clone));
+    })
+    .await
+    .unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{}", addr);
+    let job_id_clone2 = job_id.clone();
+    task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "job-status", &job_id_clone2])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains(&job_id_clone2));
+    })
+    .await
+    .unwrap();
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- add CLI integration tests under tests/integration
- invoke DAG, governance, and mesh job commands
- expose default_ledger_backend for tests
- run CLI-node integration tests in CI

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68603c3e27f083249c455c71e02efcc1