### PR TITLE
[icn-cli] add icn-mesh dependency

### DIFF
--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -10,6 +10,7 @@ icn-common = { path = "../icn-common" }
 icn-api = { path = "../icn-api" }
 icn-governance = { path = "../icn-governance" }
 icn-network = { path = "../icn-network" }
+icn-mesh = { path = "../icn-mesh" }
 icn-ccl = { path = "../../icn-ccl" }
 anyhow = "1.0"
 


### PR DESCRIPTION
## Summary
- fix missing dependency for CLI build

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt found issues)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails to finish in time)*
- `cargo test --all-features --workspace` *(fails to finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_68607062000c832497a5cf9a8548e984