### PR TITLE
[tests] add placeholder policy enforcer test

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,6 +31,10 @@ path = "integration/peer_discovery.rs"
 name = "cli_node"
 path = "integration/cli_node.rs"
 
+[[test]]
+name = "policy_enforcer"
+path = "integration/policy_enforcer.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true

--- a/tests/integration/policy_enforcer.rs
+++ b/tests/integration/policy_enforcer.rs
@@ -1,0 +1,14 @@
+#[tokio::test(flavor = "multi_thread")]
+async fn valid_scoped_write_succeeds() {
+    todo!("RuntimeContext policy enforcement not yet implemented");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_from_non_member_actor_is_denied() {
+    todo!("RuntimeContext membership enforcement not yet implemented");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dag_parent_linkage_violation_triggers_policy_denial() {
+    todo!("DAG parent linkage policy enforcement not yet implemented");
+}


### PR DESCRIPTION
## Summary
- add integration test stub `policy_enforcer.rs`
- register the new test in `tests/Cargo.toml`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused import and type mismatch in icn-economics)*
- `cargo test --all-features --workspace` *(incomplete due to long build time)*

------
https://chatgpt.com/codex/tasks/task_e_6862d441fc5883248e76f502b6ab4b11