### PR TITLE
[icn-mesh] introduce JobId newtype and deterministic job id

### DIFF
--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -14,10 +14,29 @@ use icn_identity::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Unique identifier for a mesh job.
+///
+/// Wraps a [`Cid`] to enforce type safety when referencing jobs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct JobId(pub Cid);
 
-// Define JobId and Resources if they are not already defined elsewhere
-// For now, let's use a simple type alias or placeholder
-pub type JobId = Cid;
+impl From<Cid> for JobId {
+    fn from(c: Cid) -> Self {
+        JobId(c)
+    }
+}
+
+impl From<JobId> for Cid {
+    fn from(j: JobId) -> Self {
+        j.0
+    }
+}
+
+impl std::fmt::Display for JobId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 /// Execution resource capabilities offered in a bid.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Resources {
@@ -554,9 +573,7 @@ mod tests {
                 .get_mut(did)
                 .ok_or_else(|| icn_common::CommonError::DatabaseError("account".into()))?;
             if *bal < amount {
-                return Err(icn_common::CommonError::PolicyDenied(
-                    "insufficient".into(),
-                ));
+                return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
             }
             *bal -= amount;
             Ok(())
@@ -1081,5 +1098,4 @@ mod tests {
         let (_sk2, vk2) = icn_identity::generate_ed25519_keypair();
         assert!(msg.verify_signature(&vk2).is_err());
     }
-
 }


### PR DESCRIPTION
## Summary
- add `JobId` newtype wrapping `Cid`
- compute deterministic job IDs in `host_submit_mesh_job`
- propagate JobId usage into runtime and tests

## Testing
- `cargo fmt -- crates/icn-mesh/src/lib.rs crates/icn-runtime/src/context.rs crates/icn-runtime/src/lib.rs icn-runtime/tests/mesh.rs`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation timed out)*
- `cargo test -p icn-mesh -p icn-runtime --no-run` *(failed: compilation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6864f11350dc8324b303c755a8ebb7df