### PR TITLE
[icn-ccl] use log macros in cli

### DIFF
--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -19,6 +19,8 @@ reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+log = "0.4"
+env_logger = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -212,6 +212,7 @@ enum FederationCommands {
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
     let cli = Cli::parse();
     let client = Client::new();
 

--- a/icn-ccl/Cargo.toml
+++ b/icn-ccl/Cargo.toml
@@ -13,6 +13,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 hex = "0.4" # Added for placeholder CID/hash generation in cli.rs
+# Logging
+log = "0.4"
 # Hashing
 sha2 = "0.10"
 # WASM generation

--- a/icn-ccl/src/cli.rs
+++ b/icn-ccl/src/cli.rs
@@ -10,6 +10,7 @@ use crate::parser::parse_ccl_source;
 use crate::semantic_analyzer::SemanticAnalyzer;
 use crate::wasm_backend::WasmBackend;
 use icn_common::{compute_merkle_cid, Did};
+use log::info;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::PathBuf;
@@ -20,7 +21,7 @@ pub fn compile_ccl_file(
     output_wasm_path: &PathBuf,
     output_meta_path: &PathBuf,
 ) -> Result<ContractMetadata, CclError> {
-    println!(
+    info!(
         "[CCL CLI Lib] Compiling {} to {} (meta: {})",
         source_path.display(),
         output_wasm_path.display(),
@@ -76,7 +77,7 @@ pub fn compile_ccl_file(
         ))
     })?;
 
-    println!(
+    info!(
         "[CCL CLI Lib] Compilation successful. WASM: {}, Meta: {}",
         output_wasm_path.display(),
         output_meta_path.display()
@@ -86,18 +87,18 @@ pub fn compile_ccl_file(
 
 // This function would be called by `icn-cli ccl lint ...` or `icn-cli ccl check ...`
 pub fn check_ccl_file(source_path: &PathBuf) -> Result<(), CclError> {
-    println!("[CCL CLI Lib] Checking/Linting {}", source_path.display());
+    info!("[CCL CLI Lib] Checking/Linting {}", source_path.display());
     let source_code = fs::read_to_string(source_path)?;
     let ast = parse_ccl_source(&source_code)?;
     let mut semantic_analyzer = SemanticAnalyzer::new();
     semantic_analyzer.analyze(&ast)?;
-    println!("[CCL CLI Lib] {} passed checks.", source_path.display());
+    info!("[CCL CLI Lib] {} passed checks.", source_path.display());
     Ok(())
 }
 
 // This function would be called by `icn-cli ccl fmt ...`
 pub fn format_ccl_file(source_path: &PathBuf, _inplace: bool) -> Result<String, CclError> {
-    println!(
+    info!(
         "[CCL CLI Lib] Formatting {} (Inplace: {})",
         source_path.display(),
         _inplace
@@ -122,7 +123,7 @@ pub fn explain_ccl_policy(
     source_path: &PathBuf,
     _target_construct: Option<String>,
 ) -> Result<String, CclError> {
-    println!(
+    info!(
         "[CCL CLI Lib] Explaining {} (Target: {:?})",
         source_path.display(),
         _target_construct


### PR DESCRIPTION
## Summary
- use `log` macros in `icn-ccl` CLI helpers
- add logging deps for `icn-ccl` and `icn-cli`
- initialize env_logger in the CLI binary

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test --all-features --workspace` *(failed: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6865cf29be488324ac0564d04224921f