### PR TITLE
[runtime] clarify governance host docs

### DIFF
--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -73,11 +73,11 @@ The API style emphasizes:
 
 ### Governance
 
-The runtime exposes host calls for managing on-chain proposals. Voting can be
+The runtime exposes host calls for managing governance proposals. Voting can be
 closed via `host_close_governance_proposal_voting`, returning the final
 `ProposalStatus` as a string. Accepted proposals may then be executed with
-`host_execute_governance_proposal`, which updates the stored proposal and member
-set.
+`host_execute_governance_proposal`, which broadcasts the updated proposal and
+rewards the proposer.
 
 ```rust,no_run
 use icn_runtime::{

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -533,13 +533,15 @@ pub async fn host_cast_governance_vote(
 /// Closes voting on a governance proposal and broadcasts the final
 /// [`icn_governance::ProposalStatus`] across the mesh network.
 ///
-/// Returns the status as a `String`.
+/// Returns the status string (e.g. `"Accepted"`).
 ///
 /// # Example
 /// ```no_run
 /// # async fn demo(ctx: &icn_runtime::context::RuntimeContext) -> Result<(), icn_runtime::HostAbiError> {
 /// let status = icn_runtime::host_close_governance_proposal_voting(ctx, "pid").await?;
-/// println!("Proposal status: {status}");
+/// if status == "Accepted" {
+///     icn_runtime::host_execute_governance_proposal(ctx, "pid").await?;
+/// }
 /// # Ok(())
 /// # }
 /// ```
@@ -550,8 +552,8 @@ pub async fn host_close_governance_proposal_voting(
     ctx.close_governance_proposal_voting(proposal_id).await
 }
 
-/// Executes an accepted governance proposal and rewards the proposer on
-/// success.
+/// Executes an accepted governance proposal, rewarding the proposer and
+/// broadcasting the updated proposal to the mesh network on success.
 ///
 /// # Example
 /// ```no_run


### PR DESCRIPTION
## Summary
- update `host_close_governance_proposal_voting` rustdoc example
- note proposal broadcast in `host_execute_governance_proposal`
- mention broadcasting and rewards in runtime README

## Testing
- `cargo fmt --all`
- `cargo clippy -p icn-runtime --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: could not finish compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68671ab212e08324aa0465b73e5eef46