### PR TITLE
[tests] use governance policy enforcer

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -44,3 +44,5 @@ assert_cmd = "2.0"
 predicates = "3.1"
 axum = { version = "0.7", features = ["json"] }
 icn-node = { path = "../crates/icn-node" }
+icn-runtime = { path = "../crates/icn-runtime" }
+icn-governance = { path = "../crates/icn-governance" }

--- a/tests/integration/policy_enforcer.rs
+++ b/tests/integration/policy_enforcer.rs
@@ -1,9 +1,11 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did, NodeScope, SignatureBytes};
+use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did, NodeScope};
 use icn_runtime::context::RuntimeContext;
-use icn_governance::scoped_policy::{DagPayloadOp, PolicyCheckResult, ScopedPolicyEnforcer};
+use icn_governance::scoped_policy::{
+    DagPayloadOp, InMemoryPolicyEnforcer, PolicyCheckResult, ScopedPolicyEnforcer,
+};
 
 #[derive(Debug, PartialEq, Eq)]
 enum PolicyError {
@@ -11,60 +13,6 @@ enum PolicyError {
     InvalidParent,
 }
 
-trait MembershipResolver {
-    fn is_member(&self, did: &Did, scope: &NodeScope) -> bool;
-}
-
-struct StaticMembershipResolver {
-    members: HashSet<Did>,
-}
-
-impl StaticMembershipResolver {
-    fn new(members: HashSet<Did>) -> Self {
-        Self { members }
-    }
-}
-
-impl MembershipResolver for StaticMembershipResolver {
-    fn is_member(&self, did: &Did, _scope: &NodeScope) -> bool {
-        self.members.contains(did)
-    }
-}
-
-struct MockScopedPolicyEnforcer<R: MembershipResolver> {
-    resolver: R,
-}
-
-impl<R: MembershipResolver> MockScopedPolicyEnforcer<R> {
-    fn new(resolver: R) -> Self {
-        Self { resolver }
-    }
-}
-
-impl<R: MembershipResolver> ScopedPolicyEnforcer for MockScopedPolicyEnforcer<R> {
-    fn check_permission(
-        &self,
-        _op: DagPayloadOp,
-        actor: &Did,
-        scope: Option<&NodeScope>,
-    ) -> PolicyCheckResult {
-        if let Some(scope) = scope {
-            if self.resolver.is_member(actor, scope) {
-                PolicyCheckResult::Allowed
-            } else {
-                PolicyCheckResult::Denied {
-                    reason: "scope membership missing".to_string(),
-                }
-            }
-        } else if self.resolver.is_member(actor, &NodeScope("default".into())) {
-            PolicyCheckResult::Allowed
-        } else {
-            PolicyCheckResult::Denied {
-                reason: "unauthorized".to_string(),
-            }
-        }
-    }
-}
 
 async fn anchor_block_with_policy<E: ScopedPolicyEnforcer>(
     ctx: &RuntimeContext,
@@ -100,10 +48,9 @@ async fn anchor_block_with_policy<E: ScopedPolicyEnforcer>(
 async fn authorized_dag_write_succeeds() {
     let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
     let alice = Did::from_str("did:example:alice").unwrap();
-    let mut members = HashSet::new();
-    members.insert(alice.clone());
-    let resolver = StaticMembershipResolver::new(members);
-    let enforcer = MockScopedPolicyEnforcer::new(resolver);
+    let mut submitters = HashSet::new();
+    submitters.insert(alice.clone());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
 
     let data = b"block".to_vec();
     let ts = 0u64;
@@ -130,10 +77,9 @@ async fn authorized_dag_write_succeeds() {
 async fn unauthorized_write_denied() {
     let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
     let alice = Did::from_str("did:example:alice").unwrap();
-    let mut members = HashSet::new();
-    members.insert(alice.clone());
-    let resolver = StaticMembershipResolver::new(members);
-    let enforcer = MockScopedPolicyEnforcer::new(resolver);
+    let mut submitters = HashSet::new();
+    submitters.insert(alice.clone());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
 
     let eve = Did::from_str("did:example:eve").unwrap();
     let data = b"bad".to_vec();
@@ -157,10 +103,9 @@ async fn unauthorized_write_denied() {
 async fn invalid_parent_is_rejected() {
     let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
     let alice = Did::from_str("did:example:alice").unwrap();
-    let mut members = HashSet::new();
-    members.insert(alice.clone());
-    let resolver = StaticMembershipResolver::new(members);
-    let enforcer = MockScopedPolicyEnforcer::new(resolver);
+    let mut submitters = HashSet::new();
+    submitters.insert(alice.clone());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
 
     let missing_cid = compute_merkle_cid(0x71, b"parent", &[], 0, &alice, &None, &None);
     let link = DagLink {
@@ -190,10 +135,15 @@ async fn scope_membership_enforced() {
     let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
     let alice = Did::from_str("did:example:alice").unwrap();
     let scope = NodeScope("testscope".into());
-    let mut members = HashSet::new();
-    members.insert(alice.clone());
-    let resolver = StaticMembershipResolver::new(members);
-    let enforcer = MockScopedPolicyEnforcer::new(resolver);
+    let mut submitters = HashSet::new();
+    submitters.insert(alice.clone());
+    let mut memberships = HashMap::new();
+    memberships.insert(scope.clone(), {
+        let mut set = HashSet::new();
+        set.insert(alice.clone());
+        set
+    });
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), memberships);
 
     let data = b"scoped".to_vec();
     let ts = 0u64;


### PR DESCRIPTION
## Summary
- use `InMemoryPolicyEnforcer` from governance crate in integration test
- add governance and runtime deps for tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: environment limitations)*
- `cargo test --all-features --workspace` *(failed: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686313fbfa40832484c4a59bbdaedff9