### PR TITLE
[core] extend DagBlock with NodeScope

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -133,6 +133,7 @@ pub async fn submit_dag_block(
         &block.links,
         block.timestamp,
         &block.author_did,
+        &block.scope,
         &block.signature,
     );
     if expected_cid != block.cid {
@@ -487,6 +488,7 @@ mod tests {
             std::slice::from_ref(&link),
             ts,
             &author,
+            &None,
             &sig_opt,
         );
         let block = DagBlock {
@@ -495,6 +497,7 @@ mod tests {
             links: vec![link],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig_opt,
         };
         let block_json = serde_json::to_string(&block).unwrap();
@@ -520,6 +523,7 @@ mod tests {
             links: vec![link],
             timestamp: 0,
             author_did: Did::new("key", "tester"),
+            scope: None,
             signature: None,
         };
         let block_json = serde_json::to_string(&block).unwrap();
@@ -771,13 +775,14 @@ mod tests {
         let ts = 0u64;
         let author = Did::new("key", "tester");
         let sig_opt = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig_opt);
+        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &None, &sig_opt);
         let block = DagBlock {
             cid: cid.clone(),
             data: data.clone(),
             links: vec![],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig_opt,
         };
         {
@@ -819,13 +824,14 @@ mod tests {
         let ts = 0u64;
         let author = Did::new("key", "tester");
         let sig_opt = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig_opt);
+        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &None, &sig_opt);
         let block = DagBlock {
             cid: cid.clone(),
             data,
             links: vec![],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig_opt,
         };
         let block_json = serde_json::to_string(&block).unwrap();

--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -47,13 +47,14 @@ async fn submit_transaction_and_query_data() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid,
         data: b"data".to_vec(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     let put_url = format!("http://{addr}/dag/put");

--- a/crates/icn-common/tests/signable.rs
+++ b/crates/icn-common/tests/signable.rs
@@ -70,6 +70,7 @@ fn dagblock_sign_verify() {
         std::slice::from_ref(&link),
         timestamp,
         &author,
+        &None,
         &sig_opt,
     );
     let block = DagBlock {
@@ -78,6 +79,7 @@ fn dagblock_sign_verify() {
         links: vec![link],
         timestamp,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
 

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -293,13 +293,14 @@ mod tests {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &None, &sig);
         DagBlock {
             cid,
             data,
             links: vec![],
             timestamp,
             author_did: author,
+            scope: None,
             signature: sig,
         }
     }
@@ -327,13 +328,22 @@ mod tests {
         let timestamp = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &modified_block1_data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(
+            0x71,
+            &modified_block1_data,
+            &[],
+            timestamp,
+            &author,
+            &None,
+            &sig,
+        );
         let modified_block1 = DagBlock {
             cid,
             data: modified_block1_data,
             links: vec![],
             timestamp,
             author_did: author,
+            scope: None,
             signature: sig,
         };
         assert!(store.put(&modified_block1).is_ok());
@@ -532,6 +542,7 @@ mod tests {
             std::slice::from_ref(&link),
             timestamp,
             &author,
+            &None,
             &sig,
         );
         let parent = DagBlock {
@@ -540,6 +551,7 @@ mod tests {
             links: vec![link],
             timestamp,
             author_did: author,
+            scope: None,
             signature: sig,
         };
         index.index_block(&child);

--- a/crates/icn-dag/tests/rocks_backend.rs
+++ b/crates/icn-dag/tests/rocks_backend.rs
@@ -11,13 +11,14 @@ mod tests {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &None, &sig);
         DagBlock {
             cid,
             data,
             links: vec![],
             timestamp,
             author_did: author,
+            scope: None,
             signature: sig,
         }
     }
@@ -34,13 +35,14 @@ mod tests {
         let ts = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let mod_cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig);
+        let mod_cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &None, &sig);
         let mod_block = DagBlock {
             cid: mod_cid,
             data: mod_data,
             links: vec![],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig,
         };
         assert!(store.put(&mod_block).is_ok());

--- a/crates/icn-dag/tests/sled_backend.rs
+++ b/crates/icn-dag/tests/sled_backend.rs
@@ -10,13 +10,14 @@ mod tests {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &None, &sig);
         DagBlock {
             cid,
             data,
             links: vec![],
             timestamp,
             author_did: author,
+            scope: None,
             signature: sig,
         }
     }
@@ -36,13 +37,14 @@ mod tests {
         let ts = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &None, &sig);
         let mod_block = DagBlock {
             cid,
             data: mod_data,
             links: vec![],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig,
         };
         assert!(store.put(&mod_block).is_ok());

--- a/crates/icn-dag/tests/sqlite_backend.rs
+++ b/crates/icn-dag/tests/sqlite_backend.rs
@@ -11,13 +11,14 @@ mod tests {
         let ts = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &None, &sig);
         DagBlock {
             cid,
             data,
             links: vec![],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig,
         }
     }
@@ -34,13 +35,14 @@ mod tests {
         let ts = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &None, &sig);
         let mod_block = DagBlock {
             cid,
             data: mod_data,
             links: vec![],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig,
         };
         assert!(store.put(&mod_block).is_ok());

--- a/crates/icn-governance/src/scoped_policy.rs
+++ b/crates/icn-governance/src/scoped_policy.rs
@@ -3,7 +3,7 @@ pub enum PolicyCheckResult {
     Denied { reason: String },
 }
 
-use icn_common::Did;
+use icn_common::{Did, NodeScope};
 
 /// Operations that may be subject to scoped policy checks when writing to the DAG.
 #[derive(Debug, Clone, Copy)]
@@ -14,34 +14,65 @@ pub enum DagPayloadOp {
 
 /// Trait for enforcing scoped policies on DAG operations.
 pub trait ScopedPolicyEnforcer: Send + Sync {
-    fn check_permission(&self, op: DagPayloadOp, actor: &Did) -> PolicyCheckResult;
+    fn check_permission(
+        &self,
+        op: DagPayloadOp,
+        actor: &Did,
+        scope: Option<&NodeScope>,
+    ) -> PolicyCheckResult;
 }
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// In-memory implementation of [`ScopedPolicyEnforcer`] based on membership lists.
 #[derive(Default)]
 pub struct InMemoryPolicyEnforcer {
-    submitters: HashSet<Did>,
-    anchorers: HashSet<Did>,
+    submitters: HashMap<Option<NodeScope>, HashSet<Did>>,
+    anchorers: HashMap<Option<NodeScope>, HashSet<Did>>,
 }
 
 impl InMemoryPolicyEnforcer {
     /// Create a new enforcer with the given allowed members for submitting blocks
     /// and anchoring receipts.
     pub fn new(submitters: HashSet<Did>, anchorers: HashSet<Did>) -> Self {
+        let mut s_map = HashMap::new();
+        s_map.insert(None, submitters);
+        let mut a_map = HashMap::new();
+        a_map.insert(None, anchorers);
         Self {
-            submitters,
-            anchorers,
+            submitters: s_map,
+            anchorers: a_map,
         }
+    }
+
+    /// Grant submit permission for a DID within an optional scope.
+    pub fn allow_submitter(&mut self, scope: Option<NodeScope>, did: Did) {
+        self.submitters.entry(scope).or_default().insert(did);
+    }
+
+    /// Grant anchor permission for a DID within an optional scope.
+    pub fn allow_anchorer(&mut self, scope: Option<NodeScope>, did: Did) {
+        self.anchorers.entry(scope).or_default().insert(did);
     }
 }
 
 impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
-    fn check_permission(&self, op: DagPayloadOp, actor: &Did) -> PolicyCheckResult {
+    fn check_permission(
+        &self,
+        op: DagPayloadOp,
+        actor: &Did,
+        scope: Option<&NodeScope>,
+    ) -> PolicyCheckResult {
+        let scope_key = scope.cloned();
         match op {
             DagPayloadOp::SubmitBlock => {
-                if self.submitters.contains(actor) {
+                let allowed = self
+                    .submitters
+                    .get(&scope_key)
+                    .or_else(|| self.submitters.get(&None))
+                    .map(|set| set.contains(actor))
+                    .unwrap_or(false);
+                if allowed {
                     PolicyCheckResult::Allowed
                 } else {
                     PolicyCheckResult::Denied {
@@ -50,7 +81,13 @@ impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
                 }
             }
             DagPayloadOp::AnchorReceipt => {
-                if self.anchorers.contains(actor) {
+                let allowed = self
+                    .anchorers
+                    .get(&scope_key)
+                    .or_else(|| self.anchorers.get(&None))
+                    .map(|set| set.contains(actor))
+                    .unwrap_or(false);
+                if allowed {
                     PolicyCheckResult::Allowed
                 } else {
                     PolicyCheckResult::Denied {

--- a/crates/icn-governance/tests/scoped_policy.rs
+++ b/crates/icn-governance/tests/scoped_policy.rs
@@ -1,0 +1,28 @@
+use icn_common::{Did, NodeScope};
+use icn_governance::scoped_policy::{
+    DagPayloadOp, InMemoryPolicyEnforcer, PolicyCheckResult, ScopedPolicyEnforcer,
+};
+use std::str::FromStr;
+
+#[test]
+fn scoped_permission_allows_member() {
+    let mut enforcer = InMemoryPolicyEnforcer::default();
+    let scope = NodeScope("alpha".into());
+    let did = Did::from_str("did:icn:test:alice").unwrap();
+    enforcer.allow_submitter(Some(scope.clone()), did.clone());
+    assert!(matches!(
+        enforcer.check_permission(DagPayloadOp::SubmitBlock, &did, Some(&scope)),
+        PolicyCheckResult::Allowed
+    ));
+}
+
+#[test]
+fn scoped_permission_denies_non_member() {
+    let enforcer = InMemoryPolicyEnforcer::default();
+    let scope = NodeScope("alpha".into());
+    let did = Did::from_str("did:icn:test:bob").unwrap();
+    assert!(matches!(
+        enforcer.check_permission(DagPayloadOp::SubmitBlock, &did, Some(&scope)),
+        PolicyCheckResult::Denied { .. }
+    ));
+}

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -382,6 +382,7 @@ pub async fn app_router_with_options(
         dag_store_for_rt,
         ledger,
         rep_path.clone(),
+        None,
     );
 
     #[cfg(feature = "persist-sled")]
@@ -751,6 +752,7 @@ async fn main() {
             dag_store_for_rt,
             ledger,
             config.reputation_db_path.clone(),
+            None,
         )
     };
 
@@ -995,13 +997,14 @@ async fn dag_put_handler(
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &block.data, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &block.data, &[], ts, &author, &None, &sig_opt);
     let dag_block = CoreDagBlock {
         cid,
         data: block.data,
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     let mut store = state.runtime_context.dag_store.lock().await;
@@ -1064,13 +1067,14 @@ async fn contracts_post_handler(
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = CoreDagBlock {
         cid: cid.clone(),
         data: wasm,
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
 

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1315,6 +1315,7 @@ impl RuntimeContext {
             &[],
             timestamp,
             &author,
+            &None,
             &signature,
         );
         let block = DagBlock {
@@ -1323,11 +1324,12 @@ impl RuntimeContext {
             links: vec![],
             timestamp,
             author_did: author,
+            scope: None,
             signature,
         };
         if let Some(enforcer) = &self.policy_enforcer {
             if let PolicyCheckResult::Denied { reason } =
-                enforcer.check_permission(DagPayloadOp::AnchorReceipt, &self.current_identity)
+                enforcer.check_permission(DagPayloadOp::AnchorReceipt, &self.current_identity, None)
             {
                 return Err(HostAbiError::PermissionDenied(reason));
             }

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -395,13 +395,14 @@ mod tests {
         let ts = 0u64;
         let author = Did::new("key", "tester");
         let sig_opt = None;
-        let cid = compute_merkle_cid(0x71, manifest_data, &[], ts, &author, &sig_opt);
+        let cid = compute_merkle_cid(0x71, manifest_data, &[], ts, &author, &None, &sig_opt);
         let block = DagBlock {
             cid: cid.clone(),
             data: manifest_data.to_vec(),
             links: vec![],
             timestamp: ts,
             author_did: author,
+            scope: None,
             signature: sig_opt,
         };
         {

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -310,13 +310,14 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, &receipt_bytes, &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, &receipt_bytes, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid,
         data: receipt_bytes,
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -24,13 +24,14 @@ async fn wasm_executor_runs_wasm() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm_bytes,
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -69,13 +70,14 @@ async fn wasm_executor_runs_compiled_ccl_contract() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -143,13 +145,14 @@ async fn wasm_executor_host_submit_mesh_job_json() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm_bytes,
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -209,13 +212,14 @@ async fn wasm_executor_host_anchor_receipt_json() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm_bytes,
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -252,13 +256,14 @@ async fn submit_compiled_ccl_runs_via_executor() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -295,13 +300,14 @@ async fn queued_compiled_ccl_executes() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -343,6 +349,7 @@ async fn compiled_example_contract_file_runs() {
         links: vec![],
         timestamp: 0,
         author_did: Did::new("key", "tester"),
+        scope: None,
         signature: None,
     };
     {

--- a/icn-ccl/src/cli.rs
+++ b/icn-ccl/src/cli.rs
@@ -50,7 +50,7 @@ pub fn compile_ccl_file(
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, &wasm_bytecode, &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, &wasm_bytecode, &[], ts, &author, &None, &sig_opt);
     metadata.cid = cid.to_string();
 
     // Calculate SHA-256 hash of the source code

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -75,8 +75,15 @@ fn test_compile_ccl_file_cli_function() {
             let ts = 0u64;
             let author = icn_common::Did::new("key", "tester");
             let sig_opt = None;
-            let expected_cid =
-                icn_common::compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+            let expected_cid = icn_common::compute_merkle_cid(
+                0x71,
+                &wasm_bytes,
+                &[],
+                ts,
+                &author,
+                &None,
+                &sig_opt,
+            );
             assert_eq!(metadata.cid, expected_cid.to_string());
 
             println!(
@@ -177,13 +184,14 @@ async fn test_wasm_executor_with_ccl() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -319,13 +327,14 @@ async fn test_wasm_executor_runs_addition() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -40,13 +40,14 @@ async fn wasm_executor_runs_compiled_ccl() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -90,13 +91,14 @@ async fn wasm_executor_runs_compiled_addition() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -140,13 +142,14 @@ async fn wasm_executor_fails_without_run() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -189,13 +192,14 @@ async fn compile_and_execute_simple_contract() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {
@@ -238,13 +242,14 @@ async fn wasm_executor_runs_compiled_file() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     {

--- a/icn-runtime/tests/wasm_executor.rs
+++ b/icn-runtime/tests/wasm_executor.rs
@@ -29,8 +29,16 @@ async fn compiled_policy_executes_via_host_abi() {
     let ts = 0u64;
     let author = ctx.current_identity.clone();
     let sig = None;
-    let wasm_cid = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig);
-    let wasm_block = DagBlock { cid: wasm_cid.clone(), data: wasm, links: vec![], timestamp: ts, author_did: author.clone(), signature: sig };
+    let wasm_cid = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &None, &sig);
+    let wasm_block = DagBlock {
+        cid: wasm_cid.clone(),
+        data: wasm,
+        links: vec![],
+        timestamp: ts,
+        author_did: author.clone(),
+        scope: None,
+        signature: sig,
+    };
     {
         let mut store = dag_store.lock().await;
         store.put(&wasm_block).unwrap();

--- a/tests/integration/cli_node.rs
+++ b/tests/integration/cli_node.rs
@@ -18,13 +18,14 @@ async fn dag_storage_via_cli() {
     let ts = 0u64;
     let author = Did::new("example", "alice");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &None, &sig_opt);
     let block = DagBlock {
         cid: cid.clone(),
         data: b"data".to_vec(),
         links: vec![],
         timestamp: ts,
         author_did: author,
+        scope: None,
         signature: sig_opt,
     };
     let block_json = serde_json::to_string(&block).unwrap();

--- a/tests/integration/persistence.rs
+++ b/tests/integration/persistence.rs
@@ -10,13 +10,14 @@ mod persistence_rocksdb {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &None, &sig);
         DagBlock {
             cid,
             data,
             links: vec![],
             timestamp,
             author_did: author,
+            scope: None,
             signature: sig,
         }
     }

--- a/tests/integration/policy_enforcer.rs
+++ b/tests/integration/policy_enforcer.rs
@@ -95,6 +95,7 @@ async fn authorized_dag_write_succeeds() {
         links: vec![],
         timestamp: ts,
         author_did: alice.clone(),
+        scope: None,
         signature: None,
     };
 
@@ -125,6 +126,7 @@ async fn unauthorized_write_denied() {
         links: vec![],
         timestamp: ts,
         author_did: eve.clone(),
+        scope: None,
         signature: None,
     };
 
@@ -156,6 +158,7 @@ async fn invalid_parent_is_rejected() {
         links: vec![link],
         timestamp: ts,
         author_did: alice.clone(),
+        scope: None,
         signature: None,
     };
 


### PR DESCRIPTION
## Summary
- add optional `NodeScope` to `DagBlock`
- include scope in CID computation and signing
- enforce scope membership via `ScopedPolicyEnforcer`
- update storage, API, and node usage
- adjust tests and add new scoped policy tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: timed out in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6862f227d7908324afaa39137f9826ce