### PR TITLE
[common] add scope to DagBlock

### DIFF
--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -47,7 +47,7 @@ async fn submit_transaction_and_query_data() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid,
         data: b"data".to_vec(),
@@ -55,6 +55,7 @@ async fn submit_transaction_and_query_data() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     let put_url = format!("http://{addr}/dag/put");
     let res = client.post(&put_url).json(&block).send().await.unwrap();

--- a/crates/icn-common/tests/signable.rs
+++ b/crates/icn-common/tests/signable.rs
@@ -71,6 +71,7 @@ fn dagblock_sign_verify() {
         timestamp,
         &author,
         &sig_opt,
+        &None,
     );
     let block = DagBlock {
         cid,
@@ -79,6 +80,7 @@ fn dagblock_sign_verify() {
         timestamp,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
 
     let sig = block.sign(&sk).unwrap();

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -293,7 +293,7 @@ mod tests {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig, &None);
         DagBlock {
             cid,
             data,
@@ -301,6 +301,7 @@ mod tests {
             timestamp,
             author_did: author,
             signature: sig,
+            scope: None,
         }
     }
 
@@ -327,7 +328,15 @@ mod tests {
         let timestamp = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &modified_block1_data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(
+            0x71,
+            &modified_block1_data,
+            &[],
+            timestamp,
+            &author,
+            &sig,
+            &None,
+        );
         let modified_block1 = DagBlock {
             cid,
             data: modified_block1_data,
@@ -335,6 +344,7 @@ mod tests {
             timestamp,
             author_did: author,
             signature: sig,
+            scope: None,
         };
         assert!(store.put(&modified_block1).is_ok());
         match store.get(&block1.cid) {
@@ -533,6 +543,7 @@ mod tests {
             timestamp,
             &author,
             &sig,
+            &None,
         );
         let parent = DagBlock {
             cid: parent_cid.clone(),
@@ -541,6 +552,7 @@ mod tests {
             timestamp,
             author_did: author,
             signature: sig,
+            scope: None,
         };
         index.index_block(&child);
         index.index_block(&parent);

--- a/crates/icn-dag/tests/rocks_backend.rs
+++ b/crates/icn-dag/tests/rocks_backend.rs
@@ -11,7 +11,7 @@ mod tests {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig, &None);
         DagBlock {
             cid,
             data,
@@ -19,6 +19,7 @@ mod tests {
             timestamp,
             author_did: author,
             signature: sig,
+            scope: None,
         }
     }
 
@@ -34,7 +35,7 @@ mod tests {
         let ts = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let mod_cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig);
+        let mod_cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig, &None);
         let mod_block = DagBlock {
             cid: mod_cid,
             data: mod_data,
@@ -42,6 +43,7 @@ mod tests {
             timestamp: ts,
             author_did: author,
             signature: sig,
+            scope: None,
         };
         assert!(store.put(&mod_block).is_ok());
         assert_eq!(store.get(&b1.cid).unwrap().unwrap().data, b"mod".to_vec());

--- a/crates/icn-dag/tests/sled_backend.rs
+++ b/crates/icn-dag/tests/sled_backend.rs
@@ -10,7 +10,7 @@ mod tests {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig, &None);
         DagBlock {
             cid,
             data,
@@ -18,6 +18,7 @@ mod tests {
             timestamp,
             author_did: author,
             signature: sig,
+            scope: None,
         }
     }
 
@@ -36,7 +37,7 @@ mod tests {
         let ts = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig, &None);
         let mod_block = DagBlock {
             cid,
             data: mod_data,
@@ -44,6 +45,7 @@ mod tests {
             timestamp: ts,
             author_did: author,
             signature: sig,
+            scope: None,
         };
         assert!(store.put(&mod_block).is_ok());
         assert_eq!(store.get(&b1.cid).unwrap().unwrap().data, b"mod".to_vec());

--- a/crates/icn-dag/tests/sqlite_backend.rs
+++ b/crates/icn-dag/tests/sqlite_backend.rs
@@ -11,7 +11,7 @@ mod tests {
         let ts = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig, &None);
         DagBlock {
             cid,
             data,
@@ -19,6 +19,7 @@ mod tests {
             timestamp: ts,
             author_did: author,
             signature: sig,
+            scope: None,
         }
     }
 
@@ -34,7 +35,7 @@ mod tests {
         let ts = 1u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &mod_data, &[], ts, &author, &sig, &None);
         let mod_block = DagBlock {
             cid,
             data: mod_data,
@@ -42,6 +43,7 @@ mod tests {
             timestamp: ts,
             author_did: author,
             signature: sig,
+            scope: None,
         };
         assert!(store.put(&mod_block).is_ok());
         assert_eq!(store.get(&b1.cid).unwrap().unwrap().data, b"mod".to_vec());

--- a/crates/icn-governance/src/scoped_policy.rs
+++ b/crates/icn-governance/src/scoped_policy.rs
@@ -3,7 +3,7 @@ pub enum PolicyCheckResult {
     Denied { reason: String },
 }
 
-use icn_common::Did;
+use icn_common::{Did, NodeScope};
 
 /// Operations that may be subject to scoped policy checks when writing to the DAG.
 #[derive(Debug, Clone, Copy)]
@@ -14,35 +14,66 @@ pub enum DagPayloadOp {
 
 /// Trait for enforcing scoped policies on DAG operations.
 pub trait ScopedPolicyEnforcer: Send + Sync {
-    fn check_permission(&self, op: DagPayloadOp, actor: &Did) -> PolicyCheckResult;
+    fn check_permission(
+        &self,
+        op: DagPayloadOp,
+        actor: &Did,
+        scope: Option<&NodeScope>,
+    ) -> PolicyCheckResult;
 }
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// In-memory implementation of [`ScopedPolicyEnforcer`] based on membership lists.
 #[derive(Default)]
 pub struct InMemoryPolicyEnforcer {
     submitters: HashSet<Did>,
     anchorers: HashSet<Did>,
+    memberships: HashMap<NodeScope, HashSet<Did>>,
 }
 
 impl InMemoryPolicyEnforcer {
     /// Create a new enforcer with the given allowed members for submitting blocks
     /// and anchoring receipts.
-    pub fn new(submitters: HashSet<Did>, anchorers: HashSet<Did>) -> Self {
+    pub fn new(
+        submitters: HashSet<Did>,
+        anchorers: HashSet<Did>,
+        memberships: HashMap<NodeScope, HashSet<Did>>,
+    ) -> Self {
         Self {
             submitters,
             anchorers,
+            memberships,
         }
     }
 }
 
 impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
-    fn check_permission(&self, op: DagPayloadOp, actor: &Did) -> PolicyCheckResult {
+    fn check_permission(
+        &self,
+        op: DagPayloadOp,
+        actor: &Did,
+        scope: Option<&NodeScope>,
+    ) -> PolicyCheckResult {
         match op {
             DagPayloadOp::SubmitBlock => {
                 if self.submitters.contains(actor) {
-                    PolicyCheckResult::Allowed
+                    if let Some(scope) = scope {
+                        if self
+                            .memberships
+                            .get(scope)
+                            .map(|m| m.contains(actor))
+                            .unwrap_or(false)
+                        {
+                            PolicyCheckResult::Allowed
+                        } else {
+                            PolicyCheckResult::Denied {
+                                reason: "actor not in scope".to_string(),
+                            }
+                        }
+                    } else {
+                        PolicyCheckResult::Allowed
+                    }
                 } else {
                     PolicyCheckResult::Denied {
                         reason: "actor not authorized to submit DAG blocks".to_string(),
@@ -51,7 +82,22 @@ impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
             }
             DagPayloadOp::AnchorReceipt => {
                 if self.anchorers.contains(actor) {
-                    PolicyCheckResult::Allowed
+                    if let Some(scope) = scope {
+                        if self
+                            .memberships
+                            .get(scope)
+                            .map(|m| m.contains(actor))
+                            .unwrap_or(false)
+                        {
+                            PolicyCheckResult::Allowed
+                        } else {
+                            PolicyCheckResult::Denied {
+                                reason: "actor not in scope".to_string(),
+                            }
+                        }
+                    } else {
+                        PolicyCheckResult::Allowed
+                    }
                 } else {
                     PolicyCheckResult::Denied {
                         reason: "actor not authorized to anchor receipts".to_string(),

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -999,7 +999,7 @@ async fn dag_put_handler(
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &block.data, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &block.data, &[], ts, &author, &sig_opt, &None);
     let dag_block = CoreDagBlock {
         cid,
         data: block.data,
@@ -1007,6 +1007,7 @@ async fn dag_put_handler(
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     let mut store = state.runtime_context.dag_store.lock().await;
     match store.put(&dag_block) {
@@ -1068,7 +1069,7 @@ async fn contracts_post_handler(
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = CoreDagBlock {
         cid: cid.clone(),
         data: wasm,
@@ -1076,6 +1077,7 @@ async fn contracts_post_handler(
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
 
     let block_json = match serde_json::to_string(&block) {

--- a/crates/icn-node/tests/dag_persistence.rs
+++ b/crates/icn-node/tests/dag_persistence.rs
@@ -28,7 +28,7 @@ async fn dag_persists_between_restarts_sled() {
     let data = b"hello".to_vec();
     let ts = 0u64;
     let author = Did::from_str("did:example:tester").unwrap();
-    let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &None);
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &None, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data: data.clone(),
@@ -36,6 +36,7 @@ async fn dag_persists_between_restarts_sled() {
         timestamp: ts,
         author_did: author,
         signature: None,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1380,6 +1380,7 @@ impl RuntimeContext {
             timestamp,
             &author,
             &signature,
+            &None,
         );
         let block = DagBlock {
             cid,
@@ -1388,10 +1389,11 @@ impl RuntimeContext {
             timestamp,
             author_did: author,
             signature,
+            scope: None,
         };
         if let Some(enforcer) = &self.policy_enforcer {
             if let PolicyCheckResult::Denied { reason } =
-                enforcer.check_permission(DagPayloadOp::AnchorReceipt, &self.current_identity)
+                enforcer.check_permission(DagPayloadOp::AnchorReceipt, &self.current_identity, None)
             {
                 return Err(HostAbiError::PermissionDenied(reason));
             }

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -395,7 +395,7 @@ mod tests {
         let ts = 0u64;
         let author = Did::new("key", "tester");
         let sig_opt = None;
-        let cid = compute_merkle_cid(0x71, manifest_data, &[], ts, &author, &sig_opt);
+        let cid = compute_merkle_cid(0x71, manifest_data, &[], ts, &author, &sig_opt, &None);
         let block = DagBlock {
             cid: cid.clone(),
             data: manifest_data.to_vec(),
@@ -403,6 +403,7 @@ mod tests {
             timestamp: ts,
             author_did: author,
             signature: sig_opt,
+            scope: None,
         };
         {
             let mut store = ctx.dag_store.lock().await;

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -310,7 +310,7 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, &receipt_bytes, &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, &receipt_bytes, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid,
         data: receipt_bytes,
@@ -318,6 +318,7 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = dag_store.lock().await;

--- a/crates/icn-runtime/tests/policy.rs
+++ b/crates/icn-runtime/tests/policy.rs
@@ -5,7 +5,7 @@ use icn_runtime::{
     context::{HostAbiError, RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner},
     host_anchor_receipt, ReputationUpdater,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -25,6 +25,7 @@ async fn anchor_receipt_denied_by_policy() {
         Some(Arc::new(InMemoryPolicyEnforcer::new(
             HashSet::new(),
             HashSet::new(),
+            HashMap::new(),
         ))),
     );
 

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -24,7 +24,7 @@ async fn wasm_executor_runs_wasm() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm_bytes,
@@ -32,6 +32,7 @@ async fn wasm_executor_runs_wasm() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -69,7 +70,7 @@ async fn wasm_executor_runs_compiled_ccl_contract() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
@@ -77,6 +78,7 @@ async fn wasm_executor_runs_compiled_ccl_contract() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -143,7 +145,7 @@ async fn wasm_executor_host_submit_mesh_job_json() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm_bytes,
@@ -151,6 +153,7 @@ async fn wasm_executor_host_submit_mesh_job_json() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -209,7 +212,7 @@ async fn wasm_executor_host_anchor_receipt_json() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm_bytes,
@@ -217,6 +220,7 @@ async fn wasm_executor_host_anchor_receipt_json() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -252,7 +256,7 @@ async fn submit_compiled_ccl_runs_via_executor() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
@@ -260,6 +264,7 @@ async fn submit_compiled_ccl_runs_via_executor() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -295,7 +300,7 @@ async fn queued_compiled_ccl_executes() {
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
@@ -303,6 +308,7 @@ async fn queued_compiled_ccl_executes() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -344,6 +350,7 @@ async fn compiled_example_contract_file_runs() {
         timestamp: 0,
         author_did: Did::new("key", "tester"),
         signature: None,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;

--- a/icn-ccl/src/cli.rs
+++ b/icn-ccl/src/cli.rs
@@ -50,7 +50,7 @@ pub fn compile_ccl_file(
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, &wasm_bytecode, &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, &wasm_bytecode, &[], ts, &author, &sig_opt, &None);
     metadata.cid = cid.to_string();
 
     // Calculate SHA-256 hash of the source code

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -75,8 +75,15 @@ fn test_compile_ccl_file_cli_function() {
             let ts = 0u64;
             let author = icn_common::Did::new("key", "tester");
             let sig_opt = None;
-            let expected_cid =
-                icn_common::compute_merkle_cid(0x71, &wasm_bytes, &[], ts, &author, &sig_opt);
+            let expected_cid = icn_common::compute_merkle_cid(
+                0x71,
+                &wasm_bytes,
+                &[],
+                ts,
+                &author,
+                &sig_opt,
+                &None,
+            );
             assert_eq!(metadata.cid, expected_cid.to_string());
 
             println!(
@@ -177,7 +184,7 @@ async fn test_wasm_executor_with_ccl() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
@@ -185,6 +192,7 @@ async fn test_wasm_executor_with_ccl() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -319,7 +327,7 @@ async fn test_wasm_executor_runs_addition() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
@@ -327,6 +335,7 @@ async fn test_wasm_executor_runs_addition() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -41,7 +41,7 @@ async fn wasm_executor_runs_compiled_ccl() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
@@ -49,6 +49,7 @@ async fn wasm_executor_runs_compiled_ccl() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -91,7 +92,7 @@ async fn wasm_executor_runs_compiled_addition() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
@@ -99,6 +100,7 @@ async fn wasm_executor_runs_compiled_addition() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -141,7 +143,7 @@ async fn wasm_executor_fails_without_run() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid_calc = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid_calc.clone(),
         data: wasm.clone(),
@@ -149,6 +151,7 @@ async fn wasm_executor_fails_without_run() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -190,7 +193,7 @@ async fn compile_and_execute_simple_contract() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
@@ -198,6 +201,7 @@ async fn compile_and_execute_simple_contract() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;
@@ -239,7 +243,7 @@ async fn wasm_executor_runs_compiled_file() {
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
-    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt);
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data: wasm.clone(),
@@ -247,6 +251,7 @@ async fn wasm_executor_runs_compiled_file() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     {
         let mut store = ctx.dag_store.lock().await;

--- a/icn-runtime/tests/wasm_executor.rs
+++ b/icn-runtime/tests/wasm_executor.rs
@@ -39,8 +39,8 @@ async fn compiled_policy_executes_via_host_abi() {
     // Store metadata referencing the wasm CID
     meta.cid = wasm_cid.to_string();
     let meta_bytes = serde_json::to_vec(&meta).unwrap();
-    let meta_cid = compute_merkle_cid(0x80, &meta_bytes, &[], ts, &author, &None);
-    let meta_block = DagBlock { cid: meta_cid.clone(), data: meta_bytes, links: vec![], timestamp: ts, author_did: author, signature: None };
+    let meta_cid = compute_merkle_cid(0x80, &meta_bytes, &[], ts, &author, &None, &None);
+    let meta_block = DagBlock { cid: meta_cid.clone(), data: meta_bytes, links: vec![], timestamp: ts, author_did: author, signature: None, scope: None };
     {
         let mut store = dag_store.lock().await;
         store.put(&meta_block).unwrap();

--- a/tests/integration/cli_node.rs
+++ b/tests/integration/cli_node.rs
@@ -18,7 +18,7 @@ async fn dag_storage_via_cli() {
     let ts = 0u64;
     let author = Did::new("example", "alice");
     let sig_opt = None;
-    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt);
+    let cid = compute_merkle_cid(0x71, b"data", &[], ts, &author, &sig_opt, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data: b"data".to_vec(),
@@ -26,6 +26,7 @@ async fn dag_storage_via_cli() {
         timestamp: ts,
         author_did: author,
         signature: sig_opt,
+        scope: None,
     };
     let block_json = serde_json::to_string(&block).unwrap();
 

--- a/tests/integration/persistence.rs
+++ b/tests/integration/persistence.rs
@@ -10,7 +10,7 @@ mod persistence_rocksdb {
         let timestamp = 0u64;
         let author = Did::new("key", "tester");
         let sig = None;
-        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig);
+        let cid = compute_merkle_cid(0x71, &data, &[], timestamp, &author, &sig, &None);
         DagBlock {
             cid,
             data,
@@ -18,6 +18,7 @@ mod persistence_rocksdb {
             timestamp,
             author_did: author,
             signature: sig,
+            scope: None,
         }
     }
 

--- a/tests/integration/policy_enforcer.rs
+++ b/tests/integration/policy_enforcer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::str::FromStr;
 
-use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did, SignatureBytes};
+use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did, NodeScope, SignatureBytes};
 use icn_runtime::context::RuntimeContext;
 use icn_governance::scoped_policy::{DagPayloadOp, PolicyCheckResult, ScopedPolicyEnforcer};
 
@@ -12,7 +12,7 @@ enum PolicyError {
 }
 
 trait MembershipResolver {
-    fn is_member(&self, did: &Did) -> bool;
+    fn is_member(&self, did: &Did, scope: &NodeScope) -> bool;
 }
 
 struct StaticMembershipResolver {
@@ -26,7 +26,7 @@ impl StaticMembershipResolver {
 }
 
 impl MembershipResolver for StaticMembershipResolver {
-    fn is_member(&self, did: &Did) -> bool {
+    fn is_member(&self, did: &Did, _scope: &NodeScope) -> bool {
         self.members.contains(did)
     }
 }
@@ -42,8 +42,21 @@ impl<R: MembershipResolver> MockScopedPolicyEnforcer<R> {
 }
 
 impl<R: MembershipResolver> ScopedPolicyEnforcer for MockScopedPolicyEnforcer<R> {
-    fn check_permission(&self, _op: DagPayloadOp, actor: &Did) -> PolicyCheckResult {
-        if self.resolver.is_member(actor) {
+    fn check_permission(
+        &self,
+        _op: DagPayloadOp,
+        actor: &Did,
+        scope: Option<&NodeScope>,
+    ) -> PolicyCheckResult {
+        if let Some(scope) = scope {
+            if self.resolver.is_member(actor, scope) {
+                PolicyCheckResult::Allowed
+            } else {
+                PolicyCheckResult::Denied {
+                    reason: "scope membership missing".to_string(),
+                }
+            }
+        } else if self.resolver.is_member(actor, &NodeScope("default".into())) {
             PolicyCheckResult::Allowed
         } else {
             PolicyCheckResult::Denied {
@@ -58,8 +71,11 @@ async fn anchor_block_with_policy<E: ScopedPolicyEnforcer>(
     block: &DagBlock,
     enforcer: &E,
 ) -> Result<(), PolicyError> {
-    if let PolicyCheckResult::Denied { .. } =
-        enforcer.check_permission(DagPayloadOp::SubmitBlock, &block.author_did)
+    if let PolicyCheckResult::Denied { .. } = enforcer.check_permission(
+        DagPayloadOp::SubmitBlock,
+        &block.author_did,
+        block.scope.as_ref(),
+    )
     {
         return Err(PolicyError::Unauthorized);
     }
@@ -91,7 +107,7 @@ async fn authorized_dag_write_succeeds() {
 
     let data = b"block".to_vec();
     let ts = 0u64;
-    let cid = compute_merkle_cid(0x71, &data, &[], ts, &alice, &None);
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &alice, &None, &None);
     let block = DagBlock {
         cid: cid.clone(),
         data,
@@ -99,6 +115,7 @@ async fn authorized_dag_write_succeeds() {
         timestamp: ts,
         author_did: alice.clone(),
         signature: None,
+        scope: None,
     };
 
     anchor_block_with_policy(&ctx, &block, &enforcer)
@@ -121,7 +138,7 @@ async fn unauthorized_write_denied() {
     let eve = Did::from_str("did:example:eve").unwrap();
     let data = b"bad".to_vec();
     let ts = 0u64;
-    let cid = compute_merkle_cid(0x71, &data, &[], ts, &eve, &None);
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &eve, &None, &None);
     let block = DagBlock {
         cid,
         data,
@@ -129,6 +146,7 @@ async fn unauthorized_write_denied() {
         timestamp: ts,
         author_did: eve.clone(),
         signature: None,
+        scope: None,
     };
 
     let res = anchor_block_with_policy(&ctx, &block, &enforcer).await;
@@ -144,7 +162,7 @@ async fn invalid_parent_is_rejected() {
     let resolver = StaticMembershipResolver::new(members);
     let enforcer = MockScopedPolicyEnforcer::new(resolver);
 
-    let missing_cid = compute_merkle_cid(0x71, b"parent", &[], 0, &alice, &None);
+    let missing_cid = compute_merkle_cid(0x71, b"parent", &[], 0, &alice, &None, &None);
     let link = DagLink {
         cid: missing_cid,
         name: "parent".into(),
@@ -152,7 +170,7 @@ async fn invalid_parent_is_rejected() {
     };
     let data = b"child".to_vec();
     let ts = 0u64;
-    let cid = compute_merkle_cid(0x71, &data, &[link.clone()], ts, &alice, &None);
+    let cid = compute_merkle_cid(0x71, &data, &[link.clone()], ts, &alice, &None, &None);
     let block = DagBlock {
         cid,
         data,
@@ -160,9 +178,38 @@ async fn invalid_parent_is_rejected() {
         timestamp: ts,
         author_did: alice.clone(),
         signature: None,
+        scope: None,
     };
 
     let res = anchor_block_with_policy(&ctx, &block, &enforcer).await;
     assert_eq!(res, Err(PolicyError::InvalidParent));
+}
+
+#[tokio::test]
+async fn scope_membership_enforced() {
+    let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
+    let alice = Did::from_str("did:example:alice").unwrap();
+    let scope = NodeScope("testscope".into());
+    let mut members = HashSet::new();
+    members.insert(alice.clone());
+    let resolver = StaticMembershipResolver::new(members);
+    let enforcer = MockScopedPolicyEnforcer::new(resolver);
+
+    let data = b"scoped".to_vec();
+    let ts = 0u64;
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &alice, &None, &Some(scope.clone()));
+    let block = DagBlock {
+        cid,
+        data,
+        links: vec![],
+        timestamp: ts,
+        author_did: alice,
+        signature: None,
+        scope: Some(scope),
+    };
+
+    anchor_block_with_policy(&ctx, &block, &enforcer)
+        .await
+        .expect("scoped write succeeds");
 }
 


### PR DESCRIPTION
## Summary
- extend `DagBlock` with an optional `NodeScope`
- update Merkle hashing and block verification
- enforce scope permissions in scoped policy enforcer
- adjust storage and API helpers for scope
- cover scope validation in tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_68630457fbf08324b9db940d6d9e082e