### PR TITLE
[tests] use governance scoped policy

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -382,6 +382,7 @@ pub async fn app_router_with_options(
         dag_store_for_rt,
         ledger,
         rep_path.clone(),
+        None,
     );
 
     #[cfg(feature = "persist-sled")]
@@ -751,6 +752,7 @@ async fn main() {
             dag_store_for_rt,
             ledger,
             config.reputation_db_path.clone(),
+            None,
         )
     };
 

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -605,6 +605,7 @@ pub struct RuntimeContext {
 
 impl RuntimeContext {
     /// Create a new context using a mana ledger stored at `mana_ledger_path`.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_ledger_path(
         current_identity: Did,
         mesh_network_service: Arc<dyn MeshNetworkService>,
@@ -628,6 +629,7 @@ impl RuntimeContext {
     }
 
     /// Create a new context with a preconstructed mana ledger.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_mana_ledger(
         current_identity: Did,
         mesh_network_service: Arc<dyn MeshNetworkService>,
@@ -717,6 +719,7 @@ impl RuntimeContext {
 
     /// Create a new context using filesystem paths for the DAG store and mana ledger.
     /// The store type is selected based on enabled persistence features.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_paths(
         current_identity: Did,
         mesh_network_service: Arc<dyn MeshNetworkService>,
@@ -1704,6 +1707,7 @@ impl RuntimeContext {
             did_resolver,
             dag_store,
             reputation_store,
+            policy_enforcer: None,
             default_receipt_wait_ms: 60_000,
         })
     }

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -24,6 +24,7 @@ async fn anchor_receipt_updates_reputation() {
         Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         std::path::PathBuf::from("./mana_ledger.sled"),
         std::path::PathBuf::from("./reputation.sled"),
+        None,
     );
     let job_id = Cid::new_v1_sha256(0x55, b"rep_job");
     let result_cid = Cid::new_v1_sha256(0x55, b"res");

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -24,6 +24,7 @@ fn ctx_with_temp_store(did: &str, mana: u64) -> Arc<RuntimeContext> {
         dag_store,
         temp.path().join("mana"),
         temp.path().join("reputation"),
+        None,
     );
     ctx.mana_ledger
         .set_balance(&icn_common::Did::from_str(did).unwrap(), mana)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -44,3 +44,4 @@ assert_cmd = "2.0"
 predicates = "3.1"
 axum = { version = "0.7", features = ["json"] }
 icn-node = { path = "../crates/icn-node" }
+icn-governance = { path = "../crates/icn-governance" }


### PR DESCRIPTION
## Summary
- use `icn_governance::scoped_policy` in policy_enforcer integration test
- add icn-governance dev-dependency for tests
- update runtime context for new policy enforcer field
- pass `None` policy enforcer where required

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: test result: FAILED. 4 passed; 28 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862f224ec588324ba2b3b9970f0d5da