### PR TITLE
[runtime] improve WASM docs and marshalling tests

### DIFF
--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -682,6 +682,7 @@ mod tests {
             job_id: dummy_cid("assign_notice"),
             executor_did: Did::from_str("did:icn:test:exec").unwrap(),
             signature: SignatureBytes(vec![]),
+            manifest_cid: None,
         }
         .sign(&sk)
         .unwrap();

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -49,7 +49,9 @@ pub fn execute_icn_script(info: &NodeInfo, script_id: &str) -> Result<String, Co
 /// The `id` and `submitter` fields within the deserialized job will be overridden
 /// by the runtime (new JobId generation, context's current_identity).
 ///
-/// TODO: WASM bindings will need to handle memory marshalling for `job_json`.
+/// When invoked from WebAssembly use [`wasm_host_submit_mesh_job`], which
+/// accepts pointer/length parameters and marshals the JSON string via the
+/// `memory` helpers.
 pub async fn host_submit_mesh_job(
     ctx: &std::sync::Arc<RuntimeContext>,
     job_json: &str,
@@ -119,7 +121,9 @@ pub async fn host_submit_mesh_job(
 /// ABI Index: (defined in `abi::ABI_HOST_GET_PENDING_MESH_JOBS`)
 /// Retrieves a snapshot of the current pending mesh jobs from the runtime context.
 ///
-/// TODO: WASM bindings will need to handle memory marshalling for the returned Vec<ActualMeshJob> (e.g., serialize to JSON string).
+/// For WebAssembly callers see [`wasm_host_get_pending_mesh_jobs`], which
+/// serializes the job list to JSON and writes it to guest memory using
+/// pointer/length parameters.
 pub fn host_get_pending_mesh_jobs(
     ctx: &RuntimeContext,
 ) -> Result<Vec<icn_mesh::ActualMeshJob>, HostAbiError> {
@@ -149,7 +153,8 @@ pub fn host_get_pending_mesh_jobs(
 /// In many cases, this will be the `current_identity` within the `ctx`,
 /// but the API allows specifying it for potential future flexibility (e.g., admin queries).
 ///
-/// TODO: WASM bindings will need to handle memory marshalling for `account_id_str`.
+/// WebAssembly modules should call [`wasm_host_account_get_mana`], which
+/// reads the DID string from guest memory using pointer/length arguments.
 pub async fn host_account_get_mana(
     ctx: &RuntimeContext,
     account_id_str: &str,
@@ -181,7 +186,8 @@ pub async fn host_account_get_mana(
 ///
 /// Policy Note: `RuntimeContext::spend_mana` currently only allows spending from `ctx.current_identity`.
 ///
-/// TODO: WASM bindings will need to handle memory marshalling for `account_id_str` and `amount`.
+/// For WebAssembly use [`wasm_host_account_spend_mana`], which reads the DID
+/// string and writes any errors through pointer/length parameters.
 pub async fn host_account_spend_mana(
     ctx: &RuntimeContext,
     account_id_str: &str,
@@ -284,7 +290,9 @@ impl ReputationUpdater {
 ///
 /// The `receipt_json` is expected to be a JSON string serializing `icn_identity::ExecutionReceipt`.
 ///
-/// TODO: WASM bindings will need to handle memory marshalling for `receipt_json` and returned `Cid`.
+/// WebAssembly callers should use [`wasm_host_anchor_receipt`], which reads the
+/// receipt JSON from guest memory and returns the resulting CID string via
+/// pointer/length arguments.
 pub async fn host_anchor_receipt(
     ctx: &RuntimeContext,
     receipt_json: &str,

--- a/crates/icn-runtime/tests/memory_marshalling.rs
+++ b/crates/icn-runtime/tests/memory_marshalling.rs
@@ -1,0 +1,54 @@
+use icn_runtime::{memory, context::RuntimeContext};
+use wasmtime::{Engine, Linker, Module, Store};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn write_string_limited_truncates() {
+    let ctx = RuntimeContext::new_with_stubs("did:key:zMemTest");
+    let engine = Engine::default();
+    let module_wat = r#"(module
+        (import "t" "write" (func $write (param i32 i32) (result i32)))
+        (memory (export "memory") 1)
+        (func (export "run") (param i32 i32) (result i32) (local.get 0) (local.get 1) call $write)
+    )"#;
+    let module = Module::new(&engine, wat::parse_str(module_wat).unwrap()).unwrap();
+    let mut linker = Linker::new(&engine);
+    linker
+        .func_wrap("t", "write", |mut caller: wasmtime::Caller<'_, Arc<RuntimeContext>>, ptr: u32, len: u32| -> i32 {
+            memory::write_string_limited(&mut caller, ptr, "hello world", len).unwrap() as i32
+        })
+        .unwrap();
+    let mut store = Store::new(&engine, ctx.clone());
+    let instance = linker.instantiate(&mut store, &module).unwrap();
+    let run = instance.get_typed_func::<(i32, i32), i32>(&mut store, "run").unwrap();
+    let memory = instance.get_memory(&mut store, "memory").unwrap();
+    let written = run.call(&mut store, (0, 5)).unwrap();
+    assert_eq!(written, 5);
+    let mut buf = [0u8; 5];
+    memory.read(&mut store, 0, &mut buf).unwrap();
+    assert_eq!(&buf, b"hello");
+}
+
+#[tokio::test]
+async fn read_string_safe_empty() {
+    let ctx = RuntimeContext::new_with_stubs("did:key:zMemRead");
+    let engine = Engine::default();
+    let module_wat = r#"(module
+        (import "t" "read" (func $read (param i32 i32) (result i32)))
+        (memory (export "memory") 1)
+        (func (export "run") (param i32 i32) (result i32) (local.get 0) (local.get 1) call $read)
+    )"#;
+    let module = Module::new(&engine, wat::parse_str(module_wat).unwrap()).unwrap();
+    let mut linker = Linker::new(&engine);
+    linker
+        .func_wrap("t", "read", |mut caller: wasmtime::Caller<'_, Arc<RuntimeContext>>, ptr: u32, len: u32| -> i32 {
+            let s = memory::read_string_safe(&mut caller, ptr, len).unwrap();
+            if s.is_empty() { 1 } else { 0 }
+        })
+        .unwrap();
+    let mut store = Store::new(&engine, ctx.clone());
+    let instance = linker.instantiate(&mut store, &module).unwrap();
+    let run = instance.get_typed_func::<(i32, i32), i32>(&mut store, "run").unwrap();
+    let result = run.call(&mut store, (0, 0)).unwrap();
+    assert_eq!(result, 1);
+}


### PR DESCRIPTION
## Summary
- document pointer/length marshalling for host runtime functions
- fix `JobAssignmentNotice` test compilation
- add unit tests for memory helpers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686089c46b2c8324ae73cf5516e0fb7a