### PR TITLE
[docs] onboarding and diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ This workspace is organized into several crates, each with a specific focus:
 
 More detailed information can be found in the `README.md` file within each crate's directory.
 
+## Further Reading
+
+* [RFC Index](icn-docs/rfcs/README.md) – notably [RFC 0010: ICN Governance & Deliberation Core](icn-docs/rfcs/0010-governance-core.md)
+* Crate documentation:
+  * [icn-common](crates/icn-common/README.md)
+  * [icn-dag](crates/icn-dag/README.md)
+  * [icn-identity](crates/icn-identity/README.md)
+  * [icn-mesh](crates/icn-mesh/README.md)
+  * [icn-governance](crates/icn-governance/README.md)
+  * [icn-runtime](crates/icn-runtime/README.md)
+  * [icn-network](crates/icn-network/README.md)
+
 ## Contribution Guidelines
 
 We welcome contributions to the ICN Core project! Please see our [Contributing Guidelines](CONTRIBUTING.md) for more information on how to get started, our coding conventions, and the pull request process.

--- a/crates/icn-dag/src/index.rs
+++ b/crates/icn-dag/src/index.rs
@@ -7,12 +7,16 @@ pub struct DagTraversalIndex {
 }
 
 impl DagTraversalIndex {
+    /// Create an empty traversal index.
+    ///
+    /// The index maps each [`Cid`] to the CIDs of its child blocks.
     pub fn new() -> Self {
         Self {
             adjacency: HashMap::new(),
         }
     }
 
+    /// Insert a block into the traversal index.
     pub fn index_block(&mut self, block: &DagBlock) {
         self.adjacency.insert(
             block.cid.clone(),
@@ -20,6 +24,7 @@ impl DagTraversalIndex {
         );
     }
 
+    /// Remove a block and all references to it from the index.
     pub fn remove_block(&mut self, cid: &Cid) {
         self.adjacency.remove(cid);
         for children in self.adjacency.values_mut() {
@@ -27,6 +32,9 @@ impl DagTraversalIndex {
         }
     }
 
+    /// Perform a depth‑first traversal starting from `start`.
+    ///
+    /// Returns the order of visited CIDs.
     pub fn traverse(&self, start: &Cid) -> Vec<Cid> {
         let mut visited = HashSet::new();
         let mut stack = vec![start.clone()];

--- a/crates/icn-dag/src/rocksdb_store.rs
+++ b/crates/icn-dag/src/rocksdb_store.rs
@@ -8,6 +8,7 @@ pub struct RocksDagStore {
 }
 
 impl RocksDagStore {
+    /// Create a new RocksDB backed DAG store.
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let mut opts = Options::default();
         opts.create_if_missing(true);

--- a/crates/icn-dag/src/sled_store.rs
+++ b/crates/icn-dag/src/sled_store.rs
@@ -17,6 +17,7 @@ pub struct SledDagStore {
 
 #[cfg(feature = "persist-sled")]
 impl SledDagStore {
+    /// Create a new sled backed DAG store at the given path.
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let db = sled::open(path)
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open sled DB: {}", e)))?;

--- a/crates/icn-dag/src/sqlite_store.rs
+++ b/crates/icn-dag/src/sqlite_store.rs
@@ -8,6 +8,7 @@ pub struct SqliteDagStore {
 }
 
 impl SqliteDagStore {
+    /// Create a new SQLite backed DAG store.
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let conn = Connection::open(path)
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {}", e)))?;

--- a/crates/icn-economics/src/ledger/rocksdb.rs
+++ b/crates/icn-economics/src/ledger/rocksdb.rs
@@ -9,6 +9,7 @@ pub struct RocksdbManaLedger {
 }
 
 impl RocksdbManaLedger {
+    /// Initialise a RocksDB backed mana ledger at `path`.
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let db = DB::open_default(path)
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open rocksdb: {e}")))?;

--- a/crates/icn-economics/src/ledger/sqlite.rs
+++ b/crates/icn-economics/src/ledger/sqlite.rs
@@ -9,6 +9,7 @@ pub struct SqliteManaLedger {
 }
 
 impl SqliteManaLedger {
+    /// Create a new SQLite based mana ledger stored at `path`.
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let conn = Connection::open(&path)
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -342,8 +342,7 @@ pub async fn app_router_with_options(
     let rep_path = reputation_db_path
         .clone()
         .unwrap_or_else(|| PathBuf::from("./reputation.sled"));
-    let ledger_backend =
-        mana_ledger_backend.unwrap_or_else(super::config::default_ledger_backend);
+    let ledger_backend = mana_ledger_backend.unwrap_or_else(super::config::default_ledger_backend);
     let ledger = icn_runtime::context::SimpleManaLedger::new_with_backend(
         mana_ledger_path.unwrap_or_else(|| PathBuf::from("./mana_ledger.sled")),
         ledger_backend,

--- a/crates/icn-reputation/src/rocksdb_store.rs
+++ b/crates/icn-reputation/src/rocksdb_store.rs
@@ -12,6 +12,7 @@ pub struct RocksdbReputationStore {
 
 #[cfg(feature = "persist-rocksdb")]
 impl RocksdbReputationStore {
+    /// Open or create a RocksDB database at `path` to store reputation scores.
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let db = DB::open_default(path)
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open rocksdb: {e}")))?;

--- a/crates/icn-reputation/src/sqlite_store.rs
+++ b/crates/icn-reputation/src/sqlite_store.rs
@@ -12,6 +12,7 @@ pub struct SqliteReputationStore {
 
 #[cfg(feature = "persist-sqlite")]
 impl SqliteReputationStore {
+    /// Create a SQLite backed store for executor reputation.
     pub fn new(path: PathBuf) -> Result<Self, CommonError> {
         let conn = Connection::open(&path)
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -36,6 +36,12 @@ Welcome to the InterCooperative Network (ICN) Core project! This guide will help
     just --list    # Show available development commands
     ```
     The `just` command runner provides shortcuts for formatting, linting, testing, and devnet tasks defined in the repository's `justfile`.
+5.  **Install WebAssembly tooling:**
+    ```bash
+    rustup target add wasm32-unknown-unknown
+    cargo install wasm-tools --locked
+    ```
+    ICN crates compile to WebAssembly for deterministic sandboxing. The `wasm32-unknown-unknown` target and `wasm-tools` utilities are required for building and running tests that involve the runtime or CCL compiler.
 
 ## 3. Building and Running Components
 

--- a/icn-docs/diagrams/README.md
+++ b/icn-docs/diagrams/README.md
@@ -1,0 +1,8 @@
+# ICN Architecture Diagrams
+
+This directory contains high level diagrams that illustrate core flows within the InterCooperative Network.
+
+- `mesh_job_pipeline.mmd` – Mermaid diagram of the mesh job lifecycle from submission to governance audit.
+- `governance_flow.mmd` – Mermaid diagram showing proposal voting and execution.
+
+Render these diagrams using any Mermaid compatible tool or GitHub's built in preview.

--- a/icn-docs/diagrams/governance_flow.mmd
+++ b/icn-docs/diagrams/governance_flow.mmd
@@ -1,0 +1,6 @@
+flowchart TD
+    P[Proposal Created] --> V[Members Vote]
+    V --> C{Quorum & Threshold Met?}
+    C -- yes --> A[Proposal Accepted]
+    C -- no --> R[Proposal Rejected]
+    A --> E[Execute Decision]

--- a/icn-docs/diagrams/mesh_job_pipeline.mmd
+++ b/icn-docs/diagrams/mesh_job_pipeline.mmd
@@ -1,0 +1,7 @@
+flowchart TD
+    A[Job Submitted] --> B[Job Announced]
+    B --> C[Executors Bid]
+    C --> D[Select Executor]
+    D --> E[Execute Job]
+    E --> F[Anchor Receipt]
+    F --> G[Governance Audit]


### PR DESCRIPTION
## Summary
- document wasm tools in onboarding
- add mermaid diagrams for mesh jobs and governance
- cross-link RFCs and crates from main README
- add rustdoc for DAG index and storage backends
- format node options

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: command terminated due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686052ce66008324a4441ed08646bf36