### PR TITLE
[runtime] adjust message payload matches

### DIFF
--- a/crates/icn-governance/Cargo.toml
+++ b/crates/icn-governance/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 [dependencies]
 icn-common = { path = "../icn-common" }
 icn-network = { path = "../icn-network", optional = true } # For federation sync
+icn-protocol = { path = "../icn-protocol", optional = true }
 sled = { version = "0.34", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 bincode = { version = "1.3", optional = true}

--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -10,7 +10,9 @@
 
 use icn_common::{CommonError, Did, NodeInfo};
 #[cfg(feature = "federation")]
-use icn_network::{MeshNetworkError, NetworkMessage, NetworkService, PeerId};
+use icn_network::{MeshNetworkError, NetworkService, PeerId};
+#[cfg(feature = "federation")]
+use icn_protocol::{MessagePayload, ProtocolMessage};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 #[cfg(feature = "persist-sled")]
@@ -1128,7 +1130,11 @@ pub async fn request_federation_sync(
         .map(|ts| Did::new("sync", &ts.to_string()))
         .unwrap_or_default();
 
-    let msg = NetworkMessage::FederationSyncRequest(payload);
+    let msg = ProtocolMessage::new(
+        MessagePayload::FederationSyncRequest(payload),
+        Did::default(),
+        None,
+    );
     service
         .send_message(target_peer, msg)
         .await

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -18,8 +18,8 @@ pub mod metrics;
 use async_trait::async_trait;
 use downcast_rs::{impl_downcast, DowncastSync};
 use icn_common::{Cid, DagBlock, Did, NodeInfo};
-use icn_protocol::{ProtocolMessage, MessagePayload};
 use icn_identity::{ExecutionReceipt, SignatureBytes};
+use icn_protocol::{MessagePayload, ProtocolMessage};
 #[cfg(feature = "libp2p")]
 use libp2p::PeerId as Libp2pPeerId;
 #[cfg(feature = "libp2p")]
@@ -56,7 +56,7 @@ pub const DID_DOC_PREFIX: &str = "/icn/did/";
 
 /// Legacy type aliases for compatibility
 pub type Job = icn_protocol::MeshJobAnnouncementMessage;
-pub type Bid = icn_protocol::MeshBidSubmissionMessage; 
+pub type Bid = icn_protocol::MeshBidSubmissionMessage;
 pub type JobId = Cid;
 
 /// Cache of recently verified message hashes to prevent replay.
@@ -385,19 +385,19 @@ pub async fn send_network_ping(
     target_peer: &str,
 ) -> Result<String, MeshNetworkError> {
     let service = StubNetworkService::default();
-    use icn_protocol::{ProtocolMessage, MessagePayload, GossipMessage};
+    use icn_protocol::{GossipMessage, MessagePayload, ProtocolMessage};
     use std::str::FromStr;
-    
+
     let ping_message = ProtocolMessage::new(
         MessagePayload::GossipMessage(GossipMessage {
             topic: "ping_topic".to_string(),
             payload: vec![1, 2, 3],
             ttl: 5,
         }),
-        Did::from_str("did:key:stub").unwrap(), 
-        None
+        Did::from_str("did:key:stub").unwrap(),
+        None,
     );
-    
+
     let _ = service
         .send_message(&PeerId(target_peer.to_string()), ping_message)
         .await?;
@@ -1162,7 +1162,11 @@ pub mod libp2p_service {
                 SwarmEvent::Behaviour(CombinedBehaviourEvent::RequestResponse(ev)) => {
                     use libp2p::request_response::{Event as ReqEvent, Message};
                     match ev {
-                        ReqEvent::Message { peer: _, message, connection_id: _ } => match message {
+                        ReqEvent::Message {
+                            peer: _,
+                            message,
+                            connection_id: _,
+                        } => match message {
                             Message::Request {
                                 request, channel, ..
                             } => {

--- a/crates/icn-network/tests/libp2p.rs
+++ b/crates/icn-network/tests/libp2p.rs
@@ -50,8 +50,8 @@ mod libp2p_tests {
             .await
             .expect("recv timeout")
             .expect("recv");
-        match msg {
-            NetworkMessage::GossipSub(_, _) => {}
+        match msg.payload {
+            MessagePayload::GossipMessage(_) => {}
             _ => panic!("unexpected message"),
         }
 
@@ -67,8 +67,8 @@ mod libp2p_tests {
             .await
             .expect("req timeout")
             .expect("recv");
-        match req {
-            NetworkMessage::FederationSyncRequest(_) => {}
+        match req.payload {
+            MessagePayload::FederationSyncRequest(_) => {}
             _ => panic!("unexpected request"),
         }
 

--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -182,7 +182,10 @@ mod libp2p_mesh_integration {
                                             received_msg
                                         );
                                         assert!(
-                                            matches!(received_msg, NetworkMessage::GossipSub(_, _)),
+                                            matches!(
+                                                received_msg.payload,
+                                                MessagePayload::GossipMessage(_)
+                                            ),
                                             "Expected GossipSub message"
                                         );
                                     }
@@ -399,7 +402,9 @@ mod libp2p_mesh_integration {
         let received_on_b_res = timeout(Duration::from_secs(15), node_b_receiver.recv()).await;
         match received_on_b_res {
             Ok(Some(network_message_b)) => {
-                if let NetworkMessage::MeshJobAnnouncement(received_job) = network_message_b {
+                if let MessagePayload::MeshJobAnnouncement(received_job) =
+                    &network_message_b.payload
+                {
                     assert_eq!(
                         received_job.id, job_to_announce.id,
                         "Node B received incorrect job ID"
@@ -671,7 +676,9 @@ mod libp2p_mesh_integration {
         // Node A receives and verifies receipt
         let verified_receipt = wait_for_message(&mut node_a.receiver, 10, |msg| match msg {
             NetworkMessage::SubmitReceipt(receipt) => {
-                if receipt.job_id == job_id.clone().into() && receipt.executor_did == assigned_executor {
+                if receipt.job_id == job_id.clone().into()
+                    && receipt.executor_did == assigned_executor
+                {
                     Some(receipt.clone())
                 } else {
                     None

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -222,7 +222,8 @@ mod runtime_host_abi_tests {
 
         // The receipt should already be anchored by the runtime, but let's verify it
         assert_eq!(
-            receipt.job_id, submitted_job_id.into(),
+            receipt.job_id,
+            submitted_job_id.into(),
             "Receipt job ID matches submitted job"
         );
         assert_eq!(

--- a/crates/icn-runtime/tests/integration/cross_node_governance.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_governance.rs
@@ -57,8 +57,11 @@ mod cross_node_governance {
 
         let proposal_bytes = timeout(Duration::from_secs(10), async {
             loop {
-                if let Some(NetworkMessage::ProposalAnnouncement(bytes)) = b_rx.recv().await {
-                    break bytes;
+                if let Some(message) = b_rx.recv().await {
+                    if let MessagePayload::GovernanceProposalAnnouncement(bytes) = &message.payload
+                    {
+                        break bytes.clone();
+                    }
                 }
             }
         })
@@ -79,8 +82,10 @@ mod cross_node_governance {
 
         let vote_bytes = timeout(Duration::from_secs(10), async {
             loop {
-                if let Some(NetworkMessage::VoteAnnouncement(bytes)) = a_rx.recv().await {
-                    break bytes;
+                if let Some(message) = a_rx.recv().await {
+                    if let MessagePayload::GovernanceVoteAnnouncement(bytes) = &message.payload {
+                        break bytes.clone();
+                    }
                 }
             }
         })

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -168,10 +168,10 @@ mod cross_node_tests {
             loop {
                 if let Some(message) = node_b_receiver.recv().await {
                     debug!("Node B received message: {:?}", message);
-                    if let NetworkMessage::MeshJobAnnouncement(announced_job) = message {
+                    if let MessagePayload::MeshJobAnnouncement(announced_job) = &message.payload {
                         if announced_job.id == test_job.id {
                             info!("✓ Node B received job announcement for {:?}", announced_job.id);
-                            return Some(announced_job);
+                            return Some(announced_job.clone());
                         }
                     }
                 }
@@ -249,10 +249,10 @@ mod cross_node_tests {
             loop {
                 if let Some(message) = node_a_receiver.recv().await {
                     debug!("Node A received message: {:?}", message);
-                    if let NetworkMessage::BidSubmission(received_bid) = message {
+                    if let MessagePayload::MeshBidSubmission(received_bid) = &message.payload {
                         if received_bid.job_id == test_job.id {
                             info!("✓ Node A received bid for job {:?} from {:?}", received_bid.job_id, received_bid.executor_did);
-                            return Some(received_bid);
+                            return Some(received_bid.clone());
                         }
                     }
                 }
@@ -317,10 +317,10 @@ mod cross_node_tests {
             loop {
                 if let Some(message) = node_b_receiver.recv().await {
                     debug!("Node B received message: {:?}", message);
-                    if let NetworkMessage::JobAssignmentNotification(job_id, assigned_executor) = message {
-                        if job_id == test_job.id && assigned_executor == executor_did {
-                            info!("✓ Node B received assignment for job {:?}", job_id);
-                            return Some((job_id, assigned_executor));
+                    if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
+                        if assign.job_id == test_job.id && assign.executor_did == executor_did {
+                            info!("✓ Node B received assignment for job {:?}", assign.job_id);
+                            return Some((assign.job_id.clone(), assign.executor_did.clone()));
                         }
                     }
                 }
@@ -403,10 +403,10 @@ mod cross_node_tests {
             loop {
                 if let Some(message) = node_a_receiver.recv().await {
                     debug!("Node A received message: {:?}", message);
-                    if let NetworkMessage::SubmitReceipt(received_receipt) = message {
+                    if let MessagePayload::MeshReceiptSubmission(received_receipt) = &message.payload {
                         if received_receipt.job_id == test_job.id {
                             info!("✓ Node A received receipt for job {:?}", received_receipt.job_id);
-                            return Some(received_receipt);
+                            return Some(received_receipt.clone());
                         }
                     }
                 }
@@ -490,9 +490,11 @@ mod cross_node_tests {
         // Node B: Wait for job announcement
         let job_announcement = timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::MeshJobAnnouncement(job)) = node_b_receiver.recv().await {
-                    if job.id == test_job.id {
-                        return Some(job);
+                if let Some(message) = node_b_receiver.recv().await {
+                    if let MessagePayload::MeshJobAnnouncement(job) = &message.payload {
+                        if job.id == test_job.id {
+                            return Some(job.clone());
+                        }
                     }
                 }
             }
@@ -528,9 +530,11 @@ mod cross_node_tests {
         // Node A: Wait for bid
         let received_bid = timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::BidSubmission(bid)) = node_a_receiver.recv().await {
-                    if bid.job_id == test_job.id {
-                        return Some(bid);
+                if let Some(message) = node_a_receiver.recv().await {
+                    if let MessagePayload::MeshBidSubmission(bid) = &message.payload {
+                        if bid.job_id == test_job.id {
+                            return Some(bid.clone());
+                        }
                     }
                 }
             }
@@ -553,9 +557,11 @@ mod cross_node_tests {
         // Node B: Wait for assignment and execute
         let assignment_received = timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::JobAssignmentNotification(job_id, assigned_executor)) = node_b_receiver.recv().await {
-                    if job_id == test_job.id && assigned_executor == executor_did {
-                        return Some((job_id, assigned_executor));
+                if let Some(message) = node_b_receiver.recv().await {
+                    if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
+                        if assign.job_id == test_job.id && assign.executor_did == executor_did {
+                            return Some((assign.job_id.clone(), assign.executor_did.clone()));
+                        }
                     }
                 }
             }
@@ -582,9 +588,11 @@ mod cross_node_tests {
         // Node A: Wait for receipt
         let received_receipt = timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::SubmitReceipt(receipt)) = node_a_receiver.recv().await {
-                    if receipt.job_id == test_job.id {
-                        return Some(receipt);
+                if let Some(message) = node_a_receiver.recv().await {
+                    if let MessagePayload::MeshReceiptSubmission(receipt) = &message.payload {
+                        if receipt.job_id == test_job.id {
+                            return Some(receipt.clone());
+                        }
                     }
                 }
             }

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -843,9 +843,11 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
 
     timeout(Duration::from_secs(5), async {
         loop {
-            if let Some(NetworkMessage::MeshJobAnnouncement(job)) = recv_b.recv().await {
-                if job.id == job_id.clone().into() {
-                    break;
+            if let Some(message) = recv_b.recv().await {
+                if let MessagePayload::MeshJobAnnouncement(job) = &message.payload {
+                    if job.id == job_id.clone().into() {
+                        break;
+                    }
                 }
             }
         }
@@ -873,9 +875,11 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
 
     timeout(Duration::from_secs(5), async {
         loop {
-            if let Some(NetworkMessage::BidSubmission(b)) = recv_a.recv().await {
-                if b.job_id == job_id.clone().into() {
-                    break;
+            if let Some(message) = recv_a.recv().await {
+                if let MessagePayload::MeshBidSubmission(b) = &message.payload {
+                    if b.job_id == job_id.clone().into() {
+                        break;
+                    }
                 }
             }
         }
@@ -891,9 +895,11 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
 
     timeout(Duration::from_secs(5), async {
         loop {
-            if let Some(NetworkMessage::JobAssignmentNotification(id, ex)) = recv_b.recv().await {
-                if id == job_id && ex == executor_did {
-                    break;
+            if let Some(message) = recv_b.recv().await {
+                if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
+                    if assign.job_id == job_id && assign.executor_did == executor_did {
+                        break;
+                    }
                 }
             }
         }
@@ -911,9 +917,11 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
 
     let final_receipt = timeout(Duration::from_secs(5), async {
         loop {
-            if let Some(NetworkMessage::SubmitReceipt(r)) = recv_a.recv().await {
-                if r.job_id == job_id.clone().into() {
-                    break r;
+            if let Some(message) = recv_a.recv().await {
+                if let MessagePayload::MeshReceiptSubmission(r) = &message.payload {
+                    if r.job_id == job_id.clone().into() {
+                        break r.clone();
+                    }
                 }
             }
         }

--- a/tests/integration/icn_node_end_to_end.rs
+++ b/tests/integration/icn_node_end_to_end.rs
@@ -114,8 +114,10 @@ mod icn_node_end_to_end {
         // Wait for announcement on B
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::MeshJobAnnouncement(j)) = recv_b.recv().await {
-                    if j.id.to_string() == job_id { break; }
+                if let Some(message) = recv_b.recv().await {
+                    if let MessagePayload::MeshJobAnnouncement(j) = &message.payload {
+                        if j.id.to_string() == job_id { break; }
+                    }
                 }
             }
         })
@@ -139,8 +141,10 @@ mod icn_node_end_to_end {
         // Wait for bid on A
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::BidSubmission(_)) = recv_a.recv().await {
-                    break;
+                if let Some(message) = recv_a.recv().await {
+                    if let MessagePayload::MeshBidSubmission(_) = &message.payload {
+                        break;
+                    }
                 }
             }
         })
@@ -157,8 +161,10 @@ mod icn_node_end_to_end {
         // Wait for assignment on B
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::JobAssignmentNotification(id, ex)) = recv_b.recv().await {
-                    if id == job.id && ex == ctx_b.current_identity { break; }
+                if let Some(message) = recv_b.recv().await {
+                    if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
+                        if assign.job_id == job.id && assign.executor_did == ctx_b.current_identity { break; }
+                    }
                 }
             }
         })

--- a/tests/integration/libp2p_job_pipeline.rs
+++ b/tests/integration/libp2p_job_pipeline.rs
@@ -263,9 +263,11 @@ mod libp2p_job_pipeline {
         // Wait for announcement
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::MeshJobAnnouncement(j)) = recv_b.recv().await {
-                    if j.id == job_id {
-                        break;
+                if let Some(message) = recv_b.recv().await {
+                    if let MessagePayload::MeshJobAnnouncement(j) = &message.payload {
+                        if j.id == job_id {
+                            break;
+                        }
                     }
                 }
             }
@@ -289,9 +291,11 @@ mod libp2p_job_pipeline {
         // Wait for bid on A
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::BidSubmission(b)) = recv_a.recv().await {
-                    if b.job_id == job_id {
-                        break;
+                if let Some(message) = recv_a.recv().await {
+                    if let MessagePayload::MeshBidSubmission(b) = &message.payload {
+                        if b.job_id == job_id {
+                            break;
+                        }
                     }
                 }
             }
@@ -319,9 +323,11 @@ mod libp2p_job_pipeline {
         // Wait for assignment on B
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::JobAssignmentNotification(id, ex)) = recv_b.recv().await {
-                    if id == job_id && ex == node_b.current_identity {
-                        break;
+                if let Some(message) = recv_b.recv().await {
+                    if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
+                        if assign.job_id == job_id && assign.executor_did == node_b.current_identity {
+                            break;
+                        }
                     }
                 }
             }
@@ -341,9 +347,11 @@ mod libp2p_job_pipeline {
         // Node A waits for receipt
         let final_receipt = timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::SubmitReceipt(r)) = recv_a.recv().await {
-                    if r.job_id == job_id {
-                        break r;
+                if let Some(message) = recv_a.recv().await {
+                    if let MessagePayload::MeshReceiptSubmission(r) = &message.payload {
+                        if r.job_id == job_id {
+                            break r.clone();
+                        }
                     }
                 }
             }

--- a/tests/integration/multi_node_libp2p.rs
+++ b/tests/integration/multi_node_libp2p.rs
@@ -84,8 +84,10 @@ mod multi_node_libp2p {
         // Wait for announcement
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::MeshJobAnnouncement(job)) = recv_b.recv().await {
-                    if job.id == job_id { break; }
+                if let Some(message) = recv_b.recv().await {
+                    if let MessagePayload::MeshJobAnnouncement(job) = &message.payload {
+                        if job.id == job_id { break; }
+                    }
                 }
             }
         }).await?;
@@ -111,8 +113,10 @@ mod multi_node_libp2p {
         // Wait for bid on Node A
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::BidSubmission(b)) = recv_a.recv().await {
-                    if b.job_id == job_id { break; }
+                if let Some(message) = recv_a.recv().await {
+                    if let MessagePayload::MeshBidSubmission(b) = &message.payload {
+                        if b.job_id == job_id { break; }
+                    }
                 }
             }
         }).await?;
@@ -128,8 +132,10 @@ mod multi_node_libp2p {
         // Wait for assignment on Node B
         timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::JobAssignmentNotification(id, ex)) = recv_b.recv().await {
-                    if id == job_id && ex == executor_did { break; }
+                if let Some(message) = recv_b.recv().await {
+                    if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
+                        if assign.job_id == job_id && assign.executor_did == executor_did { break; }
+                    }
                 }
             }
         }).await?;
@@ -148,8 +154,10 @@ mod multi_node_libp2p {
         // Node A waits for receipt
         let final_receipt = timeout(Duration::from_secs(5), async {
             loop {
-                if let Some(NetworkMessage::SubmitReceipt(r)) = recv_a.recv().await {
-                    if r.job_id == job_id { break r; }
+                if let Some(message) = recv_a.recv().await {
+                    if let MessagePayload::MeshReceiptSubmission(r) = &message.payload {
+                        if r.job_id == job_id { break r.clone(); }
+                    }
                 }
             }
         })


### PR DESCRIPTION
## Summary
- switch to inspecting `message.payload` for runtime job logic
- update message match logic in runtime integration tests
- tweak network tests for new payload API
- adjust governance sync request helper

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: couldn't finish due to network restrictions)*
- `cargo test --all-features --workspace` *(failed: unresolved import `icn_protocol`)*

------
https://chatgpt.com/codex/tasks/task_e_686af41ab5148324b20eeb179d8830b9