### PR TITLE
[icn-economics] use log instead of println

### DIFF
--- a/crates/icn-economics/Cargo.toml
+++ b/crates/icn-economics/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] } # For Mutex, RwLock if needed async
 thiserror = "1.0" # Added thiserror
 serde_json = "1.0"
+log = "0.4"
 sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
 rusqlite = { version = "0.29", optional = true, features = ["bundled"] }

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -6,6 +6,7 @@
 //! aiming for security, accuracy, and interoperability.
 
 use icn_common::{CommonError, Did, NodeInfo};
+use log::{debug, info};
 pub mod ledger;
 pub use ledger::FileManaLedger;
 #[cfg(feature = "persist-rocksdb")]
@@ -14,7 +15,6 @@ pub use ledger::RocksdbManaLedger;
 pub use ledger::SledManaLedger;
 #[cfg(feature = "persist-sqlite")]
 pub use ledger::SqliteManaLedger;
-
 
 /// Abstraction over the persistence layer storing account balances.
 pub trait ManaLedger: Send + Sync {
@@ -91,7 +91,7 @@ impl<L: ManaLedger> ResourcePolicyEnforcer<L> {
 
     /// Spend mana after applying basic policy checks.
     pub fn spend_mana(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
-        println!("[ResourcePolicyEnforcer] Enforcing spend_mana for DID {did:?}, amount {amount}");
+        debug!("[ResourcePolicyEnforcer] Enforcing spend_mana for DID {did:?}, amount {amount}");
 
         if amount == 0 {
             return Err(CommonError::PolicyDenied(
@@ -122,14 +122,14 @@ pub fn charge_mana<L: ManaLedger>(ledger: L, did: &Did, amount: u64) -> Result<(
     let mana_adapter = ManaRepositoryAdapter::new(ledger);
     let policy_enforcer = ResourcePolicyEnforcer::new(mana_adapter);
 
-    println!("[icn-economics] charge_mana called for DID {did:?}, amount {amount}");
+    info!("[icn-economics] charge_mana called for DID {did:?}, amount {amount}");
     policy_enforcer.spend_mana(did, amount)
 }
 
 /// Credits mana to the given DID using the provided ledger.
 pub fn credit_mana<L: ManaLedger>(ledger: L, did: &Did, amount: u64) -> Result<(), CommonError> {
     let mana_adapter = ManaRepositoryAdapter::new(ledger);
-    println!("[icn-economics] credit_mana called for DID {did:?}, amount {amount}");
+    info!("[icn-economics] credit_mana called for DID {did:?}, amount {amount}");
     mana_adapter.credit_mana(did, amount)
 }
 
@@ -141,12 +141,12 @@ pub fn credit_by_reputation(
     reputation_store: &dyn icn_reputation::ReputationStore,
     base_amount: u64,
 ) -> Result<(), CommonError> {
-        for did in ledger.all_accounts() {
-            let rep = reputation_store.get_reputation(&did);
-            let credit_amount = rep.saturating_mul(base_amount);
+    for did in ledger.all_accounts() {
+        let rep = reputation_store.get_reputation(&did);
+        let credit_amount = rep.saturating_mul(base_amount);
         ledger.credit(&did, credit_amount)?;
-        }
-        Ok(())
+    }
+    Ok(())
 }
 
 /// Placeholder function demonstrating use of common types for economics.


### PR DESCRIPTION
## Summary
- replace `println!` debug output in `icn-economics` with log macros
- add the `log` crate dependency

## Testing
- `cargo fmt --all -- --check` *(fails: shows diff)*
- `cargo clippy -p icn-economics -- -D warnings` *(fails: 5 errors in ledger code)*
- `cargo test -p icn-economics -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6865ec4e18648324b42ca33dae77210a