### PR TITLE
[ccl] compute CID via icn_common

### DIFF
--- a/icn-ccl/src/cli.rs
+++ b/icn-ccl/src/cli.rs
@@ -12,7 +12,7 @@ use crate::wasm_backend::WasmBackend;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::PathBuf;
-// use icn_common::Cid; // If calculating actual CIDs
+use icn_common::{compute_merkle_cid, Did};
 
 // This function would be called by `icn-cli ccl compile ...`
 pub fn compile_ccl_file(
@@ -46,13 +46,12 @@ pub fn compile_ccl_file(
     let wasm_backend = WasmBackend::new();
     let (wasm_bytecode, mut metadata) = wasm_backend.compile_to_wasm(&optimized_ast)?;
 
-    // Calculate CID of wasm_bytecode (placeholder)
-    // In reality, use icn_dag or similar to produce a real CID
-    let wasm_cid_placeholder = format!(
-        "bafy2bzace{}",
-        hex::encode(&wasm_bytecode[0..min(10, wasm_bytecode.len())])
-    ); // Very rough placeholder
-    metadata.cid = wasm_cid_placeholder;
+    // Calculate CID of the generated WASM using icn_common utilities
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = compute_merkle_cid(0x71, &wasm_bytecode, &[], ts, &author, &sig_opt);
+    metadata.cid = cid.to_string();
 
     // Calculate SHA-256 hash of the source code
     let hash = Sha256::digest(source_code.as_bytes());
@@ -342,5 +341,3 @@ fn explain_ast(ast: &AstNode, target: Option<&str>) -> String {
     }
 }
 
-// Helper for min, replace with std::cmp::min
-use std::cmp::min;

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -72,6 +72,12 @@ fn test_compile_ccl_file_cli_function() {
             assert_eq!(metadata.source_hash, expected_hash);
             assert_eq!(parsed_meta.source_hash, expected_hash);
 
+            let ts = 0u64;
+            let author = icn_common::Did::new("key", "tester");
+            let sig_opt = None;
+            let expected_cid = icn_common::compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+            assert_eq!(metadata.cid, expected_cid.to_string());
+
             println!(
                 "CLI compile_ccl_file test successful. Metadata: {:?}",
                 metadata


### PR DESCRIPTION
## Summary
- compute CID for compiled WASM modules with `compute_merkle_cid`
- verify CLI CID generation in integration tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: environment timeout)*
- `cargo test --all-features --workspace` *(failed: environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6860a5b94af483248a2d1bcafb2dce01