### PR TITLE
Add replay protection for SignedMessage

### DIFF
--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -158,6 +158,10 @@ pub enum CommonError {
 
     #[error("Not implemented: {0}")]
     NotImplemented(String),
+
+    /// Duplicate or replayed message detected
+    #[error("Duplicate message")]
+    DuplicateMessage,
 }
 
 /// Trait for types that can produce a canonical byte representation for

--- a/crates/icn-network/Cargo.toml
+++ b/crates/icn-network/Cargo.toml
@@ -25,6 +25,8 @@ bincode = "1.3"
 oneshot = "0.1"
 once_cell = "1.21"
 prometheus-client = "0.22"
+lru = "0.16"
+sha2 = "0.10"
 
 # libp2p dependencies with consistent versions
 libp2p = { version = "0.53.2", features = ["tokio", "gossipsub", "mdns", "kad", "macros", "ping", "yamux", "noise", "tcp", "dns", "request-response"], optional = true }

--- a/crates/icn-network/tests/signed_message.rs
+++ b/crates/icn-network/tests/signed_message.rs
@@ -40,3 +40,25 @@ async fn stub_service_invalid_signature() {
         other => panic!("unexpected error: {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn stub_service_rejects_duplicate() {
+    let service = StubNetworkService::default();
+    let (sk, vk) = generate_ed25519_keypair();
+    let did_str = did_key_from_verifying_key(&vk);
+    let did = Did::from_str(&did_str).unwrap();
+    let msg = NetworkMessage::GossipSub("dup".into(), b"hello".to_vec());
+    let signed = sign_message(&msg, &did, &sk).unwrap();
+    service
+        .send_signed_message(&icn_network::PeerId("peer1".into()), signed.clone())
+        .await
+        .unwrap();
+    let err = service
+        .send_signed_message(&icn_network::PeerId("peer1".into()), signed)
+        .await
+        .expect_err("should fail on duplicate");
+    match err {
+        icn_network::MeshNetworkError::Common(icn_common::CommonError::DuplicateMessage) => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- track recent message hashes in icn-network
- reject duplicate signed messages
- test duplicate rejection

## Testing
- `cargo test -p icn-network --all-features`

------
https://chatgpt.com/codex/tasks/task_e_6865f1e2d7b08324ae51b06046dd1431