### PR TITLE
[runtime] mana refund and credit function

### DIFF
--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -121,6 +121,13 @@ pub fn charge_mana<L: ManaLedger>(ledger: L, did: &Did, amount: u64) -> Result<(
     policy_enforcer.spend_mana(did, amount)
 }
 
+/// Credits mana to the given DID using the provided ledger.
+pub fn credit_mana<L: ManaLedger>(ledger: L, did: &Did, amount: u64) -> Result<(), EconError> {
+    let mana_adapter = ManaRepositoryAdapter::new(ledger);
+    println!("[icn-economics] credit_mana called for DID {did:?}, amount {amount}");
+    mana_adapter.credit_mana(did, amount)
+}
+
 /// Placeholder function demonstrating use of common types for economics.
 pub fn process_economic_event(info: &NodeInfo, event_details: &str) -> Result<String, CommonError> {
     Ok(format!(

--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -528,7 +528,10 @@ impl SubmitReceiptMessage {
         Ok(self)
     }
 
-    pub fn verify_signature(&self, verifying_key: &IdentityVerifyingKey) -> Result<(), CommonError> {
+    pub fn verify_signature(
+        &self,
+        verifying_key: &IdentityVerifyingKey,
+    ) -> Result<(), CommonError> {
         let message = self.to_signable_bytes()?;
         let ed_sig = self.signature.to_ed_signature()?;
         if identity_verify_signature(verifying_key, &message, &ed_sig) {
@@ -682,6 +685,7 @@ mod tests {
             job_id: dummy_cid("assign_notice"),
             executor_did: Did::from_str("did:icn:test:exec").unwrap(),
             signature: SignatureBytes(vec![]),
+            manifest_cid: None,
         }
         .sign(&sk)
         .unwrap();


### PR DESCRIPTION
## Summary
- add `credit_mana` helper in `icn-economics`
- expose crediting in `RuntimeContext` and refund job creator when receipts fail
- patch mesh unit test to use new credit API
- fix compilation of mesh assignment test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: test_wasm_executor_runs_addition)*

------
https://chatgpt.com/codex/tasks/task_e_686089cc47788324a922f8e69552eca1