### PR TITLE
[cli] add network peers subcommand

### DIFF
--- a/crates/icn-api/Cargo.toml
+++ b/crates/icn-api/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { workspace = true }
 async-trait = "0.1"
+reqwest.workspace = true
 
 [features]
 default = []

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -19,6 +19,7 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
 *   **Network Operations:**
     *   `icn-cli network discover-peers`: Query the connected node for peers. With the `with-libp2p` feature enabled the node will perform real discovery via libp2p.
     *   `icn-cli network send-message <PEER_ID> <MESSAGE_JSON>`: Send a `NetworkMessage` to a specified peer. Requires the node to run with libp2p networking.
+    *   `icn-cli network peers`: Display this node's peer ID and the currently discovered peer list.
 *   **Federation Operations:**
     *   `icn-cli federation join <PEER_ID>`: Join a federation by adding the given peer.
     *   `icn-cli federation leave <PEER_ID>`: Leave a federation or remove the peer.


### PR DESCRIPTION
## Summary
- support querying peer list in `icn-cli`
- expose `/network/local-peer-id` and `/network/peers` in `icn-node`
- implement HTTP helpers in `icn-api`
- document new command

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-cli -p icn-node -p icn-api --all-features -- -D warnings`
- `cargo test --all-features --workspace --no-run` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6864f11897b4832497e5c0240f401ca8