### PR TITLE
[economics] mana regen uses reputation

### DIFF
--- a/crates/icn-runtime/tests/mana_regenerator.rs
+++ b/crates/icn-runtime/tests/mana_regenerator.rs
@@ -4,10 +4,15 @@ use std::time::Duration;
 #[tokio::test]
 async fn balances_increase_when_regenerator_runs() {
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:regen", 0).unwrap();
+    ctx.reputation_store
+        .record_execution(&ctx.current_identity, true, 0);
+    ctx.reputation_store
+        .record_execution(&ctx.current_identity, true, 0);
     let interval = Duration::from_millis(100);
     ctx.clone().spawn_mana_regenerator(5, interval).await;
     assert_eq!(ctx.mana_ledger.get_balance(&ctx.current_identity), 0);
     tokio::time::sleep(Duration::from_millis(120)).await;
     let bal1 = ctx.mana_ledger.get_balance(&ctx.current_identity);
-    assert!(bal1 >= 5);
+    // reputation is 2, so at least 10 mana should be credited per cycle
+    assert!(bal1 >= 10);
 }


### PR DESCRIPTION
## Summary
- extend `ManaLedger` with `all_accounts`
- support listing accounts for file, rocksdb, and sqlite ledgers
- add `credit_by_reputation` function to credit based on reputation scores
- update `RuntimeContext::spawn_mana_regenerator` to use reputation
- adjust mana regenerator test for reputation-aware logic

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timed out)*
- `cargo test --all-features --workspace` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686317587e748324b6ebc401a7f53383