### PR TITLE
[runtime] enforce wasm limits

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -2086,7 +2086,11 @@ mod tests {
         let exec_did = did_key_from_verifying_key(&vk);
         let exec_did = Did::from_str(&exec_did).unwrap();
         let signer = std::sync::Arc::new(icn_runtime::context::StubSigner::new_with_keys(sk, vk));
-        let executor = WasmExecutor::new(ctx.clone(), signer);
+        let executor = WasmExecutor::new(
+            ctx.clone(),
+            signer,
+            icn_runtime::executor::WasmExecutorConfig::default(),
+        );
         let job = ActualMeshJob {
             id: job_id.clone(),
             manifest_cid: wasm_cid.clone(),

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -83,6 +83,13 @@ set.
 `spawn_mana_regenerator` to start a background task that credits every
 account with a fixed amount on a configurable interval.
 
+## WASM Execution Limits
+
+`WasmExecutor` instances can be configured with a maximum linear memory size and
+a fuel allowance. Fuel metering is enabled via Wasmtime and each instruction
+consumes fuel. When a module exhausts its fuel or attempts to grow memory beyond
+the configured limit, execution is aborted.
+
 ## Error Types
 
 `CommonError` is used for all runtime failures.

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -215,7 +215,11 @@ async fn test_wasm_executor_with_ccl() {
     };
 
     let signer = std::sync::Arc::new(icn_runtime::context::StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer);
+    let exec = WasmExecutor::new(
+        ctx.clone(),
+        signer,
+        icn_runtime::executor::WasmExecutorConfig::default(),
+    );
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
 }
@@ -358,7 +362,11 @@ async fn test_wasm_executor_runs_addition() {
     };
 
     let signer = std::sync::Arc::new(icn_runtime::context::StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer);
+    let exec = WasmExecutor::new(
+        ctx.clone(),
+        signer,
+        icn_runtime::executor::WasmExecutorConfig::default(),
+    );
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
 }

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -13,9 +13,7 @@ use tokio::sync::Mutex as TokioMutex;
 
 fn ctx_with_temp_store(did: &str, mana: u64) -> Arc<RuntimeContext> {
     let temp = tempfile::tempdir().unwrap();
-    let dag_store = Arc::new(TokioMutex::new(
-        InMemoryDagStore::new(),
-    ));
+    let dag_store = Arc::new(TokioMutex::new(InMemoryDagStore::new()));
     let ctx = RuntimeContext::new_with_ledger_path(
         icn_common::Did::from_str(did).unwrap(),
         Arc::new(StubMeshNetworkService::new()),
@@ -71,7 +69,7 @@ async fn wasm_executor_runs_compiled_ccl() {
     };
 
     let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer);
+    let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();
@@ -122,7 +120,7 @@ async fn wasm_executor_runs_compiled_addition() {
     };
 
     let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer);
+    let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();
@@ -173,7 +171,7 @@ async fn wasm_executor_fails_without_run() {
     };
 
     let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer);
+    let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();
@@ -221,7 +219,7 @@ async fn compile_and_execute_simple_contract() {
     };
 
     let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer);
+    let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
         let rt = Runtime::new().unwrap();
@@ -274,7 +272,7 @@ async fn wasm_executor_runs_compiled_file() {
     };
 
     let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer);
+    let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = std::thread::spawn(move || {
         let rt = Runtime::new().unwrap();


### PR DESCRIPTION
## Summary
- add `WasmExecutorConfig` with memory and fuel settings
- configure wasmtime to consume fuel and enforce memory via `StoreLimits`
- expose defaults in `WasmExecutor::new`
- document limits in runtime README
- test memory and fuel limits

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68634847a4b48324b48a971899395079