### PR TITLE
[icn-node] add sled storage support

### DIFF
--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -95,7 +95,7 @@ Useful CLI flags include:
 
 * `--node-did-path <PATH>` – location to read/write the node DID string
 * `--node-private-key-path <PATH>` – location to read/write the node private key
-* `--storage-backend <memory|file|sqlite|rocksdb>` – choose the DAG storage backend
+* `--storage-backend <memory|file|sqlite|sled|rocksdb>` – choose the DAG storage backend
 * `--storage-path <PATH>` – directory for the file or SQLite backends
 * `--mana-ledger-backend <file|sled|sqlite|rocksdb>` – choose ledger persistence
 * `--mana-ledger-path <PATH>` – location of the mana ledger database

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -3,6 +3,17 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
+
+use icn_common::{CommonError, DagBlock};
+use icn_dag::{FileDagStore, InMemoryDagStore, StorageService};
+#[cfg(feature = "persist-rocksdb")]
+use icn_dag::rocksdb_store::RocksDagStore;
+#[cfg(feature = "persist-sled")]
+use icn_dag::sled_store::SledDagStore;
+#[cfg(feature = "persist-sqlite")]
+use icn_dag::sqlite_store::SqliteDagStore;
 
 /// Storage backends supported by the node.
 #[derive(clap::ValueEnum, Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -511,5 +522,62 @@ impl NodeConfig {
             }
         }
         Ok(())
+    }
+
+    /// Initialize a DAG store based on this configuration.
+    pub fn init_dag_store(
+        &self,
+    ) -> Result<Arc<TokioMutex<dyn StorageService<DagBlock> + Send>>, CommonError> {
+        let store: Arc<TokioMutex<dyn StorageService<DagBlock> + Send>> =
+            match self.storage_backend {
+                StorageBackendType::Memory =>
+                    Arc::new(TokioMutex::new(InMemoryDagStore::new())) as Arc<_>,
+                StorageBackendType::File => Arc::new(TokioMutex::new(
+                    FileDagStore::new(self.storage_path.clone())?,
+                )) as Arc<_>,
+                StorageBackendType::Sqlite => {
+                    #[cfg(feature = "persist-sqlite")]
+                    {
+                        Arc::new(TokioMutex::new(SqliteDagStore::new(
+                            self.storage_path.clone(),
+                        )?)) as Arc<_>
+                    }
+                    #[cfg(not(feature = "persist-sqlite"))]
+                    {
+                        return Err(CommonError::ConfigError(
+                            "sqlite backend requires 'persist-sqlite' feature".into(),
+                        ));
+                    }
+                }
+                StorageBackendType::Sled => {
+                    #[cfg(feature = "persist-sled")]
+                    {
+                        Arc::new(TokioMutex::new(SledDagStore::new(
+                            self.storage_path.clone(),
+                        )?)) as Arc<_>
+                    }
+                    #[cfg(not(feature = "persist-sled"))]
+                    {
+                        return Err(CommonError::ConfigError(
+                            "sled backend requires 'persist-sled' feature".into(),
+                        ));
+                    }
+                }
+                StorageBackendType::Rocksdb => {
+                    #[cfg(feature = "persist-rocksdb")]
+                    {
+                        Arc::new(TokioMutex::new(RocksDagStore::new(
+                            self.storage_path.clone(),
+                        )?)) as Arc<_>
+                    }
+                    #[cfg(not(feature = "persist-rocksdb"))]
+                    {
+                        return Err(CommonError::ConfigError(
+                            "rocksdb backend requires 'persist-rocksdb' feature".into(),
+                        ));
+                    }
+                }
+            };
+        Ok(store)
     }
 }

