### PR TITLE
[icn-common] add nonce and gas fields

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -746,6 +746,9 @@ mod tests {
             recipient_did: None,
             payload_type: "test".to_string(),
             payload: b"hello".to_vec(),
+            nonce: 0,
+            gas_limit: 100,
+            gas_price: 1,
             signature: None,
         };
         let tx_json = serde_json::to_string(&tx).unwrap();

--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -24,6 +24,9 @@ async fn submit_transaction_and_query_data() {
         recipient_did: None,
         payload_type: "test".to_string(),
         payload: b"hello".to_vec(),
+        nonce: 0,
+        gas_limit: 100,
+        gas_price: 1,
         signature: None,
     };
     let tx_json = serde_json::to_string(&tx).unwrap();

--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -475,9 +475,14 @@ pub struct Transaction {
     pub payload_type: String,
     /// Serialized transaction-specific data.
     pub payload: Vec<u8>,
+    /// Nonce ensuring transaction uniqueness.
+    pub nonce: u64,
+    /// Maximum compute units the sender is willing to expend.
+    pub gas_limit: u64,
+    /// Price per compute unit the sender is willing to pay.
+    pub gas_price: u64,
     /// Optional Ed25519 signature of the transaction content.
     pub signature: Option<SignatureBytes>,
-    // TODO: Add fields like nonce, gas_limit, gas_price if relevant to economic model
 }
 
 /// Minimal DID document containing the public verifying key for a [`Did`].
@@ -516,6 +521,9 @@ impl Signable for Transaction {
         }
         bytes.extend_from_slice(self.payload_type.as_bytes());
         bytes.extend_from_slice(&self.payload);
+        bytes.extend_from_slice(&self.nonce.to_le_bytes());
+        bytes.extend_from_slice(&self.gas_limit.to_le_bytes());
+        bytes.extend_from_slice(&self.gas_price.to_le_bytes());
         Ok(bytes)
     }
 }
@@ -635,6 +643,9 @@ mod tests {
             recipient_did: None,
             payload_type: "test_payload".to_string(),
             payload: b"some test data".to_vec(),
+            nonce: 1,
+            gas_limit: 10,
+            gas_price: 1,
             signature: Some(SignatureBytes(vec![0u8; ed25519_dalek::SIGNATURE_LENGTH])),
         };
         assert_eq!(transaction.sender_did, sender);

--- a/crates/icn-common/tests/signable.rs
+++ b/crates/icn-common/tests/signable.rs
@@ -15,6 +15,9 @@ fn transaction_sign_verify() {
         recipient_did: None,
         payload_type: "test".to_string(),
         payload: b"hello".to_vec(),
+        nonce: 0,
+        gas_limit: 100,
+        gas_price: 1,
         signature: None,
     };
 
@@ -24,6 +27,26 @@ fn transaction_sign_verify() {
     let mut bad_tx = tx.clone();
     bad_tx.payload.push(1);
     assert!(bad_tx.verify(&sig, &pk).is_err());
+}
+
+#[test]
+fn transaction_serialization_roundtrip() {
+    let tx = Transaction {
+        id: "tx2".to_string(),
+        timestamp: 42,
+        sender_did: Did::new("key", "alice"),
+        recipient_did: Some(Did::new("key", "bob")),
+        payload_type: "test".to_string(),
+        payload: b"hello".to_vec(),
+        nonce: 7,
+        gas_limit: 200,
+        gas_price: 2,
+        signature: None,
+    };
+
+    let json = serde_json::to_string(&tx).unwrap();
+    let parsed: Transaction = serde_json::from_str(&json).unwrap();
+    assert_eq!(tx, parsed);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- extend `Transaction` with `nonce`, `gas_limit`, and `gas_price`
- update signing to include these new fields
- adapt transaction helpers and tests
- add round‑trip serialization test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --version`
- `cargo test --all-features --workspace` *(failed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686138ccd04c832484a8fa5f262bec88