### PR TITLE
Detect duplicate signed messages

### DIFF
--- a/crates/icn-network/Cargo.toml
+++ b/crates/icn-network/Cargo.toml
@@ -25,6 +25,7 @@ bincode = "1.3"
 oneshot = "0.1"
 once_cell = "1.21"
 prometheus-client = "0.22"
+sha2 = "0.10"
 
 # libp2p dependencies with consistent versions
 libp2p = { version = "0.53.2", features = ["tokio", "gossipsub", "mdns", "kad", "macros", "ping", "yamux", "noise", "tcp", "dns", "request-response"], optional = true }

--- a/crates/icn-network/src/error.rs
+++ b/crates/icn-network/src/error.rs
@@ -54,4 +54,8 @@ pub enum MeshNetworkError {
     /// Failure decoding a received network message
     #[error("Message decode failed: {0}")]
     MessageDecodeFailed(String),
+
+    /// Duplicate signed message detected
+    #[error("Duplicate signed message")]
+    DuplicateMessage,
 }

--- a/crates/icn-network/tests/signed_message.rs
+++ b/crates/icn-network/tests/signed_message.rs
@@ -40,3 +40,25 @@ async fn stub_service_invalid_signature() {
         other => panic!("unexpected error: {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn stub_service_duplicate_message() {
+    let service = StubNetworkService::default();
+    let (sk, vk) = generate_ed25519_keypair();
+    let did_str = did_key_from_verifying_key(&vk);
+    let did = Did::from_str(&did_str).unwrap();
+    let msg = NetworkMessage::GossipSub("dup".into(), b"hello".to_vec());
+    let signed = sign_message(&msg, &did, &sk).unwrap();
+    service
+        .send_signed_message(&icn_network::PeerId("peer1".into()), signed.clone())
+        .await
+        .unwrap();
+    let err = service
+        .send_signed_message(&icn_network::PeerId("peer1".into()), signed)
+        .await
+        .expect_err("should fail");
+    match err {
+        icn_network::MeshNetworkError::DuplicateMessage => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- prevent replay of signed messages using a deduplication cache
- hash each `(sender, message)` pair
- reject duplicates with new `DuplicateMessage` error
- test sending the same signed message twice

## Testing
- `cargo test -p icn-network --lib --tests --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6865ec55566c8324a434df1017105e0a