### PR TITLE
[identity] rename overlapping policy enforcer

### DIFF
--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -335,11 +335,11 @@ impl MembershipResolver for InMemoryMembershipResolver {
 }
 
 /// Enforces scoped permissions by consulting a [`MembershipResolver`].
-pub struct ScopedPolicyEnforcer<R: MembershipResolver> {
+pub struct MembershipPolicyEnforcer<R: MembershipResolver> {
     resolver: R,
 }
 
-impl<R: MembershipResolver> ScopedPolicyEnforcer<R> {
+impl<R: MembershipResolver> MembershipPolicyEnforcer<R> {
     /// Create a new enforcer using the provided membership resolver.
     pub fn new(resolver: R) -> Self {
         Self { resolver }
@@ -805,7 +805,7 @@ mod tests {
 
         assert!(resolver.is_member(&did, &scope));
 
-        let enforcer = ScopedPolicyEnforcer::new(resolver);
+        let enforcer = MembershipPolicyEnforcer::new(resolver);
         assert!(enforcer.check_permission(&did, &scope).is_ok());
 
         let outsider = Did::from_str("did:icn:test:bob").unwrap();


### PR DESCRIPTION
## Summary
- rename `ScopedPolicyEnforcer` struct in `icn-identity` to `MembershipPolicyEnforcer`
- use `icn-governance` policy trait in integration tests

## Testing
- `cargo fmt --all -- --check`
- `cargo check -p icn-identity`
- `cargo check -p icn-runtime`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timed out)*
- `cargo test --all-features --workspace` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6862f21f786c832481d41f22ede4cde3