### PR TITLE
[icn-governance] add pending proposals and open voting

### DIFF
--- a/crates/icn-governance/tests/callback.rs
+++ b/crates/icn-governance/tests/callback.rs
@@ -28,6 +28,7 @@ fn callback_runs_on_execute() {
             60,
         )
         .unwrap();
+    gov.open_voting(&pid).unwrap();
     gov.cast_vote(
         Did::from_str("did:example:bob").unwrap(),
         &pid,

--- a/crates/icn-governance/tests/pending.rs
+++ b/crates/icn-governance/tests/pending.rs
@@ -1,0 +1,52 @@
+use icn_common::Did;
+use icn_governance::{GovernanceModule, ProposalStatus, ProposalType, VoteOption};
+use std::str::FromStr;
+
+#[test]
+fn open_voting_transitions_from_pending() {
+    let mut gov = GovernanceModule::new();
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("pending".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap();
+    let prop = gov.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.status, ProposalStatus::Pending);
+
+    gov.open_voting(&pid).unwrap();
+    let prop = gov.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.status, ProposalStatus::VotingOpen);
+}
+
+#[test]
+fn vote_rejected_before_opening() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("vote".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap();
+
+    let res = gov.cast_vote(
+        Did::from_str("did:example:alice").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    );
+    assert!(res.is_err());
+
+    gov.open_voting(&pid).unwrap();
+    assert!(gov
+        .cast_vote(
+            Did::from_str("did:example:alice").unwrap(),
+            &pid,
+            VoteOption::Yes
+        )
+        .is_ok());
+}

--- a/crates/icn-governance/tests/sled.rs
+++ b/crates/icn-governance/tests/sled.rs
@@ -21,6 +21,8 @@ mod tests {
             )
             .unwrap();
 
+        gov.open_voting(&pid).unwrap();
+
         // 2. vote
         gov.cast_vote(
             Did::from_str("did:example:bob").unwrap(),
@@ -56,6 +58,7 @@ mod tests {
                 60,
             )
             .unwrap();
+        gov.open_voting(&pid).unwrap();
         gov.cast_vote(
             Did::from_str("did:example:alice").unwrap(),
             &pid,
@@ -124,6 +127,7 @@ mod tests {
                 60,
             )
             .unwrap();
+        gov.open_voting(&pid).unwrap();
         drop(gov);
 
         let mut gov2 = GovernanceModule::new_sled(dir.path().to_path_buf()).unwrap();

--- a/crates/icn-governance/tests/voting.rs
+++ b/crates/icn-governance/tests/voting.rs
@@ -20,6 +20,9 @@ fn vote_tally_and_execute() {
         )
         .unwrap();
 
+    // open voting period
+    gov.open_voting(&pid).unwrap();
+
     gov.cast_vote(
         Did::from_str("did:example:bob").unwrap(),
         &pid,
@@ -62,6 +65,8 @@ fn reject_due_to_quorum() {
             60,
         )
         .unwrap();
+
+    gov.open_voting(&pid).unwrap();
 
     gov.cast_vote(
         Did::from_str("did:example:bob").unwrap(),


### PR DESCRIPTION
## Summary
- start proposals in `Pending`
- add `open_voting` to move proposals to `VotingOpen`
- restrict votes to open proposals
- adjust tests for new workflow
- add coverage for pending → open transition

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: Codex couldn't finish due to environment limits)*
- `cargo test --all-features --workspace` *(failed: Codex couldn't finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6861a441dee483249f7c455209f1704e