### PR TITLE
[governance] scoped DAG policy enforcement

### DIFF
--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -19,6 +19,8 @@ use std::path::PathBuf;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+pub mod scoped_policy;
+
 // --- Proposal System ---
 
 /// Unique identifier for a governance proposal.

--- a/crates/icn-governance/src/scoped_policy.rs
+++ b/crates/icn-governance/src/scoped_policy.rs
@@ -1,0 +1,63 @@
+pub enum PolicyCheckResult {
+    Allowed,
+    Denied { reason: String },
+}
+
+use icn_common::Did;
+
+/// Operations that may be subject to scoped policy checks when writing to the DAG.
+#[derive(Debug, Clone, Copy)]
+pub enum DagPayloadOp {
+    SubmitBlock,
+    AnchorReceipt,
+}
+
+/// Trait for enforcing scoped policies on DAG operations.
+pub trait ScopedPolicyEnforcer: Send + Sync {
+    fn check_permission(&self, op: DagPayloadOp, actor: &Did) -> PolicyCheckResult;
+}
+
+use std::collections::HashSet;
+
+/// In-memory implementation of [`ScopedPolicyEnforcer`] based on membership lists.
+#[derive(Default)]
+pub struct InMemoryPolicyEnforcer {
+    submitters: HashSet<Did>,
+    anchorers: HashSet<Did>,
+}
+
+impl InMemoryPolicyEnforcer {
+    /// Create a new enforcer with the given allowed members for submitting blocks
+    /// and anchoring receipts.
+    pub fn new(submitters: HashSet<Did>, anchorers: HashSet<Did>) -> Self {
+        Self {
+            submitters,
+            anchorers,
+        }
+    }
+}
+
+impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
+    fn check_permission(&self, op: DagPayloadOp, actor: &Did) -> PolicyCheckResult {
+        match op {
+            DagPayloadOp::SubmitBlock => {
+                if self.submitters.contains(actor) {
+                    PolicyCheckResult::Allowed
+                } else {
+                    PolicyCheckResult::Denied {
+                        reason: "actor not authorized to submit DAG blocks".to_string(),
+                    }
+                }
+            }
+            DagPayloadOp::AnchorReceipt => {
+                if self.anchorers.contains(actor) {
+                    PolicyCheckResult::Allowed
+                } else {
+                    PolicyCheckResult::Denied {
+                        reason: "actor not authorized to anchor receipts".to_string(),
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/icn-runtime/src/error.rs
+++ b/crates/icn-runtime/src/error.rs
@@ -113,6 +113,10 @@ impl From<HostAbiError> for MeshJobError {
                 reason,
             },
             HostAbiError::CryptoError(reason) => MeshJobError::CryptoError { reason },
+            HostAbiError::PermissionDenied(reason) => MeshJobError::PermissionDenied {
+                job_id: Cid::new_v1_sha256(0, b"host_abi_permission"),
+                reason,
+            },
             HostAbiError::WasmExecutionError(reason) => MeshJobError::WasmExecutionError { reason },
             HostAbiError::ResourceLimitExceeded(reason) => {
                 MeshJobError::ResourceLimitExceeded { reason }

--- a/crates/icn-runtime/tests/error_variants.rs
+++ b/crates/icn-runtime/tests/error_variants.rs
@@ -61,3 +61,15 @@ fn host_abi_dag_error_maps_to_dag_operation_failed() {
         _ => panic!("Unexpected mapping: {mesh_err:?}"),
     }
 }
+
+#[test]
+fn host_abi_permission_denied_maps() {
+    let err = HostAbiError::PermissionDenied("nope".to_string());
+    let mesh_err: MeshJobError = err.into();
+    match mesh_err {
+        MeshJobError::PermissionDenied { reason, .. } => {
+            assert_eq!(reason, "nope");
+        }
+        _ => panic!("Unexpected mapping: {mesh_err:?}"),
+    }
+}

--- a/crates/icn-runtime/tests/policy.rs
+++ b/crates/icn-runtime/tests/policy.rs
@@ -1,0 +1,48 @@
+use icn_common::{Cid, Did};
+use icn_governance::scoped_policy::InMemoryPolicyEnforcer;
+use icn_identity::{ExecutionReceipt, SignatureBytes};
+use icn_runtime::{
+    context::{HostAbiError, RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner},
+    host_anchor_receipt, ReputationUpdater,
+};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
+
+#[tokio::test]
+async fn anchor_receipt_denied_by_policy() {
+    let did = Did::from_str("did:icn:test:denied").unwrap();
+    let ctx = RuntimeContext::new_with_ledger_path(
+        did.clone(),
+        Arc::new(StubMeshNetworkService::new()),
+        Arc::new(StubSigner::new()),
+        Arc::new(icn_identity::KeyDidResolver),
+        Arc::new(TokioMutex::new(StubDagStore::new())),
+        PathBuf::from("./mana_ledger.sled"),
+        PathBuf::from("./reputation.sled"),
+        Some(Arc::new(InMemoryPolicyEnforcer::new(
+            HashSet::new(),
+            HashSet::new(),
+        ))),
+    );
+
+    let receipt = ExecutionReceipt {
+        job_id: Cid::new_v1_sha256(0x55, b"job"),
+        executor_did: did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"res"),
+        cpu_ms: 1,
+        success: true,
+        sig: SignatureBytes(vec![]),
+    };
+    let receipt_json = serde_json::to_string(&receipt).unwrap();
+    let err = host_anchor_receipt(&ctx, &receipt_json, &ReputationUpdater::new())
+        .await
+        .err()
+        .unwrap();
+    match err {
+        HostAbiError::PermissionDenied(reason) => assert!(reason.contains("authorized")),
+        other => panic!("unexpected error: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- add new scoped policy module in governance crate
- hook optional policy enforcer into RuntimeContext
- enforce permissions when anchoring receipts
- expose new HostAbiError variant and map to MeshJobError
- test policy denial through runtime host API

## Testing
- `cargo fmt --all -- --check`
- ❌ `cargo clippy -p icn-governance -p icn-runtime --all-targets --all-features -- -D warnings` (failed to run in CI environment)
- ❌ `cargo test --all-features --workspace` (failed to run in CI environment)


------
https://chatgpt.com/codex/tasks/task_e_6862d43d73f083248eb61eb92cc854c1