### PR TITLE
Implement credit_all across ledgers

### DIFF
--- a/crates/icn-economics/README.md
+++ b/crates/icn-economics/README.md
@@ -25,9 +25,10 @@ The API style emphasizes:
 
 ### Mana Regeneration
 
-Ledger implementations may support bulk credit operations.
-`ManaLedger::credit_all` adds a specified amount to every account and is used by
-the runtime to periodically regenerate balances.
+All persistent ledger backends expose a bulk credit operation via
+`ManaLedger::credit_all`. This method adds a specified amount to every stored
+account and is used by the runtime to periodically regenerate balances. In-memory
+test ledgers implement the same interface for parity with the on-disk backends.
 
 ## Feature Flags
 

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -208,6 +208,14 @@ mod tests {
             Ok(())
         }
 
+        fn credit_all(&self, amount: u64) -> Result<(), CommonError> {
+            let mut map = self.balances.lock().unwrap();
+            for bal in map.values_mut() {
+                *bal = bal.saturating_add(amount);
+            }
+            Ok(())
+        }
+
         fn all_accounts(&self) -> Vec<Did> {
             self.balances.lock().unwrap().keys().cloned().collect()
         }
@@ -346,5 +354,17 @@ mod tests {
         credit_by_reputation(&ledger, &rep_store, u64::MAX).unwrap();
 
         assert_eq!(ledger.get_balance(&over), u64::MAX);
+    }
+
+    #[test]
+    fn test_inmemory_ledger_credit_all() {
+        let ledger = InMemoryLedger::new();
+        let alice = Did::from_str("did:example:alice").unwrap();
+        let bob = Did::from_str("did:example:bob").unwrap();
+        ledger.set_balance(&alice, 1).unwrap();
+        ledger.set_balance(&bob, 2).unwrap();
+        ledger.credit_all(5).unwrap();
+        assert_eq!(ledger.get_balance(&alice), 6);
+        assert_eq!(ledger.get_balance(&bob), 7);
     }
 }

--- a/crates/icn-economics/tests/rocksdb_ledger.rs
+++ b/crates/icn-economics/tests/rocksdb_ledger.rs
@@ -2,6 +2,7 @@
 mod tests {
     use icn_common::Did;
     use icn_economics::ledger::RocksdbManaLedger;
+    use icn_economics::ManaLedger;
     use std::str::FromStr;
     use tempfile::tempdir;
 

--- a/crates/icn-economics/tests/sled_ledger.rs
+++ b/crates/icn-economics/tests/sled_ledger.rs
@@ -2,6 +2,7 @@
 mod tests {
     use icn_common::Did;
     use icn_economics::ledger::SledManaLedger;
+    use icn_economics::ManaLedger;
     use std::str::FromStr;
     use tempfile::tempdir;
 

--- a/crates/icn-economics/tests/sqlite_ledger.rs
+++ b/crates/icn-economics/tests/sqlite_ledger.rs
@@ -2,6 +2,7 @@
 mod tests {
     use icn_common::Did;
     use icn_economics::ledger::SqliteManaLedger;
+    use icn_economics::ManaLedger;
     use std::str::FromStr;
     use tempfile::tempdir;
 


### PR DESCRIPTION
## Summary
- implement `credit_all` for the in-memory ledger
- add unit test for in-memory implementation
- ensure integration tests import the `ManaLedger` trait
- document `credit_all` in economics README

## Testing
- `cargo test -p icn-economics --no-default-features --features persist-sled`

------
https://chatgpt.com/codex/tasks/task_e_686a001b56a8832480cb9a1caa17beef