### PR TITLE
[economics,runtime] add mana regeneration

### DIFF
--- a/crates/icn-economics/README.md
+++ b/crates/icn-economics/README.md
@@ -21,6 +21,12 @@ The API style emphasizes:
 *   **Accuracy:** Precise and auditable tracking of economic states.
 *   **Interoperability:** Clear interfaces for other crates (e.g., `icn-governance`, `icn-runtime`) to interact with economic functions.
 
+### Mana Regeneration
+
+Ledger implementations may support bulk credit operations.
+`ManaLedger::credit_all` adds a specified amount to every account and is used by
+the runtime to periodically regenerate balances.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -39,6 +39,16 @@ pub trait ManaLedger: Send + Sync {
     fn spend(&self, did: &Did, amount: u64) -> Result<(), EconError>;
     /// Credit mana to the account.
     fn credit(&self, did: &Did, amount: u64) -> Result<(), EconError>;
+    /// Credit every known account with additional mana.
+    ///
+    /// The default implementation returns an [`EconError::AdapterError`]
+    /// if the ledger backend does not support iterating over accounts.
+    fn credit_all(&self, amount: u64) -> Result<(), EconError> {
+        let _ = amount;
+        Err(EconError::AdapterError(
+            "credit_all not implemented for this ledger".into(),
+        ))
+    }
 }
 
 /// Thin wrapper exposing convenience methods over a [`ManaLedger`].

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -77,6 +77,12 @@ closed via `host_close_governance_proposal_voting`, returning the final
 `host_execute_governance_proposal`, which updates the stored proposal and member
 set.
 
+## Mana Regeneration
+
+`RuntimeContext` can automatically replenish mana. Use
+`spawn_mana_regenerator` to start a background task that credits every
+account with a fixed amount on a configurable interval.
+
 ## Error Types
 
 `MeshJobError` enumerates failures that can occur while processing mesh jobs.

--- a/crates/icn-runtime/tests/mana_regenerator.rs
+++ b/crates/icn-runtime/tests/mana_regenerator.rs
@@ -1,0 +1,13 @@
+use icn_runtime::context::RuntimeContext;
+use std::time::Duration;
+
+#[tokio::test]
+async fn balances_increase_when_regenerator_runs() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:regen", 0).unwrap();
+    let interval = Duration::from_millis(100);
+    ctx.clone().spawn_mana_regenerator(5, interval).await;
+    assert_eq!(ctx.mana_ledger.get_balance(&ctx.current_identity), 0);
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    let bal1 = ctx.mana_ledger.get_balance(&ctx.current_identity);
+    assert!(bal1 >= 5);
+}

--- a/icn-runtime/tests/mesh.rs
+++ b/icn-runtime/tests/mesh.rs
@@ -152,6 +152,14 @@ impl icn_economics::ManaLedger for InMemoryManaLedger {
         *map.entry(did.clone()).or_insert(0) += amount;
         Ok(())
     }
+
+    fn credit_all(&self, amount: u64) -> Result<(), EconError> {
+        let mut map = self.balances.lock().unwrap();
+        for val in map.values_mut() {
+            *val += amount;
+        }
+        Ok(())
+    }
 }
 
 // Helper to create a test RuntimeContext with mocked dependencies


### PR DESCRIPTION
## Summary
- add credit_all method to ManaLedger trait and implementations
- spawn_mana_regenerator task in RuntimeContext
- document mana regeneration behavior
- test regen increments balances

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-runtime -- -D warnings` *(fails: cannot borrow `*self` as mutable more than once at a time)*
- `cargo test -p icn-runtime balances_increase_when_regenerator_runs` *(interrupted after long build)*

------
https://chatgpt.com/codex/tasks/task_e_6861e59a6810832490cf817bedf22318