### PR TITLE
[devnet] add clang packages for zstd-sys

### DIFF
--- a/icn-devnet/Dockerfile
+++ b/icn-devnet/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     curl \
     build-essential \
+    clang \
+    libclang-dev \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- install clang and libclang-dev in devnet Dockerfile for zstd-sys build

## Testing
- `cargo fmt --all -- --check` *(fails: diffs found)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused imports in icn-network)*
- `cargo test --all-features --workspace` *(fails: build in progress when interrupted)*
- `docker build -f icn-devnet/Dockerfile -t icn-devnet-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686a41a4c69483249c2c25cec059f3d9