--- a/crates/icn-node/tests/auth.rs
+++ b/crates/icn-node/tests/auth.rs
@@ -7,7 +7,17 @@ use tokio::task;
 #[tokio::test]
 async fn api_key_required_for_requests() {
     let (router, _ctx) =
-        app_router_with_options(Some("secret".into()), None, None, None, None, None, None).await;
+        app_router_with_options(
+            Some("secret".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = task::spawn(async move {
@@ -42,7 +52,17 @@ async fn api_key_required_for_requests() {
 #[tokio::test]
 async fn bearer_token_required_for_requests() {
     let (router, _ctx) =
-        app_router_with_options(None, Some("s3cr3t".into()), None, None, None, None, None).await;
+        app_router_with_options(
+            None,
+            Some("s3cr3t".into()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = task::spawn(async move {
@@ -88,6 +108,7 @@ async fn tls_api_key_and_bearer_token() {
     let (router, _ctx) = app_router_with_options(
         Some("secret".into()),
         Some("token".into()),
+        None,
         None,
         None,
         None,

--- a/crates/icn-node/tests/dag_persistence.rs
+++ b/crates/icn-node/tests/dag_persistence.rs
@@ -1,0 +1,61 @@
+#[cfg(feature = "persist-sled")]
+use icn_common::{compute_merkle_cid, DagBlock, Did};
+use icn_node::{app_router_with_options, config::StorageBackendType};
+use std::str::FromStr;
+use tempfile::tempdir;
+
+#[cfg(feature = "persist-sled")]
+#[tokio::test]
+async fn dag_persists_between_restarts_sled() {
+    let dir = tempdir().unwrap();
+    let ledger_path = dir.path().join("mana.sled");
+    let dag_path = dir.path().join("dag_db");
+
+    let (_router, ctx) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(ledger_path.clone()),
+        Some(StorageBackendType::Sled),
+        Some(dag_path.clone()),
+        None,
+        None,
+    )
+    .await;
+
+    let data = b"hello".to_vec();
+    let ts = 0u64;
+    let author = Did::from_str("did:example:tester").unwrap();
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &None);
+    let block = DagBlock {
+        cid: cid.clone(),
+        data: data.clone(),
+        links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: None,
+    };
+    {
+        let mut store = ctx.dag_store.lock().await;
+        store.put(&block).unwrap();
+    }
+
+    drop(_router);
+
+    let (_router2, ctx2) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(ledger_path.clone()),
+        Some(StorageBackendType::Sled),
+        Some(dag_path.clone()),
+        None,
+        None,
+    )
+    .await;
+
+    let stored = ctx2.dag_store.lock().await.get(&cid).unwrap();
+    assert!(stored.is_some());
+}

--- a/crates/icn-node/tests/governance_persistence.rs
+++ b/crates/icn-node/tests/governance_persistence.rs
@@ -16,6 +16,7 @@ async fn governance_persists_between_restarts() {
         None,
         None,
         Some(ledger_path.clone()),
+        None,
         Some(gov_path.clone()),
         None,
     )
@@ -51,6 +52,7 @@ async fn governance_persists_between_restarts() {
         None,
         None,
         Some(ledger_path.clone()),
+        None,
         Some(gov_path.clone()),
         None,
     )

--- a/crates/icn-node/tests/ledger.rs
+++ b/crates/icn-node/tests/ledger.rs
@@ -16,6 +16,7 @@ async fn ledger_persists_between_restarts() {
         Some(ledger_path.clone()),
         None,
         None,
+        None,
     )
     .await;
     let did = Did::from_str("did:example:alice").unwrap();
@@ -29,6 +30,7 @@ async fn ledger_persists_between_restarts() {
         None,
         None,
         Some(ledger_path.clone()),
+        None,
         None,
         None,
     )

--- a/crates/icn-node/tests/reputation.rs
+++ b/crates/icn-node/tests/reputation.rs
@@ -16,6 +16,7 @@ async fn reputation_persists_between_restarts() {
         None,
         Some(ledger_path.clone()),
         None,
+        None,
         Some(rep_path.clone()),
     )
     .await;
@@ -30,6 +31,7 @@ async fn reputation_persists_between_restarts() {
         None,
         None,
         Some(ledger_path.clone()),
+        None,
         None,
         Some(rep_path.clone()),
     )


### PR DESCRIPTION
## Summary
- handle `--storage-backend sled` in `NodeConfig`
- use new configuration helper in node startup
- expose sled option in README
- allow tests to choose DAG backend
- test sled DAG persistence across restarts

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: compilation aborted)*
- `cargo test --all-features --workspace` *(fails: compilation aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68615b8eeab88324b5710c8e4a075f46