### PR TITLE
[tests] use governance policy enforcer

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -44,3 +44,4 @@ assert_cmd = "2.0"
 predicates = "3.1"
 axum = { version = "0.7", features = ["json"] }
 icn-node = { path = "../crates/icn-node" }
+icn-governance = { path = "../crates/icn-governance" }


### PR DESCRIPTION
## Summary
- use `icn_governance` `InMemoryPolicyEnforcer` in integration test
- add `icn-governance` dependency for tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(fails: test failed, to rerun pass `-p icn-runtime --lib`)*

------
https://chatgpt.com/codex/tasks/task_e_6863046717cc83248410b5358c0b80f9