### PR TITLE
[icn-dag] enable sqlite backend test

### DIFF
--- a/crates/icn-dag/tests/sqlite_backend.rs
+++ b/crates/icn-dag/tests/sqlite_backend.rs
@@ -53,7 +53,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn sqlite_round_trip() {
         let dir = tempdir().unwrap();
         let db_path: PathBuf = dir.path().join("dag.sqlite");


### PR DESCRIPTION
## Summary
- enable the SQLite backend test in icn-dag

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --features persist-sqlite -p icn-dag -- -D warnings` *(fails: environment constraints)*
- `cargo test --features persist-sqlite -p icn-dag` *(fails: environment constraints)*


------
https://chatgpt.com/codex/tasks/task_e_6864f11693e48324a7d88aa35bf48f97