### PR TITLE
Add Block AST support

### DIFF
--- a/icn-ccl/src/cli.rs
+++ b/icn-ccl/src/cli.rs
@@ -169,6 +169,7 @@ fn ast_to_string(ast: &AstNode, indent: usize) -> String {
                 action_to_string(action)
             )
         }
+        AstNode::Block(b) => block_to_string(b, indent),
     }
 }
 

--- a/icn-ccl/src/optimizer.rs
+++ b/icn-ccl/src/optimizer.rs
@@ -44,6 +44,7 @@ impl Optimizer {
                 condition: self.fold_expr(condition),
                 action: self.fold_action(action),
             },
+            AstNode::Block(b) => AstNode::Block(self.fold_block(b)),
         }
     }
 

--- a/icn-ccl/src/semantic_analyzer.rs
+++ b/icn-ccl/src/semantic_analyzer.rs
@@ -136,6 +136,10 @@ impl SemanticAnalyzer {
                 }
                 self.visit_action(action)?;
             }
+            AstNode::Block(block) => {
+                let mut _has_ret = false;
+                self.visit_block(block, &mut _has_ret)?;
+            }
         }
         Ok(())
     }

--- a/icn-ccl/tests/ast_pair.rs
+++ b/icn-ccl/tests/ast_pair.rs
@@ -102,3 +102,15 @@ fn test_pair_to_ast_import_statement() {
     }]);
     assert_eq!(ast, expected);
 }
+
+#[test]
+fn test_pair_to_ast_block() {
+    let src = "{ return 1; }";
+    let mut pairs = CclParser::parse(Rule::block, src).unwrap();
+    let pair = pairs.next().unwrap();
+    let ast = ast::pair_to_ast(pair).unwrap();
+    let expected = AstNode::Block(BlockNode {
+        statements: vec![StatementNode::Return(ExpressionNode::IntegerLiteral(1))],
+    });
+    assert_eq!(ast, expected);
+}


### PR DESCRIPTION
## Summary
- support parsing `block` rules by adding `AstNode::Block`
- update CLI, optimizer, and semantic analyzer to handle the new variant
- extend `pair_to_ast` and tests for block conversion

## Testing
- `cargo clippy -p icn-ccl --all-targets --all-features --no-deps -- -D warnings` *(fails: could not compile `icn-ccl` due to dependencies)*
- `cargo test -p icn-ccl --test ast_pair -- --nocapture` *(fails to build due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68671ab134388324a245003e84fb524a