### PR TITLE
Make host_get_pending_mesh_jobs async

### DIFF
--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -133,7 +133,7 @@ pub async fn host_submit_mesh_job(
 /// For WebAssembly callers see [`wasm_host_get_pending_mesh_jobs`], which
 /// serializes the job list to JSON and writes it to guest memory using
 /// pointer/length parameters.
-pub fn host_get_pending_mesh_jobs(
+pub async fn host_get_pending_mesh_jobs(
     ctx: &RuntimeContext,
 ) -> Result<Vec<icn_mesh::ActualMeshJob>, HostAbiError> {
     metrics::HOST_GET_PENDING_MESH_JOBS_CALLS.inc();
@@ -142,14 +142,13 @@ pub fn host_get_pending_mesh_jobs(
     // Directly clone the jobs from the queue. This provides a snapshot.
     // Depending on WASM interface, this might need to be serialized (e.g., to JSON).
     // Need to acquire the lock and then await its resolution.
-    let jobs = futures::executor::block_on(async {
-        ctx.pending_mesh_jobs
-            .lock()
-            .await
-            .iter()
-            .cloned()
-            .collect::<Vec<icn_mesh::ActualMeshJob>>()
-    });
+    let jobs = ctx
+        .pending_mesh_jobs
+        .lock()
+        .await
+        .iter()
+        .cloned()
+        .collect::<Vec<icn_mesh::ActualMeshJob>>();
 
     debug!(
         "[host_get_pending_mesh_jobs] Returning {} pending jobs.",
@@ -384,7 +383,7 @@ pub fn wasm_host_get_pending_mesh_jobs(
     len: u32,
 ) -> u32 {
     let handle = tokio::runtime::Handle::current();
-    let jobs = match handle.block_on(async { host_get_pending_mesh_jobs(caller.data()) }) {
+    let jobs = match handle.block_on(host_get_pending_mesh_jobs(caller.data())) {
         Ok(j) => j,
         Err(e) => {
             log::error!("wasm_host_get_pending_mesh_jobs runtime error: {e:?}");
@@ -617,7 +616,7 @@ mod tests {
         assert_eq!(mana_after, 90);
 
         // Verify job was queued
-        let pending_jobs = host_get_pending_mesh_jobs(&ctx).unwrap();
+        let pending_jobs = host_get_pending_mesh_jobs(&ctx).await.unwrap();
         assert_eq!(pending_jobs.len(), 1);
         assert_eq!(pending_jobs[0].cost_mana, 10);
     }
@@ -661,7 +660,7 @@ mod tests {
         let _job_id1 = host_submit_mesh_job(&ctx, &job_json1).await.unwrap();
         let _job_id2 = host_submit_mesh_job(&ctx, &job_json2).await.unwrap();
 
-        let pending_jobs = host_get_pending_mesh_jobs(&ctx).unwrap();
+        let pending_jobs = host_get_pending_mesh_jobs(&ctx).await.unwrap();
         assert_eq!(pending_jobs.len(), 2);
         assert!(pending_jobs.iter().any(|j| j.cost_mana == 10));
         assert!(pending_jobs.iter().any(|j| j.cost_mana == 5));
@@ -670,7 +669,7 @@ mod tests {
     #[tokio::test]
     async fn test_host_get_pending_mesh_jobs_empty_queue() {
         let ctx = create_test_context();
-        let pending_jobs_result = host_get_pending_mesh_jobs(&ctx);
+        let pending_jobs_result = host_get_pending_mesh_jobs(&ctx).await;
         assert!(pending_jobs_result.is_ok());
         let pending_jobs = pending_jobs_result.unwrap();
         assert_eq!(pending_jobs.len(), 0);
@@ -861,7 +860,7 @@ mod tests {
         use crate::metrics::HOST_GET_PENDING_MESH_JOBS_CALLS;
         let ctx = create_test_context();
         let before = HOST_GET_PENDING_MESH_JOBS_CALLS.get();
-        host_get_pending_mesh_jobs(&ctx).unwrap();
+        host_get_pending_mesh_jobs(&ctx).await.unwrap();
         assert!(HOST_GET_PENDING_MESH_JOBS_CALLS.get() > before);
     }
 

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -86,7 +86,8 @@ async fn assert_job_state(
         ) => {
             if let Some(data) = expected_receipt_data {
                 assert_eq!(
-                    &receipt.job_id, &data.job_id.clone().into(),
+                    &receipt.job_id,
+                    &data.job_id.clone().into(),
                     "Completed receipt job_id mismatch"
                 );
                 assert_eq!(
@@ -731,7 +732,7 @@ async fn test_submit_mesh_job_with_custom_timeout() {
         .await
         .expect("Job submission failed");
 
-    let pending_jobs = host_get_pending_mesh_jobs(&ctx).unwrap();
+    let pending_jobs = host_get_pending_mesh_jobs(&ctx).await.unwrap();
     assert_eq!(pending_jobs.len(), 1);
     assert_eq!(pending_jobs[0].max_execution_wait_ms, Some(1234));
 }


### PR DESCRIPTION
## Summary
- make `host_get_pending_mesh_jobs` async
- await mutex inside the function instead of using `block_on`
- update WASM wrapper and tests to await the async API

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build timeout)*
- `cargo test --workspace --all-features` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6865e27bade88324b3c650006245c6e4