### PR TITLE
[icn-node] enable auth token CLI and HTTPS tests

### DIFF
--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -111,6 +111,13 @@ Useful CLI flags include:
 * `--tls-cert-path <PATH>` – PEM certificate file to enable HTTPS
 * `--tls-key-path <PATH>` – PEM private key file to enable HTTPS
 
+### Authentication and TLS
+
+If `auth_token` or `auth_token_path` is supplied, the server requires
+`Authorization: Bearer <token>` on every request in addition to any `x-api-key`.
+Providing both `tls_cert_path` and `tls_key_path` switches the HTTP server to
+HTTPS mode using the given PEM files.
+
 Supplying both TLS options makes the server listen on HTTPS instead of HTTP.
 
 When the node starts, it will attempt to load its DID and private key from the

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -468,6 +468,12 @@ impl NodeConfig {
         if let Some(v) = cli.open_rate_limit {
             self.open_rate_limit = v;
         }
+        if let Some(v) = &cli.auth_token {
+            self.auth_token = Some(v.clone());
+        }
+        if let Some(v) = &cli.auth_token_path {
+            self.auth_token_path = Some(v.clone());
+        }
         if let Some(v) = &cli.tls_cert_path {
             self.tls_cert_path = Some(v.clone());
         }

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -146,6 +146,14 @@ pub struct Cli {
     #[clap(long)]
     pub open_rate_limit: Option<u64>,
 
+    /// Bearer token required via the `Authorization` header
+    #[clap(long)]
+    pub auth_token: Option<String>,
+
+    /// Path to a file containing the bearer token
+    #[clap(long)]
+    pub auth_token_path: Option<PathBuf>,
+
     #[clap(long)]
     pub tls_cert_path: Option<PathBuf>,
 
@@ -1368,6 +1376,7 @@ async fn mesh_submit_job_handler(
                 "[NODE] Job submitted via runtime, Actual Job ID: {}",
                 actual_job_id_cid
             );
+            info!(target: "audit", "job_submitted id={}" , actual_job_id_cid);
             (
                 StatusCode::ACCEPTED,
                 Json(serde_json::json!({ "job_id": actual_job_id_cid.to_string() })),
@@ -1376,6 +1385,7 @@ async fn mesh_submit_job_handler(
         }
         Err(e) => {
             error!("[NODE] Error submitting job via runtime: {:?}", e);
+            info!(target: "audit", "job_submission_failed error={}" , e);
             map_rust_error_to_json_response(
                 format!("Mesh job submission failed: {}", e),
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -1626,6 +1636,7 @@ async fn federation_add_peer_handler(
     let mut peers = state.peers.lock().await;
     if !peers.contains(&payload.peer) {
         peers.push(payload.peer.clone());
+        info!(target: "audit", "peer_added peer={}" , payload.peer);
     }
     (
         StatusCode::CREATED,

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # ICN HTTP API
 
-The ICN node exposes a REST interface. All endpoints require the configured `x-api-key` header if an API key is set. If an `auth_token` is configured, requests must also include `Authorization: Bearer <token>`. When no API key is set the `--open-rate-limit` option controls the number of unauthenticated requests allowed per minute.
+The ICN node exposes a REST interface. All endpoints require the configured `x-api-key` header if an API key is set. If an `auth_token` is configured, requests must also include `Authorization: Bearer <token>`. When no API key is set the `--open-rate-limit` option controls the number of unauthenticated requests allowed per minute. If `tls_cert_path` and `tls_key_path` are supplied the server only accepts HTTPS connections.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/tests/integration/auth_tls.rs
+++ b/tests/integration/auth_tls.rs
@@ -1,0 +1,85 @@
+use icn_node::app_router_with_options;
+use reqwest::Client;
+use tokio::time::{sleep, Duration};
+use rcgen::generate_simple_self_signed;
+use axum_server::tls_rustls::{from_tcp_rustls, RustlsConfig};
+
+#[tokio::test]
+async fn authentication_enforced() {
+    let (router, _ctx) = app_router_with_options(
+        Some("key123".into()),
+        Some("secret".into()),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    sleep(Duration::from_millis(100)).await;
+    let base = format!("http://{}", addr);
+    let client = Client::new();
+
+    let resp = client.get(format!("{}/info", base)).send().await.unwrap();
+    assert_eq!(resp.status(), 401);
+
+    let resp = client
+        .get(format!("{}/info", base))
+        .header("x-api-key", "key123")
+        .header("Authorization", "Bearer secret")
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn https_serving() {
+    let (router, _ctx) = app_router_with_options(None, None, None, None, None, None, None).await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let std_listener = listener.into_std().unwrap();
+
+    let cert = generate_simple_self_signed(["localhost".into()]).unwrap();
+    let cert_pem = cert.serialize_pem().unwrap();
+    let key_pem = cert.serialize_private_key_pem();
+    let dir = tempfile::tempdir().unwrap();
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+    std::fs::write(&cert_path, cert_pem).unwrap();
+    std::fs::write(&key_path, key_pem).unwrap();
+
+    let cfg = RustlsConfig::from_pem_file(&cert_path, &key_path)
+        .await
+        .unwrap();
+
+    let server = tokio::spawn(async move {
+        from_tcp_rustls(std_listener, cfg)
+            .serve(router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    sleep(Duration::from_millis(100)).await;
+    let url = format!("https://localhost:{}", addr.port());
+    let client = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+    let resp = client.get(format!("{}/info", url)).send().await.unwrap();
+    assert!(resp.status().is_success());
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- support `--auth-token` and `--auth-token-path` CLI flags
- log audit events for job submission and federation peer additions
- document authentication and TLS configuration
- test API authentication and HTTPS binding

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686052cf28048324a2af6b127e104cd6