### PR TITLE
[workspace] add docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Docs
+
+on:
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build documentation
+        run: cargo doc --workspace --no-deps
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          publish_branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ rustup override set nightly
 
 ## Getting Started
 
-Refer to `docs/ONBOARDING.md` for detailed instructions on prerequisites, setup, building, testing, and running the components.
+Refer to `docs/ONBOARDING.md` for detailed instructions on prerequisites, setup, building, testing, and running the components. The latest API documentation is available at [https://intercooperative.network/docs/icn-core](https://intercooperative.network/docs/icn-core).
 
 ### Quick CLI Examples:
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build rustdoc and deploy
- reference the docs website in the project README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build took too long)*
- `cargo test --all-features --workspace` *(failed: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_68631e04740c8324a2f272ff95c4e658