### PR TITLE
[runtime] add TimeProvider trait

### DIFF
--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -35,6 +35,42 @@ pub struct NodeStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NodeScope(pub String);
 
+/// Provides the current time for deterministic operations.
+pub trait TimeProvider: Send + Sync {
+    /// Return the current Unix timestamp in seconds.
+    fn unix_seconds(&self) -> u64;
+}
+
+/// Uses [`std::time::SystemTime`] as the source of time.
+#[derive(Debug, Clone)]
+pub struct SystemTimeProvider;
+
+impl TimeProvider for SystemTimeProvider {
+    fn unix_seconds(&self) -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+}
+
+/// Deterministic time provider returning a fixed timestamp.
+#[derive(Debug, Clone)]
+pub struct FixedTimeProvider(pub u64);
+
+impl FixedTimeProvider {
+    /// Create a new [`FixedTimeProvider`] returning `ts`.
+    pub fn new(ts: u64) -> Self {
+        Self(ts)
+    }
+}
+
+impl TimeProvider for FixedTimeProvider {
+    fn unix_seconds(&self) -> u64 {
+        self.0
+    }
+}
+
 /// Represents a generic error that can occur within the ICN network.
 #[derive(Debug, Error, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum CommonError {

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -374,7 +374,7 @@ pub async fn app_router_with_options(
         mana_ledger_path.unwrap_or_else(|| PathBuf::from("./mana_ledger.sled")),
         ledger_backend,
     );
-    let mut rt_ctx = RuntimeContext::new_with_mana_ledger(
+    let mut rt_ctx = RuntimeContext::new_with_mana_ledger_and_time(
         node_did.clone(),
         mesh_network_service,
         signer,
@@ -382,6 +382,8 @@ pub async fn app_router_with_options(
         dag_store_for_rt,
         ledger,
         rep_path.clone(),
+        None,
+        Arc::new(icn_common::SystemTimeProvider),
     );
 
     #[cfg(feature = "persist-sled")]
@@ -743,7 +745,7 @@ async fn main() {
             config.mana_ledger_path.clone(),
             config.mana_ledger_backend,
         );
-        RuntimeContext::new_with_mana_ledger(
+        RuntimeContext::new_with_mana_ledger_and_time(
             node_did.clone(),
             mesh_network_service,
             signer,
@@ -751,6 +753,8 @@ async fn main() {
             dag_store_for_rt,
             ledger,
             config.reputation_db_path.clone(),
+            None,
+            Arc::new(icn_common::SystemTimeProvider),
         )
     };
 

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -24,6 +24,7 @@ async fn anchor_receipt_updates_reputation() {
         Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         std::path::PathBuf::from("./mana_ledger.sled"),
         std::path::PathBuf::from("./reputation.sled"),
+        None,
     );
     let job_id = Cid::new_v1_sha256(0x55, b"rep_job");
     let result_cid = Cid::new_v1_sha256(0x55, b"res");

--- a/crates/icn-runtime/tests/time_provider.rs
+++ b/crates/icn-runtime/tests/time_provider.rs
@@ -1,0 +1,42 @@
+use icn_common::{Cid, Did, FixedTimeProvider, TimeProvider};
+use icn_identity::{ExecutionReceipt, SignatureBytes};
+use icn_runtime::{
+    context::{RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner},
+    host_anchor_receipt, ReputationUpdater,
+};
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
+
+#[tokio::test]
+async fn anchor_receipt_uses_time_provider() {
+    let provider = Arc::new(FixedTimeProvider::new(42));
+    let did = Did::from_str("did:icn:test:time").unwrap();
+    let ctx = RuntimeContext::new_with_ledger_path_and_time(
+        did.clone(),
+        Arc::new(StubMeshNetworkService::new()),
+        Arc::new(StubSigner::new()),
+        Arc::new(icn_identity::KeyDidResolver),
+        Arc::new(TokioMutex::new(StubDagStore::new())),
+        std::path::PathBuf::from("./mana_ledger.sled"),
+        std::path::PathBuf::from("./reputation.sled"),
+        None,
+        provider.clone(),
+    );
+
+    let receipt = ExecutionReceipt {
+        job_id: Cid::new_v1_sha256(0x55, b"job"),
+        executor_did: did,
+        result_cid: Cid::new_v1_sha256(0x55, b"res"),
+        cpu_ms: 1,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    };
+    let json = serde_json::to_string(&receipt).unwrap();
+    let cid = host_anchor_receipt(&ctx, &json, &ReputationUpdater::new())
+        .await
+        .unwrap();
+    let store = ctx.dag_store.lock().await;
+    let block = store.get(&cid).unwrap().unwrap();
+    assert_eq!(block.timestamp, provider.unix_seconds());
+}

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -24,6 +24,7 @@ fn ctx_with_temp_store(did: &str, mana: u64) -> Arc<RuntimeContext> {
         dag_store,
         temp.path().join("mana"),
         temp.path().join("reputation"),
+        None,
     );
     ctx.mana_ledger
         .set_balance(&icn_common::Did::from_str(did).unwrap(), mana)


### PR DESCRIPTION
## Summary
- introduce `TimeProvider` with system and fixed implementations
- inject a `TimeProvider` into `RuntimeContext`
- use `TimeProvider` for anchoring receipts
- wire default time provider through node setup and runtime constructors
- add deterministic timestamp test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: Database lock errors)*


------
https://chatgpt.com/codex/tasks/task_e_6862f22a4c8c8324b91a9a3ae250343f