### PR TITLE
[icn-network] replace println with log macros

### DIFF
--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -209,7 +209,7 @@ impl NetworkService for StubNetworkService {
         &self,
         target_peer_id_str: Option<String>,
     ) -> Result<Vec<PeerId>, MeshNetworkError> {
-        println!(
+        log::info!(
             "[StubNetworkService] Discovering peers (target: {:?})... returning mock peers.",
             target_peer_id_str
         );
@@ -224,9 +224,10 @@ impl NetworkService for StubNetworkService {
         peer: &PeerId,
         message: NetworkMessage,
     ) -> Result<(), MeshNetworkError> {
-        println!(
+        log::debug!(
             "[StubNetworkService] Sending message to peer {:?}: {:?}",
-            peer, message
+            peer,
+            message
         );
         if peer.0 == "error_peer" {
             return Err(MeshNetworkError::SendFailure(format!(
@@ -244,7 +245,7 @@ impl NetworkService for StubNetworkService {
     }
 
     async fn broadcast_message(&self, message: NetworkMessage) -> Result<(), MeshNetworkError> {
-        println!("[StubNetworkService] Broadcasting message: {:?}", message);
+        log::debug!("[StubNetworkService] Broadcasting message: {:?}", message);
         if let NetworkMessage::GossipSub(topic, _) = &message {
             if topic == "system_critical_error_topic" {
                 return Err(MeshNetworkError::Libp2p(
@@ -256,7 +257,7 @@ impl NetworkService for StubNetworkService {
     }
 
     async fn subscribe(&self) -> Result<Receiver<NetworkMessage>, MeshNetworkError> {
-        println!("[StubNetworkService] Subscribing to messages... returning an empty channel.");
+        log::info!("[StubNetworkService] Subscribing to messages... returning an empty channel.");
         let (_tx, rx) = tokio::sync::mpsc::channel(1);
         Ok(rx)
     }


### PR DESCRIPTION
## Summary
- use `log` macros in the `StubNetworkService`
- ensure `log` dependency already enabled (already present)

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features` *(fails: build timeout)*
- `cargo test --workspace --all-features` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6865cf2682c883248537d6ccf5807da5