### PR TITLE
[icn-network] remove unused attribute

### DIFF
--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -478,7 +478,6 @@ pub mod libp2p_service {
     }
 
     #[derive(Debug)]
-    #[allow(dead_code)]
     enum Command {
         DiscoverPeers {
             target: Option<Libp2pPeerId>,


### PR DESCRIPTION
## Summary
- remove allow(dead_code) from Command enum

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build or network issues)*
- `cargo test --all-features --workspace` *(failed: build or network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6865cf2fcd3c832498eda7a74feb378d