### PR TITLE
[icn-dag] add async store tests and docs

### DIFF
--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -22,6 +22,24 @@ The API style prioritizes:
 *   **Flexibility:** Supporting different codecs and storage backends where appropriate.
 *   **Pluggable Persistence:** Includes in-memory, file-based, and optional `sled` backends via the `persist-sled` feature. When enabled, `SledDagStore` provides durable storage on disk.
 
+## Async Feature
+
+Enable the `async` feature to use asynchronous storage via `TokioFileDagStore`:
+
+```toml
+[dependencies]
+icn-dag = { path = "../icn-dag", features = ["async"] }
+```
+
+```rust
+use icn_dag::{AsyncStorageService, TokioFileDagStore};
+use tokio::sync::Mutex;
+use std::path::PathBuf;
+
+let store = TokioFileDagStore::new(PathBuf::from("./dag")).unwrap();
+let dag_store = Mutex::new(store); // implement AsyncStorageService
+```
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -83,6 +83,31 @@ set.
 `spawn_mana_regenerator` to start a background task that credits every
 account with a fixed amount on a configurable interval.
 
+## DAG Storage
+
+`RuntimeContext` selects a storage backend for receipts and other DAG data. When
+compiled with the `async` feature, use `TokioFileDagStore`:
+
+```rust
+use icn_runtime::context::{RuntimeContext, StubMeshNetworkService, StubSigner};
+use icn_common::Did;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[cfg(feature = "async")]
+let dag_store = Arc::new(Mutex::new(icn_dag::TokioFileDagStore::new("./dag".into()).unwrap()));
+#[cfg(not(feature = "async"))]
+let dag_store = Arc::new(Mutex::new(icn_dag::FileDagStore::new("./dag".into()).unwrap()));
+
+let ctx = RuntimeContext::new(
+    Did::new("key", "node"),
+    Arc::new(StubMeshNetworkService::new()),
+    Arc::new(StubSigner::new()),
+    Arc::new(icn_identity::KeyDidResolver),
+    dag_store,
+);
+```
+
 ## WASM Execution Limits
 
 `WasmExecutor` instances can be configured with a maximum linear memory size and


### PR DESCRIPTION
## Summary
- cover TokioFileDagStore persistence and error handling
- document enabling the async feature in icn-dag
- show RuntimeContext using TokioFileDagStore when async feature is enabled

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation interrupted)*
- `cargo test --all-features --workspace` *(failed: compilation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6865cf2f67e08324809d9b403816a54d