### PR TITLE
[icn-api] enforce scoped policy on DAG submission

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1085,7 +1085,14 @@ async fn contracts_post_handler(
         }
     };
 
-    match icn_api::submit_dag_block(state.runtime_context.dag_store.clone(), block_json).await {
+    match icn_api::submit_dag_block(
+        state.runtime_context.dag_store.clone(),
+        block_json,
+        state.runtime_context.policy_enforcer.clone(),
+        state.runtime_context.current_identity.clone(),
+    )
+    .await
+    {
         Ok(_) => (
             StatusCode::CREATED,
             Json(serde_json::json!({ "manifest_cid": cid.to_string() })),


### PR DESCRIPTION
## Summary
- inject `ScopedPolicyEnforcer` into DAG submission
- gate DAG writes behind `check_permission`
- surface denied policy checks as `CommonError::PolicyDenied`
- add tests for allowed and denied DAG submissions

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timeout)*
- `cargo test --all-features --workspace` *(failed: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6862f22384608324b18f5c9a437078e3