### PR TITLE
[icn-dag] remove deprecated global store helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The project has achieved a significant milestone, delivering an MVP with a funct
 
 *   **Modular Crate Structure:** Well-defined crates for common types (`icn-common`), API definitions (`icn-api`), DAG L1 logic (`icn-dag`), an initial identity module (`icn-identity`), networking abstractions (`icn-network`), a node runner (`icn-node`), a CLI (`icn-cli`), and the Cooperative Contract Language compiler (`icn-ccl`, located at the repository root outside `crates/`).
 *   **Real Protocol Data Models:** Core data types like DIDs, CIDs, DagBlocks, Transactions, and NodeStatus are defined in `icn-common` and utilize `serde` for serialization.
-*   **In-Memory DAG Store:** `icn-dag` ships with an in-memory DAG store implementing the `StorageService` trait. Use this trait directly rather than the deprecated `put_block`/`get_block` helpers.
+*   **In-Memory DAG Store:** `icn-dag` provides an in-memory DAG store implementing the `StorageService` trait. Interact with DAG data through a chosen `StorageService` implementation.
 *   **API Layer:** `icn-api` exposes functions for node interaction (info, status) and DAG operations (submit, retrieve blocks).
 *   **Node & CLI Prototypes:**
     *   `icn-node`: A binary that demonstrates the integration of API, DAG, and networking components. When compiled with `with-libp2p` and started with `--enable-p2p`, it joins the libp2p mesh, discovers peers, and exchanges messages via gossipsub.

--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -7,7 +7,6 @@ license.workspace = true
 
 [dependencies]
 icn-common = { path = "../icn-common" }
-lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = { version = "0.34", optional = true }


### PR DESCRIPTION
## Summary
- remove DEFAULT_IN_MEMORY_STORE with put/get helpers
- drop related unit test
- clean README to mention only StorageService implementations

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: manual_flatten lint in icn-economics)*
- `cargo test --all-features --workspace` *(interrupted due to build time)*

------
https://chatgpt.com/codex/tasks/task_e_6865b4555fd08324a2371a90a5ac515e