### PR TITLE
[node] return result for identity loading

### DIFF
--- a/crates/icn-node/tests/identity.rs
+++ b/crates/icn-node/tests/identity.rs
@@ -13,14 +13,14 @@ async fn identity_persists_between_runs() {
         node_private_key_path: key_path.clone(),
         ..Default::default()
     };
-    let (_sk1, _pk1, did1) = load_or_generate_identity(&mut cfg1);
+    let (_sk1, _pk1, did1) = load_or_generate_identity(&mut cfg1).unwrap();
 
     let mut cfg2 = NodeConfig {
         node_did_path: did_path.clone(),
         node_private_key_path: key_path.clone(),
         ..Default::default()
     };
-    let (_sk2, _pk2, did2) = load_or_generate_identity(&mut cfg2);
+    let (_sk2, _pk2, did2) = load_or_generate_identity(&mut cfg2).unwrap();
 
     assert_eq!(did1, did2);
     assert_eq!(cfg2.node_did.as_deref(), Some(did1.as_str()));


### PR DESCRIPTION
## Summary
- return `Result` from `load_or_generate_identity`
- propagate errors instead of panicking
- update node start-up and tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not finish in time)*
- `cargo test --all-features --workspace` *(failed: could not finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_6865ec50ac348324810d90c1cfab0cd9