### PR TITLE
[icn-network] add message signing

### DIFF
--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -20,6 +20,7 @@ The `icn-network` crate is responsible for:
 
 *   **`PeerId`**: A struct representing a unique identifier for a network peer. Currently a simple string wrapper, but intended to be compatible with underlying P2P library IDs (e.g., libp2p `PeerId`).
 *   **`NetworkMessage`**: An enum defining the various types of messages that can be exchanged between ICN nodes. This includes messages for block announcements (`AnnounceBlock`), block requests (`RequestBlock`), generic gossip messages (`GossipSub`), federation sync requests (`FederationSyncRequest`), and federation join handshakes (`FederationJoinRequest`/`FederationJoinResponse`). This enum derives `Serialize` and `Deserialize` for network transmission.
+*   **`SignedMessage`**: Wraps a `NetworkMessage` together with the sender's DID and an Ed25519 signature. Helpers `sign_message` and `verify_message_signature` are provided to create and validate these structures.
 *   **`NetworkService` Trait**: An abstraction defining the core functionalities a network service provider must implement. This includes methods like `discover_peers`, `send_message`, and `broadcast_message`. Methods return `Result<_, CommonError>` using specific error variants like `PeerNotFound`, `MessageSendError`, etc.
 *   **`StubNetworkService`**: A default implementation of `NetworkService` that simulates network interactions by logging actions to the console and returning predefined data. It's used for development and testing of higher-level crates without requiring a live P2P network. It demonstrates returning specific `CommonError` variants for simulated network issues.
 
@@ -54,6 +55,15 @@ cargo build --features libp2p
 
 to use the `get_kademlia_record` and `put_kademlia_record` APIs as well as peer
 discovery via the DHT.
+
+## Message Signing
+
+All network messages should be authenticated. The helper function `sign_message`
+takes a `NetworkMessage`, the sender's `Did`, and a signing key to produce a
+`SignedMessage`. Peers can verify authenticity using
+`verify_message_signature`, which resolves the public key from the DID and
+checks the Ed25519 signature. The `StubNetworkService` verifies signatures for
+`send_signed_message` and `broadcast_signed_message` calls.
 
 ## Public API Style
 

--- a/crates/icn-network/tests/signed_message.rs
+++ b/crates/icn-network/tests/signed_message.rs
@@ -1,0 +1,42 @@
+use icn_common::Did;
+use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
+use icn_network::{
+    sign_message, NetworkMessage, NetworkService, SignedMessage, StubNetworkService,
+};
+use std::str::FromStr;
+
+#[tokio::test]
+async fn stub_service_valid_signature() {
+    let service = StubNetworkService::default();
+    let (sk, vk) = generate_ed25519_keypair();
+    let did_str = did_key_from_verifying_key(&vk);
+    let did = Did::from_str(&did_str).unwrap();
+    let msg = NetworkMessage::GossipSub("test".into(), b"hello".to_vec());
+    let signed = sign_message(&msg, &did, &sk).unwrap();
+    service
+        .send_signed_message(&icn_network::PeerId("peer1".into()), signed)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn stub_service_invalid_signature() {
+    let service = StubNetworkService::default();
+    let (sk, vk) = generate_ed25519_keypair();
+    let did_str = did_key_from_verifying_key(&vk);
+    let did = Did::from_str(&did_str).unwrap();
+    let msg = NetworkMessage::GossipSub("test".into(), b"hello".to_vec());
+    let mut signed = sign_message(&msg, &did, &sk).unwrap();
+    // Corrupt the signature
+    if let Some(byte) = signed.signature.0.first_mut() {
+        *byte ^= 0xFF;
+    }
+    let err = service
+        .send_signed_message(&icn_network::PeerId("peer1".into()), signed)
+        .await
+        .expect_err("should fail");
+    match err {
+        icn_network::MeshNetworkError::Common(_) => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- add SignedMessage struct with sign/verify helpers
- extend NetworkService with signed variants
- implement signed variants for StubNetworkService
- add tests for message signing
- document message signing in README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not finish)*
- `cargo test --all-features --workspace` *(failed: could not finish)*

------
https://chatgpt.com/codex/tasks/task_e_6865cf28c53c8324814c351bcc8e53ea