### PR TITLE
[docs] clarify icn-identity status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The InterCooperative Network is envisioned as a decentralized network fostering 
 
 The project has achieved a significant milestone, delivering an MVP with a functional protocol stack powered by a real libp2p mesh. Key features include:
 
-*   **Modular Crate Structure:** Well-defined crates for common types (`icn-common`), API definitions (`icn-api`), DAG L1 logic (`icn-dag`), identity placeholders (`icn-identity`), networking abstractions (`icn-network`), a node runner (`icn-node`), a CLI (`icn-cli`), and the Cooperative Contract Language compiler (`icn-ccl`, located at the repository root outside `crates/`).
+*   **Modular Crate Structure:** Well-defined crates for common types (`icn-common`), API definitions (`icn-api`), DAG L1 logic (`icn-dag`), an initial identity module (`icn-identity`), networking abstractions (`icn-network`), a node runner (`icn-node`), a CLI (`icn-cli`), and the Cooperative Contract Language compiler (`icn-ccl`, located at the repository root outside `crates/`).
 *   **Real Protocol Data Models:** Core data types like DIDs, CIDs, DagBlocks, Transactions, and NodeStatus are defined in `icn-common` and utilize `serde` for serialization.
 *   **In-Memory DAG Store:** `icn-dag` ships with an in-memory DAG store implementing the `StorageService` trait. Use this trait directly rather than the deprecated `put_block`/`get_block` helpers.
 *   **API Layer:** `icn-api` exposes functions for node interaction (info, status) and DAG operations (submit, retrieve blocks).

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -307,7 +307,7 @@ cargo run -p icn-node --config node_config.toml
     *   **`icn-api`**: Defines functions that act as the API layer for node interactions. Currently, these are direct function calls but are designed to be adaptable for RPC.
     *   **`icn-dag`**: Implements L1 DAG block storage (currently an in-memory `HashMap`).
     *   **`icn-network`**: Contains networking abstractions (`NetworkService` trait, `NetworkMessage` enum) and a `StubNetworkService` for testing.
-    *   **`icn-identity`**: Placeholders for DID management and cryptographic functions.
+    *   **`icn-identity`**: Provides an initial module for DID management and cryptographic functions.
     *   **`icn-node`**: The main binary executable that runs a persistent HTTP server for the ICN node API.
     *   **`icn-cli`**: The command-line interface client that interacts with `icn-node` via HTTP.
     *   Other crates (`icn-economics`, `icn-governance`, etc.) are placeholders for future development.


### PR DESCRIPTION
## Summary
- note that `icn-identity` is an initial identity module
- update onboarding guide to match

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timed out)*
- `cargo test --all-features --workspace` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6864f119fa4c8324b4d3c4ace0525e5e