### PR TITLE
[identity] add membership resolver

### DIFF
--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -31,6 +31,10 @@ pub struct NodeStatus {
     pub version: String,
 }
 
+/// Identifies a membership scope such as a community, cooperative, or federation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NodeScope(pub String);
+
 /// Represents a generic error that can occur within the ICN network.
 #[derive(Debug, Error, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum CommonError {


### PR DESCRIPTION
## Summary
- define `NodeScope` in `icn-common`
- add `MembershipResolver` and `ScopedPolicyEnforcer` in `icn-identity`
- provide `InMemoryMembershipResolver` and tests

## Testing
- `cargo fmt --all -- --check` *(fails: diffs in other crates)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to finish in time)*
- `cargo test --all-features --workspace` *(failed to finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_6862d43ee2b883249a34c9d05c5a219d