### PR TITLE
[dag] async storage service

### DIFF
--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -9,10 +9,12 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+async-trait = "0.1"
 sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
 rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
 rocksdb = { version = "0.21", optional = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"
@@ -20,9 +22,11 @@ sled = { version = "0.34", optional = false }
 bincode = { version = "1.3", optional = false }
 rusqlite = { version = "0.29", optional = false, features = ["bundled"] }
 rocksdb = { version = "0.21", optional = false }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "io-util"] }
 
 [features]
 default = ["persist-rocksdb"]
 persist-sled = ["dep:sled", "dep:bincode"]
 persist-sqlite = ["dep:rusqlite"]
 persist-rocksdb = ["dep:rocksdb", "dep:bincode"]
+async = ["dep:tokio"]

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -54,6 +54,7 @@ persist-sled = ["icn-governance/persist-sled", "icn-reputation/persist-sled"]
 persist-sqlite = ["icn-governance/persist-sled", "icn-reputation/persist-sqlite", "icn-economics/persist-sqlite"]
 persist-rocksdb = ["icn-governance/persist-sled", "icn-reputation/persist-rocksdb", "icn-economics/persist-rocksdb"]
 cli = ["dep:clap"]
+async = ["icn-dag/async"]
 
 # Integration tests for cross-node functionality
 [[test]]

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -20,6 +20,9 @@ pub mod metrics;
 
 // Re-export important types for convenience
 pub use context::{HostAbiError, RuntimeContext, Signer};
+#[cfg(feature = "async")]
+pub use icn_dag::AsyncStorageService as StorageService;
+#[cfg(not(feature = "async"))]
 pub use icn_dag::StorageService;
 
 // Re-export ABI constants


### PR DESCRIPTION
## Summary
- add `AsyncStorageService` trait with async CRUD operations
- implement `TokioFileDagStore` using `tokio::fs`
- support async DAG storage in `RuntimeContext`
- expose storage trait conditionally in `icn-runtime`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: environment limitations)*
- `cargo test --all-features --workspace` *(failed: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6865c66cf8688324aa7c36c434d2d54b