### PR TITLE
[governance] add RemoveMember proposal

### DIFF
--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -47,6 +47,7 @@ impl std::str::FromStr for ProposalId {
 pub enum ProposalType {
     SystemParameterChange(String, String), // param_name, new_value
     NewMemberInvitation(Did),              // DID of the member to invite
+    RemoveMember(Did),                    // DID of the member to remove
     SoftwareUpgrade(String),               // Version or identifier for the upgrade
     GenericText(String),                   // For general purpose proposals
 }
@@ -443,6 +444,11 @@ impl GovernanceModule {
         self.members.insert(member);
     }
 
+    /// Removes a member from the federation if present.
+    pub fn remove_member(&mut self, did: &Did) {
+        self.members.remove(did);
+    }
+
     /// Returns a reference to the current member set.
     pub fn members(&self) -> &HashSet<Did> {
         &self.members
@@ -743,8 +749,14 @@ impl GovernanceModule {
                         proposal_id.0
                     )));
                 }
-                if let ProposalType::NewMemberInvitation(did) = &proposal.proposal_type {
-                    self.members.insert(did.clone());
+                match &proposal.proposal_type {
+                    ProposalType::NewMemberInvitation(did) => {
+                        self.members.insert(did.clone());
+                    }
+                    ProposalType::RemoveMember(did) => {
+                        self.remove_member(did);
+                    }
+                    _ => {}
                 }
                 if let Some(cb) = &self.proposal_callback {
                     if let Err(e) = cb(proposal) {
@@ -794,8 +806,14 @@ impl GovernanceModule {
                         proposal_id.0
                     )));
                 }
-                if let ProposalType::NewMemberInvitation(did) = &proposal.proposal_type {
-                    self.members.insert(did.clone());
+                match &proposal.proposal_type {
+                    ProposalType::NewMemberInvitation(did) => {
+                        self.members.insert(did.clone());
+                    }
+                    ProposalType::RemoveMember(did) => {
+                        self.remove_member(did);
+                    }
+                    _ => {}
                 }
                 if let Some(cb) = &self.proposal_callback {
                     if let Err(e) = cb(&proposal) {

--- a/crates/icn-governance/tests/membership.rs
+++ b/crates/icn-governance/tests/membership.rs
@@ -1,0 +1,55 @@
+use icn_common::Did;
+use icn_governance::{GovernanceModule, ProposalStatus, ProposalType, VoteOption};
+use std::str::FromStr;
+
+#[test]
+fn new_member_invitation_executes() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.set_quorum(2);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::NewMemberInvitation(Did::from_str("did:example:dave").unwrap()),
+            "invite dave".into(),
+            60,
+        )
+        .unwrap();
+
+    gov.cast_vote(Did::from_str("did:example:alice").unwrap(), &pid, VoteOption::Yes).unwrap();
+    gov.cast_vote(Did::from_str("did:example:bob").unwrap(), &pid, VoteOption::Yes).unwrap();
+
+    assert_eq!(gov.close_voting_period(&pid).unwrap(), ProposalStatus::Accepted);
+    gov.execute_proposal(&pid).unwrap();
+
+    assert!(gov.members().contains(&Did::from_str("did:example:dave").unwrap()));
+}
+
+#[test]
+fn remove_member_proposal_executes() {
+    let mut gov = GovernanceModule::new();
+    let alice = Did::from_str("did:example:alice").unwrap();
+    let bob = Did::from_str("did:example:bob").unwrap();
+    gov.add_member(alice.clone());
+    gov.add_member(bob.clone());
+    gov.set_quorum(2);
+
+    let pid = gov
+        .submit_proposal(
+            alice.clone(),
+            ProposalType::RemoveMember(bob.clone()),
+            "remove bob".into(),
+            60,
+        )
+        .unwrap();
+
+    gov.cast_vote(alice.clone(), &pid, VoteOption::Yes).unwrap();
+    gov.cast_vote(bob.clone(), &pid, VoteOption::Yes).unwrap();
+
+    assert_eq!(gov.close_voting_period(&pid).unwrap(), ProposalStatus::Accepted);
+    gov.execute_proposal(&pid).unwrap();
+
+    assert!(!gov.members().contains(&bob));
+}


### PR DESCRIPTION
## Summary
- support removing members via governance proposals
- add membership tests for add/remove member proposals

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-governance --all-targets --all-features -- -D warnings` *(failed: compilation timed out)*
- `cargo test -p icn-governance --all-features -- --test-threads=1` *(failed: compilation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4434ccc8324a4389d9037754651