### PR TITLE
[runtime] reward proposer on proposal execution

### DIFF
--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1440,21 +1440,39 @@ impl RuntimeContext {
             .map_err(|e| HostAbiError::InvalidParameters(format!("Invalid proposal id: {e}")))?;
 
         let mut gov = self.governance_module.lock().await;
-        gov.execute_proposal(&proposal_id)
-            .map_err(HostAbiError::Common)?;
-        let proposal = gov
+        let result = gov.execute_proposal(&proposal_id);
+        let proposal_opt = gov
             .get_proposal(&proposal_id)
-            .map_err(HostAbiError::Common)?
-            .expect("Proposal should exist after execution");
+            .map_err(HostAbiError::Common)?;
         drop(gov);
 
-        let encoded = bincode::serialize(&proposal).map_err(|e| {
-            HostAbiError::InternalError(format!("Failed to serialize proposal: {e}"))
-        })?;
-        if let Err(e) = self.mesh_network_service.announce_proposal(encoded).await {
-            warn!("Failed to broadcast proposal {:?}: {}", proposal_id, e);
+        if let Some(proposal) = proposal_opt {
+            match result {
+                Ok(()) => {
+                    // reward proposer for successful execution
+                    self.credit_mana(&proposal.proposer, 1).await?;
+                    self.reputation_store
+                        .record_execution(&proposal.proposer, true, 0);
+
+                    let encoded = bincode::serialize(&proposal).map_err(|e| {
+                        HostAbiError::InternalError(format!("Failed to serialize proposal: {e}"))
+                    })?;
+                    if let Err(e) = self.mesh_network_service.announce_proposal(encoded).await {
+                        warn!("Failed to broadcast proposal {:?}: {}", proposal_id, e);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    // penalize proposer on failure without crediting mana
+                    self.reputation_store
+                        .record_execution(&proposal.proposer, false, 0);
+                    Err(HostAbiError::Common(e))
+                }
+            }
+        } else {
+            // Proposal not found
+            result.map_err(HostAbiError::Common)
         }
-        Ok(())
     }
 
     /// Inserts a proposal received from the network into the local GovernanceModule.


### PR DESCRIPTION
## Summary
- reward and penalize proposal executors in `execute_governance_proposal`
- test proposer mana and reputation changes on success/failure

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-runtime --all-targets --all-features -- -D warnings` *(failed: could not finish build)*
- `cargo test --all-features --workspace` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6861e59f2bc88324b28b00ff140399b0