### PR TITLE
Remove NetworkMessage uses

### DIFF
--- a/crates/icn-api/Cargo.toml
+++ b/crates/icn-api/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-dag = { path = "../icn-dag" }
 icn-network = { path = "../icn-network" }
+icn-protocol = { path = "../icn-protocol" }
 icn-governance = { path = "../icn-governance", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/icn-governance/Cargo.toml
+++ b/crates/icn-governance/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 [dependencies]
 icn-common = { path = "../icn-common" }
 icn-network = { path = "../icn-network", optional = true } # For federation sync
+icn-protocol = { path = "../icn-protocol" }
 sled = { version = "0.34", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 bincode = { version = "1.3", optional = true}


### PR DESCRIPTION
## Summary
- import ProtocolMessage and MessagePayload
- convert API, runtime, node, governance code to use ProtocolMessage

## Testing
- `cargo test -p icn-api`
- `cargo test -p icn-governance --no-run` *(fails: trait bounds not satisfied)*

------
https://chatgpt.com/codex/tasks/task_e_686af4193ed48324b4d8b5f44301e006