### PR TITLE
[runtime] propagate dag store init errors

### DIFF
--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -816,7 +816,7 @@ mod tests {
     #[tokio::test]
     async fn test_runtime_context_new_with_stubs() {
         let node_did_str = "did:key:z6MkjL4FwS3np2p2NLiqH57sX99pZtG9x3Fy9bYh3xHqs14z";
-        let ctx = RuntimeContext::new_with_stubs(node_did_str);
+        let ctx = RuntimeContext::new_with_stubs(node_did_str).unwrap();
         assert_eq!(ctx.current_identity.to_string(), node_did_str);
         // Further checks can be added here if needed
     }
@@ -825,7 +825,7 @@ mod tests {
     async fn test_runtime_context_new_with_stubs_and_mana() {
         let node_did_str = "did:key:zTestManaDid";
         let initial_mana = 1000u64;
-        let ctx = RuntimeContext::new_with_stubs_and_mana(node_did_str, initial_mana);
+        let ctx = RuntimeContext::new_with_stubs_and_mana(node_did_str, initial_mana).unwrap();
         assert_eq!(ctx.current_identity.to_string(), node_did_str);
         let balance = ctx.get_mana(&ctx.current_identity).await.unwrap();
         assert_eq!(balance, initial_mana);

--- a/crates/icn-runtime/tests/governance.rs
+++ b/crates/icn-runtime/tests/governance.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 #[tokio::test]
 async fn proposal_can_be_closed_and_executed() {
     // setup context
-    let ctx = RuntimeContext::new_with_stubs("did:icn:test:alice");
+    let ctx = RuntimeContext::new_with_stubs("did:icn:test:alice").unwrap();
     {
         let mut gov = ctx.governance_module.lock().await;
         gov.add_member(Did::from_str("did:icn:test:alice").unwrap());

--- a/crates/icn-runtime/tests/memory_marshalling.rs
+++ b/crates/icn-runtime/tests/memory_marshalling.rs
@@ -1,10 +1,10 @@
-use icn_runtime::{memory, context::RuntimeContext};
-use wasmtime::{Engine, Linker, Module, Store};
+use icn_runtime::{context::RuntimeContext, memory};
 use std::sync::Arc;
+use wasmtime::{Engine, Linker, Module, Store};
 
 #[tokio::test]
 async fn write_string_limited_truncates() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zMemTest");
+    let ctx = RuntimeContext::new_with_stubs("did:key:zMemTest").unwrap();
     let engine = Engine::default();
     let module_wat = r#"(module
         (import "t" "write" (func $write (param i32 i32) (result i32)))
@@ -14,13 +14,19 @@ async fn write_string_limited_truncates() {
     let module = Module::new(&engine, wat::parse_str(module_wat).unwrap()).unwrap();
     let mut linker = Linker::new(&engine);
     linker
-        .func_wrap("t", "write", |mut caller: wasmtime::Caller<'_, Arc<RuntimeContext>>, ptr: u32, len: u32| -> i32 {
-            memory::write_string_limited(&mut caller, ptr, "hello world", len).unwrap() as i32
-        })
+        .func_wrap(
+            "t",
+            "write",
+            |mut caller: wasmtime::Caller<'_, Arc<RuntimeContext>>, ptr: u32, len: u32| -> i32 {
+                memory::write_string_limited(&mut caller, ptr, "hello world", len).unwrap() as i32
+            },
+        )
         .unwrap();
     let mut store = Store::new(&engine, ctx.clone());
     let instance = linker.instantiate(&mut store, &module).unwrap();
-    let run = instance.get_typed_func::<(i32, i32), i32>(&mut store, "run").unwrap();
+    let run = instance
+        .get_typed_func::<(i32, i32), i32>(&mut store, "run")
+        .unwrap();
     let memory = instance.get_memory(&mut store, "memory").unwrap();
     let written = run.call(&mut store, (0, 5)).unwrap();
     assert_eq!(written, 5);
@@ -31,7 +37,7 @@ async fn write_string_limited_truncates() {
 
 #[tokio::test]
 async fn read_string_safe_empty() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zMemRead");
+    let ctx = RuntimeContext::new_with_stubs("did:key:zMemRead").unwrap();
     let engine = Engine::default();
     let module_wat = r#"(module
         (import "t" "read" (func $read (param i32 i32) (result i32)))
@@ -41,14 +47,24 @@ async fn read_string_safe_empty() {
     let module = Module::new(&engine, wat::parse_str(module_wat).unwrap()).unwrap();
     let mut linker = Linker::new(&engine);
     linker
-        .func_wrap("t", "read", |mut caller: wasmtime::Caller<'_, Arc<RuntimeContext>>, ptr: u32, len: u32| -> i32 {
-            let s = memory::read_string_safe(&mut caller, ptr, len).unwrap();
-            if s.is_empty() { 1 } else { 0 }
-        })
+        .func_wrap(
+            "t",
+            "read",
+            |mut caller: wasmtime::Caller<'_, Arc<RuntimeContext>>, ptr: u32, len: u32| -> i32 {
+                let s = memory::read_string_safe(&mut caller, ptr, len).unwrap();
+                if s.is_empty() {
+                    1
+                } else {
+                    0
+                }
+            },
+        )
         .unwrap();
     let mut store = Store::new(&engine, ctx.clone());
     let instance = linker.instantiate(&mut store, &module).unwrap();
-    let run = instance.get_typed_func::<(i32, i32), i32>(&mut store, "run").unwrap();
+    let run = instance
+        .get_typed_func::<(i32, i32), i32>(&mut store, "run")
+        .unwrap();
     let result = run.call(&mut store, (0, 0)).unwrap();
     assert_eq!(result, 1);
 }

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -44,7 +44,7 @@ fn create_test_mesh_job(manifest_cid: Cid, cost_mana: u64, creator_did: Did) -> 
 // The Stub services are now part of RuntimeContext::new_with_stubs_and_mana
 fn create_test_context(identity_did_str: &str, initial_mana: u64) -> Arc<RuntimeContext> {
     let _ = std::fs::remove_file("./mana_ledger.sled");
-    RuntimeContext::new_with_stubs_and_mana(identity_did_str, initial_mana)
+    RuntimeContext::new_with_stubs_and_mana(identity_did_str, initial_mana).unwrap()
 }
 
 // Helper to assert the state of a job

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn wasm_executor_runs_wasm() {
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 42);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 42).unwrap();
     let (sk, vk) = generate_ed25519_keypair();
     let node_did = did_key_from_verifying_key(&vk);
     let node_did = icn_common::Did::from_str(&node_did).unwrap();
@@ -57,7 +57,7 @@ async fn wasm_executor_runs_wasm() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn wasm_executor_runs_compiled_ccl_contract() {
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zCclExec", 10);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zCclExec", 10).unwrap();
     let (sk, vk) = generate_ed25519_keypair();
     let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
 
@@ -103,7 +103,7 @@ async fn wasm_executor_runs_compiled_ccl_contract() {
 async fn wasm_executor_host_submit_mesh_job_json() {
     use icn_mesh::{JobKind, Resources};
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostSubmit", 50);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostSubmit", 50).unwrap();
     let (sk, vk) = generate_ed25519_keypair();
     let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
 
@@ -179,7 +179,7 @@ async fn wasm_executor_host_submit_mesh_job_json() {
 async fn wasm_executor_host_anchor_receipt_json() {
     use icn_identity::ExecutionReceipt;
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostAnchor", 10);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostAnchor", 10).unwrap();
     let (exec_sk, exec_vk) = generate_ed25519_keypair();
     let executor_did = icn_common::Did::from_str(&did_key_from_verifying_key(&exec_vk)).unwrap();
     let (node_sk, node_vk) = generate_ed25519_keypair();
@@ -243,7 +243,7 @@ async fn wasm_executor_host_anchor_receipt_json() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn submit_compiled_ccl_runs_via_executor() {
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zEndToEnd", 5);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zEndToEnd", 5).unwrap();
     let source = "fn run() -> Integer { return 9; }";
     let (wasm, _) = icn_ccl::compile_ccl_source_to_wasm(source).unwrap();
     let ts = 0u64;
@@ -286,7 +286,7 @@ async fn submit_compiled_ccl_runs_via_executor() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn queued_compiled_ccl_executes() {
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zQueueExec", 5);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zQueueExec", 5).unwrap();
     let source = "fn run() -> Integer { return 4; }";
     let (wasm, _) = icn_ccl::compile_ccl_source_to_wasm(source).unwrap();
     let ts = 0u64;
@@ -333,7 +333,7 @@ async fn compiled_example_contract_file_runs() {
     let source = std::fs::read_to_string(contract_path).expect("read example");
     let (wasm, _) = icn_ccl::compile_ccl_source_to_wasm(&source).unwrap();
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zExampleExec", 5);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zExampleExec", 5).unwrap();
     let block = DagBlock {
         cid: Cid::new_v1_sha256(0x71, &wasm),
         data: wasm.clone(),

--- a/crates/icn-runtime/tests/wasm_host_api.rs
+++ b/crates/icn-runtime/tests/wasm_host_api.rs
@@ -13,7 +13,7 @@ use wasmtime::{Engine, Linker, Module, Store};
 
 #[tokio::test]
 async fn wasm_host_api_functions() {
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostTest", 50);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostTest", 50).unwrap();
     let engine = Engine::default();
     let module_wat = r#"(module
         (import "icn" "wasm_host_submit_mesh_job" (func $submit (param i32 i32 i32 i32) (result i32)))
@@ -179,7 +179,7 @@ async fn wasm_host_api_functions() {
 
 #[tokio::test]
 async fn wasm_host_api_error_paths() {
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostErr", 10);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zHostErr", 10).unwrap();
     let engine = Engine::default();
     let module_wat = r#"(module
         (import "icn" "wasm_host_submit_mesh_job" (func $submit (param i32 i32 i32 i32) (result i32)))

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -165,7 +165,7 @@ async fn test_wasm_executor_with_ccl() {
 
     use icn_common::DagBlock;
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 10);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 10).unwrap();
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
@@ -307,7 +307,7 @@ async fn test_wasm_executor_runs_addition() {
 
     use icn_common::DagBlock;
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zAddExecInt", 10);
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zAddExecInt", 10).unwrap();
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;

--- a/tests/integration/persistence.rs
+++ b/tests/integration/persistence.rs
@@ -37,7 +37,8 @@ mod persistence_rocksdb {
             dag_path.clone(),
             mana_path.clone(),
             rep_path.clone(),
-        );
+        )
+        .unwrap();
 
         ctx1.credit_mana(&id, 42).await.unwrap();
         let block = sample_block();
@@ -52,7 +53,8 @@ mod persistence_rocksdb {
             dag_path,
             mana_path,
             rep_path,
-        );
+        )
+        .unwrap();
 
         assert_eq!(ctx2.mana_ledger.get_balance(&id), 42);
         assert!(ctx2


### PR DESCRIPTION
## Summary
- make RuntimeContext's stub and path constructors return `Result`
- unwrap constructors at callsites in tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: environment limitations)*
- `cargo test --all-features --workspace` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6860a5bb85a48324a2ea1340742f9c92