### PR TITLE
[governance] add RemoveMember proposal

### DIFF
--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -47,6 +47,7 @@ impl std::str::FromStr for ProposalId {
 pub enum ProposalType {
     SystemParameterChange(String, String), // param_name, new_value
     NewMemberInvitation(Did),              // DID of the member to invite
+    RemoveMember(Did),                     // DID of the member to remove
     SoftwareUpgrade(String),               // Version or identifier for the upgrade
     GenericText(String),                   // For general purpose proposals
 }
@@ -522,8 +523,8 @@ impl GovernanceModule {
     }
 
     /// Removes an existing member, preventing them from voting.
-    pub fn remove_member(&mut self, member: &Did) {
-        self.members.remove(member);
+    pub fn remove_member(&mut self, did: &Did) {
+        self.members.remove(did);
     }
 
     /// Returns a reference to the current member set.
@@ -888,8 +889,14 @@ impl GovernanceModule {
                         proposal_id.0
                     )));
                 }
-                if let ProposalType::NewMemberInvitation(did) = &proposal.proposal_type {
-                    self.members.insert(did.clone());
+                match &proposal.proposal_type {
+                    ProposalType::NewMemberInvitation(did) => {
+                        self.members.insert(did.clone());
+                    }
+                    ProposalType::RemoveMember(did) => {
+                        self.remove_member(did);
+                    }
+                    _ => {}
                 }
                 if let Some(cb) = &self.proposal_callback {
                     if let Err(e) = cb(proposal) {
@@ -939,8 +946,14 @@ impl GovernanceModule {
                         proposal_id.0
                     )));
                 }
-                if let ProposalType::NewMemberInvitation(did) = &proposal.proposal_type {
-                    self.members.insert(did.clone());
+                match &proposal.proposal_type {
+                    ProposalType::NewMemberInvitation(did) => {
+                        self.members.insert(did.clone());
+                    }
+                    ProposalType::RemoveMember(did) => {
+                        self.remove_member(did);
+                    }
+                    _ => {}
                 }
                 if let Some(cb) = &self.proposal_callback {
                     if let Err(e) = cb(&proposal) {

--- a/crates/icn-governance/tests/execution.rs
+++ b/crates/icn-governance/tests/execution.rs
@@ -1,0 +1,83 @@
+use icn_common::Did;
+use icn_governance::{GovernanceModule, ProposalStatus, ProposalType, VoteOption};
+use std::str::FromStr;
+
+#[test]
+fn execute_new_member_invitation_proposal() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.set_quorum(2);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::NewMemberInvitation(Did::from_str("did:example:dave").unwrap()),
+            "invite dave".into(),
+            60,
+        )
+        .unwrap();
+    gov.open_voting(&pid).unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:alice").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:bob").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    assert_eq!(
+        gov.close_voting_period(&pid).unwrap(),
+        ProposalStatus::Accepted
+    );
+    gov.execute_proposal(&pid).unwrap();
+    assert!(gov
+        .members()
+        .contains(&Did::from_str("did:example:dave").unwrap()));
+    let prop = gov.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.status, ProposalStatus::Executed);
+}
+
+#[test]
+fn execute_remove_member_proposal() {
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.set_quorum(2);
+
+    let pid = gov
+        .submit_proposal(
+            Did::from_str("did:example:alice").unwrap(),
+            ProposalType::RemoveMember(Did::from_str("did:example:bob").unwrap()),
+            "remove bob".into(),
+            60,
+        )
+        .unwrap();
+    gov.open_voting(&pid).unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:alice").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    gov.cast_vote(
+        Did::from_str("did:example:bob").unwrap(),
+        &pid,
+        VoteOption::Yes,
+    )
+    .unwrap();
+    assert_eq!(
+        gov.close_voting_period(&pid).unwrap(),
+        ProposalStatus::Accepted
+    );
+    gov.execute_proposal(&pid).unwrap();
+    assert!(!gov
+        .members()
+        .contains(&Did::from_str("did:example:bob").unwrap()));
+    let prop = gov.get_proposal(&pid).unwrap().unwrap();
+    assert_eq!(prop.status, ProposalStatus::Executed);
+}


### PR DESCRIPTION
## Summary
- extend `ProposalType` to support removing a federation member
- expose `remove_member(&mut self, did: &Did)`
- execute proposals that add or remove members
- test executing `NewMemberInvitation` and `RemoveMember`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6861cfa9d7fc832488a0b6f068b84c89