### PR TITLE
Switch send_network_message_api to ProtocolMessage JSON

### DIFF
--- a/crates/icn-api/Cargo.toml
+++ b/crates/icn-api/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-dag = { path = "../icn-dag" }
 icn-network = { path = "../icn-network" }
+icn-protocol = { path = "../icn-protocol" }
 icn-governance = { path = "../icn-governance", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -18,7 +18,8 @@ use icn_common::{
 use icn_dag::StorageService; // Import the trait
 use std::sync::{Arc, Mutex}; // To accept the storage service
                              // Added imports for network functionality
-use icn_network::{NetworkMessage, NetworkService, PeerId, StubNetworkService};
+use icn_network::{NetworkService, PeerId, StubNetworkService};
+use icn_protocol::ProtocolMessage;
 // Added imports for governance functionality
 use icn_governance::{
     scoped_policy::{DagPayloadOp, PolicyCheckResult, ScopedPolicyEnforcer},
@@ -402,7 +403,7 @@ pub async fn discover_peers_api(
 
 /// API endpoint to send a message to a specific peer (currently uses StubNetworkService).
 /// `peer_id_str` is the string representation of the target PeerId.
-/// `message_json` is a JSON string representation of the NetworkMessage.
+/// `message_json` is a JSON string representation of the [`ProtocolMessage`].
 pub async fn send_network_message_api(
     peer_id_str: String,
     message_json: String,
@@ -410,11 +411,11 @@ pub async fn send_network_message_api(
     let network_service = StubNetworkService::default();
     let peer_id = PeerId(peer_id_str); // Assuming PeerId is a simple wrapper around String for now.
 
-    // Deserialize the NetworkMessage from JSON.
-    // This requires NetworkMessage to implement Deserialize.
-    let message: NetworkMessage = serde_json::from_str(&message_json).map_err(|e| {
+    // Deserialize the ProtocolMessage from JSON.
+    // This requires [`ProtocolMessage`] to implement `Deserialize`.
+    let message: ProtocolMessage = serde_json::from_str(&message_json).map_err(|e| {
         CommonError::DeserializationError(format!(
-            "Failed to parse NetworkMessage JSON: {}. Input: {}",
+            "Failed to parse ProtocolMessage JSON: {}. Input: {}",
             e, message_json
         ))
     })?;
@@ -484,6 +485,7 @@ mod tests {
     use icn_common::DagLink; // For test setup
     use icn_dag::InMemoryDagStore; // For creating test stores, removed FileDagStore
     use icn_governance::GovernanceModule; // For governance tests
+    use icn_protocol::{DagBlockRequestMessage, GossipMessage, MessagePayload, ProtocolMessage};
 
     // Helper to create a default in-memory store for tests
     fn new_test_storage() -> Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>> {
@@ -773,8 +775,15 @@ mod tests {
         // Made async
         let peer_id_str = "test_peer_123".to_string();
         // Using GossipSub as a generic message type for the test, as Ping variant doesn't exist.
-        let message_to_send =
-            NetworkMessage::GossipSub("test_topic".to_string(), b"hello world".to_vec());
+        let message_to_send = ProtocolMessage::new(
+            MessagePayload::GossipMessage(GossipMessage {
+                topic: "test_topic".to_string(),
+                payload: b"hello world".to_vec(),
+                ttl: 1,
+            }),
+            Did::new("key", "tester"),
+            None,
+        );
         let message_json = serde_json::to_string(&message_to_send).unwrap();
 
         let result = send_network_message_api(peer_id_str, message_json).await;
@@ -790,7 +799,14 @@ mod tests {
         // Made async
         let peer_id_str = "unknown_peer_id".to_string(); // StubNetworkService simulates error for this peer
         let dummy_cid = Cid::new_v1_sha256(0x55, b"test_cid_for_req_block");
-        let message_to_send = NetworkMessage::RequestBlock(dummy_cid); // Corrected to tuple variant
+        let message_to_send = ProtocolMessage::new(
+            MessagePayload::DagBlockRequest(DagBlockRequestMessage {
+                block_cid: dummy_cid,
+                priority: 0,
+            }),
+            Did::new("key", "tester"),
+            None,
+        );
         let message_json = serde_json::to_string(&message_to_send).unwrap();
 
         let result = send_network_message_api(peer_id_str, message_json).await;
@@ -812,7 +828,7 @@ mod tests {
 
         match send_network_message_api(peer_id_str, invalid_message_json.to_string()).await {
             Err(CommonError::DeserializationError(msg)) => {
-                assert!(msg.contains("Failed to parse NetworkMessage JSON"));
+                assert!(msg.contains("Failed to parse ProtocolMessage JSON"));
             }
             Ok(_) => panic!("send_network_message_api should have failed for invalid JSON input"),
             Err(e) => panic!(


### PR DESCRIPTION
## Summary
- parse `ProtocolMessage` JSON in `send_network_message_api`
- add `icn-protocol` dependency for API crate
- update tests to use `ProtocolMessage`

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all-features --workspace` *(failed: compilation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686af41c4630832490f63082940d4dce