### PR TITLE
[runtime] implement hashing job

### DIFF
--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -32,6 +32,7 @@ once_cell = "1.21"
 prometheus-client = "0.22"
 clap = { version = "4.0", features = ["derive"], optional = true }
 icn-ccl = { path = "../../icn-ccl" }
+sha2 = "0.10"
 
 [dev-dependencies]
 anyhow = "1.0.75"
@@ -42,6 +43,8 @@ icn-ccl = { path = "../../icn-ccl" }
 tempfile = "3"
 # Ensure sequential execution for metrics tests
 serial_test = { version = "3", features = ["async"] }
+# Logging for integration tests
+env_logger = "0.11"
 # temp-dir = "0.1"
 
 [features]


### PR DESCRIPTION
## Summary
- implement SHA-256 hashing for `GenericPlaceholder` jobs
- add dependency on `sha2`
- add tests for deterministic hash output
- fix libp2p mesh test imports and clippy warnings

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6860e7c5dffc83249ba7f5cd8efed0a5