### PR TITLE
[devnet] include CCL code in Docker build

### DIFF
--- a/icn-devnet/Dockerfile
+++ b/icn-devnet/Dockerfile
@@ -22,6 +22,7 @@ COPY rust-toolchain.toml ./
 
 # Copy source code
 COPY crates/ ./crates/
+COPY icn-ccl/ ./icn-ccl/
 COPY tests/ ./tests/
 
 # Build the ICN node binary


### PR DESCRIPTION
## Summary
- copy icn-ccl sources in devnet Dockerfile so the builder can compile the workspace

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused imports in icn-network)*
- `cargo test --all-features --workspace` *(fails: unresolved import `icn_network::NetworkMessage`)*
- `docker compose build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3d88bc008324828d71d9c039d5bf