### PR TITLE
[docs] reference CONTEXT and update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 `icn-core` is the reference implementation of the InterCooperative Network (ICN) protocol, written in Rust.
 It provides the foundational crates for building ICN nodes, CLI tools, and other related infrastructure.
 
+For full architecture and philosophy, see [CONTEXT.md](CONTEXT.md).
+
 ## Overview
 
 The InterCooperative Network is envisioned as a decentralized network fostering collaboration and resource sharing. This repository contains the core building blocks for such a network.
@@ -37,7 +39,7 @@ rustup override set nightly
 
 ## Getting Started
 
-Refer to `docs/ONBOARDING.md` for detailed instructions on prerequisites, setup, building, testing, and running the components. The latest API documentation is available at [https://intercooperative.network/docs/icn-core](https://intercooperative.network/docs/icn-core).
+Refer to `docs/ONBOARDING.md` for detailed instructions on prerequisites, setup, building, testing, and running the components. The latest API documentation is available at [https://intercooperative.network/docs](https://intercooperative.network/docs).
 
 ### Quick CLI Examples:
 


### PR DESCRIPTION
## Summary
- mention CONTEXT.md near the top of README
- fix the external docs link to the site root

## Testing
- `cargo fmt --all -- --check` *(fails: diffs in repository)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to run: command not found or network timeout)*
- `cargo test --all-features --workspace` *(failed to run: interrupted)*
- `cargo test -p icn-ccl` *(failed to run: interrupted)*
- `just test-ccl-contracts` *(failed: just not installed)*
- `just test-covm-execution` *(failed: just not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865ff6275ac832481038bd4adf04a75