### PR TITLE
[docs] switch rocksdb examples to sled

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -252,8 +252,8 @@ Caddy).
 # node_config.toml
 node_name = "Federation Node"
 http_listen_addr = "0.0.0.0:7845"        # Behind a TLS proxy
-storage_backend = "rocksdb"
-storage_path = "./icn_data/node.rocks"
+storage_backend = "sled"
+storage_path = "./icn_data/node.sled"
 api_key = "mysecretkey"
 open_rate_limit = 0
 ```
@@ -295,9 +295,12 @@ Example usage:
 
 ```bash
 export ICN_HTTP_LISTEN_ADDR=0.0.0.0:9000
-export ICN_STORAGE_BACKEND=rocksdb
+export ICN_STORAGE_BACKEND=sled
 cargo run -p icn-node --config node_config.toml
 ```
+
+To use RocksDB instead of sled, build `icn-node` with the `persist-rocksdb` feature
+and set `storage_backend = "rocksdb"` in your configuration.
 
 ## 4. Understanding the Codebase
 

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -26,13 +26,16 @@ tls_cert_path = "./cert.pem"
 tls_key_path = "./key.pem"
 ```
 
+To use RocksDB as the persistence layer, build `icn-node` with the
+`persist-rocksdb` feature and set `storage_backend = "rocksdb"`.
+
 ## Small Federation
 
 For a small group of cooperating nodes, each node may use a persistent store and
 bootstrap to known peers.
 
 ```bash
-icn-node --storage-backend rocksdb --storage-path ./icn_data/node1.rocks \
+icn-node --storage-backend sled --storage-path ./icn_data/node1.sled \
          --bootstrap-peers /ip4/1.2.3.4/tcp/7000/p2p/QmPeer \
          --api-key node1secret --open-rate-limit 0 \
          --tls-cert-path ./cert.pem --tls-key-path ./key.pem
@@ -43,8 +46,8 @@ A configuration file might contain:
 
 ```toml
 http_listen_addr = "0.0.0.0:7845"
-storage_backend = "rocksdb"
-storage_path = "./icn_data/node1.rocks"
+storage_backend = "sled"
+storage_path = "./icn_data/node1.sled"
 bootstrap_peers = ["/ip4/1.2.3.4/tcp/7000/p2p/QmPeer"]
 api_key = "node1secret"
 tls_cert_path = "./cert.pem"


### PR DESCRIPTION
## Summary
- update onboarding and deployment docs to use sled
- show how to enable RocksDB with the `persist-rocksdb` feature

## Testing
- `cargo fmt --all -- --check` *(fails: repository not formatted)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to complete)*
- `cargo test --all-features --workspace` *(failed to complete)*
- `cargo test -p icn-ccl` *(failed: could not compile `icn-network`)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ec53b6f88324b2b983193d254f7a