### PR TITLE
[dag] async storage service and tokio file store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New scoring algorithm in `icn-mesh` with reputation-based `select_executor`.
 - Introduced `icn-reputation` crate providing `ReputationStore` trait and in-memory implementation.
 - Multi-node CLI with libp2p networking and bootstrap peer discovery.
+- AsyncStorageService trait and TokioFileDagStore for async DAG I/O.
 - Cross-node mesh job execution pipeline with signed receipts anchored to the DAG.
 - HTTP gateway enabling REST job submission and status queries.
 - Containerized 3-node federation devnet with Docker and integration tests.

--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -14,6 +14,8 @@ sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
 rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
 rocksdb = { version = "0.21", optional = true }
+tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"], optional = true }
+async-trait = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"
@@ -27,3 +29,4 @@ default = ["persist-rocksdb"]
 persist-sled = ["dep:sled", "dep:bincode"]
 persist-sqlite = ["dep:rusqlite"]
 persist-rocksdb = ["dep:rocksdb", "dep:bincode"]
+async = ["dep:tokio", "dep:async-trait"]

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -54,6 +54,7 @@ persist-sled = ["icn-governance/persist-sled", "icn-reputation/persist-sled"]
 persist-sqlite = ["icn-governance/persist-sled", "icn-reputation/persist-sqlite", "icn-economics/persist-sqlite"]
 persist-rocksdb = ["icn-governance/persist-sled", "icn-reputation/persist-rocksdb", "icn-economics/persist-rocksdb"]
 cli = ["dep:clap"]
+async = ["icn-dag/async"]
 
 # Integration tests for cross-node functionality
 [[test]]

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -96,12 +96,15 @@ pub trait Signer: Send + Sync + std::fmt::Debug {
 
 #[cfg(feature = "persist-rocksdb")]
 use icn_dag::rocksdb_store::RocksDagStore;
+#[cfg(feature = "async")]
+use icn_dag::AsyncStorageService as DagStorageService;
 #[cfg(not(any(
     feature = "persist-rocksdb",
     feature = "persist-sled",
     feature = "persist-sqlite"
 )))]
 use icn_dag::FileDagStore;
+#[cfg(not(feature = "async"))]
 use icn_dag::StorageService as DagStorageService;
 
 // Placeholder for icn_economics::ManaRepository
@@ -2051,6 +2054,26 @@ impl DagStorageService<DagBlock> for StubDagStore {
 
     fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
         Ok(self.store.contains_key(cid))
+    }
+}
+
+#[cfg(feature = "async")]
+#[async_trait::async_trait]
+impl icn_dag::AsyncStorageService<DagBlock> for StubDagStore {
+    async fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
+        self.put(block)
+    }
+
+    async fn get(&self, cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
+        self.get(cid)
+    }
+
+    async fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        self.delete(cid)
+    }
+
+    async fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
+        self.contains(cid)
     }
 }
 

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -9,6 +9,9 @@
 // crates/icn-runtime/tests/mesh.rs
 
 use icn_common::{compute_merkle_cid, Cid, Did};
+#[cfg(feature = "async")]
+use icn_dag::AsyncStorageService as StorageService;
+#[cfg(not(feature = "async"))]
 use icn_dag::StorageService;
 use icn_identity::generate_ed25519_keypair;
 use icn_identity::{ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes};


### PR DESCRIPTION
## Summary
- add `AsyncStorageService` trait with async CRUD operations
- implement `TokioFileDagStore` using `tokio::fs`
- support async DAG store in `RuntimeContext` when `async` feature is enabled
- add async unit test for `TokioFileDagStore`
- update changelog

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timed out)*
- `cargo test --all-features --workspace` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6865b43f3f8c8324bf63c9a18f6e5448