### PR TITLE
Default to sled backend in icn-economics

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,18 @@ cargo build --features with-libp2p
 # Build using the SQLite backend
 cargo build --no-default-features --features "with-libp2p persist-sqlite"
 
+# Build using the RocksDB backend
+cargo build --no-default-features --features "with-libp2p persist-rocksdb"
+
 # Start a node with persistent storage and P2P enabled
 ./target/debug/icn-node \
   --enable-p2p \
   --p2p-listen-addr /ip4/0.0.0.0/tcp/4001 \
   --storage-backend sqlite \
   --storage-path ./icn_data/node1.sqlite
+
+# To use RocksDB instead of SQLite, compile with `--features persist-rocksdb`
+# and pass `--storage-backend rocksdb` with a `.rocks` path.
 
 # In a second terminal start another node connecting to the first
 ./target/debug/icn-node \

--- a/crates/icn-economics/Cargo.toml
+++ b/crates/icn-economics/Cargo.toml
@@ -25,7 +25,7 @@ sled = { version = "0.34" }
 bincode = "1.3"
 
 [features]
-default = ["persist-rocksdb"]
+default = ["persist-sled"]
 persist-sled = ["dep:sled", "dep:bincode"]
 persist-sqlite = ["dep:rusqlite"]
 persist-rocksdb = ["dep:rocksdb", "dep:bincode"]

--- a/crates/icn-economics/README.md
+++ b/crates/icn-economics/README.md
@@ -27,6 +27,21 @@ Ledger implementations may support bulk credit operations.
 `ManaLedger::credit_all` adds a specified amount to every account and is used by
 the runtime to periodically regenerate balances.
 
+## Feature Flags
+
+Persistence backends are selected via Cargo features. The default backend uses
+[`sled`](https://crates.io/crates/sled) for a simple embedded database.
+
+- `persist-sled` *(default)* – store the mana ledger using sled.
+- `persist-rocksdb` – store the ledger using RocksDB. Enable with:
+
+```bash
+cargo build --features persist-rocksdb
+```
+
+When using RocksDB at runtime, pass `--mana-ledger-backend rocksdb` and a path
+ending in `.rocks` to the node binary.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.


### PR DESCRIPTION
## Summary
- prefer sled persistence in `icn-economics`
- document storage feature flags in `icn-economics` README
- expand root README with RocksDB build instructions

## Testing
- `cargo test --workspace --all-features` *(fails: build terminated)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6865e27f892c8324ac41f10fc1841b89