### PR TITLE
[economics] add credit_all tests

### DIFF
--- a/crates/icn-economics/tests/rocksdb_ledger.rs
+++ b/crates/icn-economics/tests/rocksdb_ledger.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "persist-rocksdb")]
+mod tests {
+    use icn_common::Did;
+    use icn_economics::ledger::RocksdbManaLedger;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rocksdb_credit_all_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mana.rocks");
+        let ledger = RocksdbManaLedger::new(path.clone()).unwrap();
+        let alice = Did::from_str("did:example:alice").unwrap();
+        let bob = Did::from_str("did:example:bob").unwrap();
+        ledger.set_balance(&alice, 1).unwrap();
+        ledger.set_balance(&bob, 2).unwrap();
+        ledger.credit_all(5).unwrap();
+        drop(ledger);
+        let ledger2 = RocksdbManaLedger::new(path).unwrap();
+        assert_eq!(ledger2.get_balance(&alice), 6);
+        assert_eq!(ledger2.get_balance(&bob), 7);
+    }
+}

--- a/crates/icn-economics/tests/sled_ledger.rs
+++ b/crates/icn-economics/tests/sled_ledger.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "persist-sled")]
+mod tests {
+    use icn_common::Did;
+    use icn_economics::ledger::SledManaLedger;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sled_ledger_credit_all_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mana.sled");
+        let ledger = SledManaLedger::new(path.clone()).unwrap();
+        let alice = Did::from_str("did:example:alice").unwrap();
+        let bob = Did::from_str("did:example:bob").unwrap();
+        ledger.set_balance(&alice, 5).unwrap();
+        ledger.set_balance(&bob, 7).unwrap();
+        ledger.credit_all(3).unwrap();
+        drop(ledger);
+        let ledger2 = SledManaLedger::new(path).unwrap();
+        assert_eq!(ledger2.get_balance(&alice), 8);
+        assert_eq!(ledger2.get_balance(&bob), 10);
+    }
+}

--- a/crates/icn-economics/tests/sqlite_ledger.rs
+++ b/crates/icn-economics/tests/sqlite_ledger.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "persist-sqlite")]
+mod tests {
+    use icn_common::Did;
+    use icn_economics::ledger::SqliteManaLedger;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sqlite_ledger_credit_all_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mana.sqlite");
+        let ledger = SqliteManaLedger::new(path.clone()).unwrap();
+        let alice = Did::from_str("did:example:alice").unwrap();
+        let bob = Did::from_str("did:example:bob").unwrap();
+        ledger.set_balance(&alice, 10).unwrap();
+        ledger.set_balance(&bob, 20).unwrap();
+        ledger.credit_all(2).unwrap();
+        drop(ledger);
+        let ledger2 = SqliteManaLedger::new(path).unwrap();
+        assert_eq!(ledger2.get_balance(&alice), 12);
+        assert_eq!(ledger2.get_balance(&bob), 22);
+    }
+}


### PR DESCRIPTION
## Summary
- add `credit_all` persistence tests for Sled, RocksDB, and SQLite ledgers

## Testing
- `cargo fmt --all -- --check` *(passes)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused import, dead code, etc.)*
- `cargo test --all-features --workspace` *(interrupted due to long build)*
- `cargo test -p icn-ccl` *(interrupted due to long build)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866aa7b50b083249a493d0cb6d8dee4