### PR TITLE
[icn-runtime] add policy enforcer trait and integration

### DIFF
--- a/crates/icn-runtime/src/policy.rs
+++ b/crates/icn-runtime/src/policy.rs
@@ -1,0 +1,50 @@
+use icn_common::{Did, DagBlock};
+use async_trait::async_trait;
+
+/// Type alias for data anchored in the DAG.
+pub type DagPayload = DagBlock;
+
+/// Represents the scope within which a policy check applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeScope {
+    Node,
+    Cooperative,
+    Federation,
+}
+
+/// Errors that can occur during policy enforcement.
+#[derive(Debug, thiserror::Error)]
+pub enum PolicyError {
+    #[error("actor not member of required scope {0:?}")]
+    NotMemberOfScope(NodeScope),
+    #[error("missing required attestation")]
+    MissingAttestation,
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+    #[error("additional approvals required")] 
+    QuorumRequired,
+}
+
+/// Result type used by policy checks.
+pub type PolicyResult = Result<(), PolicyError>;
+
+/// Trait for enforcing scoped runtime policies.
+///
+/// Implementations validate whether `actor` is allowed to submit the
+/// provided [`DagPayload`] to the DAG. The runtime calls this prior to
+/// anchoring blocks such as execution receipts.
+#[async_trait]
+pub trait ScopedPolicyEnforcer: Send + Sync {
+    /// Validate that `actor` may submit `payload`.
+    async fn check_dag_submit(&self, payload: &DagPayload, actor: &Did) -> PolicyResult;
+}
+
+/// Trivial [`ScopedPolicyEnforcer`] that allows all operations.
+pub struct AllowAllPolicyEnforcer;
+
+#[async_trait]
+impl ScopedPolicyEnforcer for AllowAllPolicyEnforcer {
+    async fn check_dag_submit(&self, _payload: &DagPayload, _actor: &Did) -> PolicyResult {
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- define `ScopedPolicyEnforcer` and supporting types
- store a policy enforcer in `RuntimeContext`
- call policy checks when anchoring receipts

## Testing
- `cargo clippy --all-targets -p icn-runtime -- -D warnings` *(fails: could not compile `icn-governance`)*
- `cargo test -p icn-runtime` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6862d5e31fac83249a482caa953bb598