### PR TITLE
[governance] expand voting tests and runtime integration

### DIFF
--- a/crates/icn-governance/tests/voting.rs
+++ b/crates/icn-governance/tests/voting.rs
@@ -73,3 +73,109 @@ fn reject_due_to_quorum() {
     let status = gov.close_voting_period(&pid).unwrap();
     assert_eq!(status, ProposalStatus::Rejected);
 }
+
+#[test]
+fn reject_due_to_threshold() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.add_member(Did::from_str("did:example:charlie").unwrap());
+    gov.set_quorum(3);
+    gov.set_threshold(0.75);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("threshold".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap();
+
+    gov.cast_vote(
+        Did::from_str("did:example:bob").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:charlie").unwrap(),
+        &pid,
+        VoteOption::No,
+    )
+    .unwrap();
+
+    let status = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Rejected);
+}
+
+#[test]
+fn auto_close_after_deadline() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.set_quorum(1);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("auto".into()),
+            "desc".into(),
+            1,
+        )
+        .unwrap();
+
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    gov.close_expired_proposals().unwrap();
+    let prop = gov.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.status, ProposalStatus::Rejected);
+    assert!(gov
+        .cast_vote(
+            Did::from_str("did:example:alice").unwrap(),
+            &pid,
+            VoteOption::Yes
+        )
+        .is_err());
+}
+
+#[test]
+fn member_removal_affects_outcome() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.add_member(Did::from_str("did:example:charlie").unwrap());
+    gov.set_quorum(2);
+    gov.set_threshold(0.75);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::GenericText("member".into()),
+            "desc".into(),
+            60,
+        )
+        .unwrap();
+
+    gov.cast_vote(
+        Did::from_str("did:example:alice").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:bob").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:charlie").unwrap(),
+        &pid,
+        VoteOption::No,
+    )
+    .unwrap();
+
+    gov.remove_member(&Did::from_str("did:example:charlie").unwrap());
+
+    let status = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
+}

--- a/crates/icn-runtime/tests/governance.rs
+++ b/crates/icn-runtime/tests/governance.rs
@@ -64,3 +64,54 @@ async fn proposal_can_be_closed_and_executed() {
         assert_eq!(prop.status, ProposalStatus::Executed);
     }
 }
+
+#[tokio::test]
+async fn lifecycle_with_member_add_and_remove() {
+    let ctx = RuntimeContext::new_with_stubs("did:icn:test:alice").unwrap();
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.add_member(Did::from_str("did:icn:test:alice").unwrap());
+        gov.add_member(Did::from_str("did:icn:test:bob").unwrap());
+        gov.set_quorum(2);
+        gov.set_threshold(0.5);
+    }
+
+    let payload = serde_json::json!({
+        "proposal_type_str": "NewMemberInvitation",
+        "type_specific_payload": b"did:icn:test:dave".to_vec(),
+        "description": "invite dave",
+        "duration_secs": 60
+    });
+    let pid_str = host_create_governance_proposal(&ctx, &payload.to_string())
+        .await
+        .expect("create proposal");
+    let pid = ProposalId(pid_str.clone());
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.cast_vote(
+            Did::from_str("did:icn:test:bob").unwrap(),
+            &pid,
+            VoteOption::Yes,
+        )
+        .unwrap();
+    }
+    let status = host_close_governance_proposal_voting(&ctx, &pid_str)
+        .await
+        .expect("close voting");
+    assert_eq!(status, format!("{:?}", ProposalStatus::Accepted));
+
+    host_execute_governance_proposal(&ctx, &pid_str)
+        .await
+        .expect("execute proposal");
+
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        assert!(gov
+            .members()
+            .contains(&Did::from_str("did:icn:test:dave").unwrap()));
+        gov.remove_member(&Did::from_str("did:icn:test:dave").unwrap());
+        assert!(!gov
+            .members()
+            .contains(&Did::from_str("did:icn:test:dave").unwrap()));
+    }
+}


### PR DESCRIPTION
## Summary
- add remove_member and close_expired_proposals helpers
- cover threshold failure, auto deadline close, and member removal
- exercise governance lifecycle with member add/remove at runtime

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: took too long)*
- `cargo test --all-features --workspace` *(failed: took too long)*

------
https://chatgpt.com/codex/tasks/task_e_6861a443ee848324b2dc53af4e1f759f