### PR TITLE
Replace NetworkMessage docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Below are actionable, bite-sized issues to drive forward the next major features
     Implement signal-based or programmatic shutdown for network tasks.
     *Difficulty: Medium*
 *   **\[Network] JSON Gossipsub Serialization**
-    Encode/decode `NetworkMessage` via JSON for pub/sub.
+    Encode/decode `ProtocolMessage` via JSON for pub/sub.
     *Difficulty: Easy-Medium*
 *   **\[API] List Connected/Known Peers**
     CLI/API to query/display current peers.

--- a/MULTI_NODE_GUIDE.md
+++ b/MULTI_NODE_GUIDE.md
@@ -164,7 +164,7 @@ Note the printed Peer ID on startup.
 
 Planned features include:
 
-* Broadcasting proposals and votes via `NetworkMessage`.
+* Broadcasting proposals and votes via `ProtocolMessage`.
 * Remote nodes receiving and syncing governance state.
 * Full inter-node proposal lifecycle with vote aggregation.
 
@@ -181,6 +181,6 @@ Planned features include:
 ## Roadmap for Multi-Node Networking
 
 * [ ] Full `Libp2pNetworkService` with peer management
-* [ ] Gossipsub propagation of `NetworkMessage::AnnounceProposal`, `AnnounceVote`, etc.
+* [ ] Gossipsub propagation of `MessagePayload::GovernanceProposalAnnouncement`, `GovernanceVoteAnnouncement`, etc.
 * [ ] CLI/API for listing peers, showing connection status
 * [ ] Governance state sync hooks across nodes

--- a/PHASE_2B_SUCCESS.md
+++ b/PHASE_2B_SUCCESS.md
@@ -32,20 +32,32 @@ The following pipeline now works end-to-end across real P2P nodes:
 let job_id = host_submit_mesh_job(&runtime_ctx, &job_json).await?;
 
 // Job announced via gossipsub to the network
-NetworkMessage::MeshJobAnnouncement(job)
+ProtocolMessage::new(
+    MessagePayload::MeshJobAnnouncement(job),
+    sender_did,
+    None,
+)
 ```
 
 ### **2. Discovery & Bidding**
 ```rust
 // Node B discovers job and submits bid
 let bid = create_test_bid(&job_id, &executor_did, price_mana);
-NetworkMessage::BidSubmission(bid)
+ProtocolMessage::new(
+    MessagePayload::MeshBidSubmission(bid),
+    executor_did,
+    None,
+)
 ```
 
 ### **3. Assignment & Notification**
 ```rust
 // Node A selects executor and notifies assignment
-NetworkMessage::JobAssignmentNotification(job_id, executor_did)
+ProtocolMessage::new(
+    MessagePayload::MeshJobAssignment(job_id, executor_did),
+    sender_did,
+    None,
+)
 ```
 
 ### **4. Job Execution**
@@ -58,7 +70,11 @@ let receipt = SimpleExecutor::new(executor_did, signing_key)
 ### **5. Receipt Submission & Verification**
 ```rust
 // Node B submits cryptographically signed receipt
-NetworkMessage::SubmitReceipt(execution_receipt)
+ProtocolMessage::new(
+    MessagePayload::MeshReceiptSubmission(execution_receipt),
+    executor_did,
+    None,
+)
 
 // Node A verifies signature and anchors to DAG
 let anchored_cid = host_anchor_receipt(&runtime_ctx, &receipt_json, &reputation_updater).await?;

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -20,7 +20,7 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
     *   `icn-cli dag get <CID_JSON_STRING>`: Retrieves a DagBlock from the node by its CID. The CID must be provided as a JSON string.
 *   **Network Operations:**
     *   `icn-cli network discover-peers`: Query the connected node for peers. With the `with-libp2p` feature enabled the node will perform real discovery via libp2p.
-    *   `icn-cli network send-message <PEER_ID> <MESSAGE_JSON>`: Send a `NetworkMessage` to a specified peer. Requires the node to run with libp2p networking.
+    *   `icn-cli network send-message <PEER_ID> <MESSAGE_JSON>`: Send a `ProtocolMessage` (encoded as JSON) to a specified peer. Requires the node to run with libp2p networking.
     *   `icn-cli network peers`: Display this node's peer ID and the currently discovered peer list.
 *   **Federation Operations:**
     *   `icn-cli federation join <PEER_ID>`: Join a federation by adding the given peer.
@@ -43,7 +43,7 @@ The CLI aims to provide clear error messages and exit with appropriate status co
 As a CLI application, its "public API" is its command-line arguments, options, and output format (both `stdout` for data and `stderr` for errors).
 
 *   Commands are structured hierarchically (e.g., `dag put`, `network discover-peers`).
-*   Input for complex data structures (like DagBlocks or NetworkMessages) is currently expected in JSON string format for simplicity in this development phase. Future versions may support file inputs or more structured argument parsing.
+*   Input for complex data structures (like DagBlocks or ProtocolMessages) is currently expected in JSON string format for simplicity in this development phase. Future versions may support file inputs or more structured argument parsing.
 *   Output is human-readable. Successful data retrieval is printed to `stdout`. Errors and verbose logging (if any) go to `stderr`.
 
 ## Contributing

--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -21,8 +21,8 @@ The `icn-network` crate is responsible for:
 ## Key Components
 
 *   **`PeerId`**: A struct representing a unique identifier for a network peer. Currently a simple string wrapper, but intended to be compatible with underlying P2P library IDs (e.g., libp2p `PeerId`).
-*   **`NetworkMessage`**: An enum defining the various types of messages that can be exchanged between ICN nodes. This includes messages for block announcements (`AnnounceBlock`), block requests (`RequestBlock`), generic gossip messages (`GossipSub`), federation sync requests (`FederationSyncRequest`), and federation join handshakes (`FederationJoinRequest`/`FederationJoinResponse`). This enum derives `Serialize` and `Deserialize` for network transmission.
-*   **`SignedMessage`**: Wraps a `NetworkMessage` together with the sender's DID and an Ed25519 signature. Helpers `sign_message` and `verify_message_signature` are provided to create and validate these structures.
+*   **`ProtocolMessage`**: A signed envelope containing a `MessagePayload`. The payload represents specific actions such as block announcements (`DagBlockAnnouncement`), block requests (`DagBlockRequest`), generic gossip messages (`GossipMessage`), federation sync requests, and federation join handshakes. The struct derives `Serialize` and `Deserialize` for transmission.
+*   **`SignedMessage`**: Wraps a `ProtocolMessage` together with the sender's DID and an Ed25519 signature. Helpers `sign_message` and `verify_message_signature` are provided to create and validate these structures.
 *   **`NetworkService` Trait**: An abstraction defining the core functionalities a network service provider must implement. This includes methods like `discover_peers`, `send_message`, and `broadcast_message`. Methods return `Result<_, CommonError>` using specific error variants like `PeerNotFound`, `MessageSendError`, etc.
 *   **`StubNetworkService`**: A default implementation of `NetworkService` that simulates network interactions by logging actions to the console and returning predefined data. It's used for development and testing of higher-level crates without requiring a live P2P network. It demonstrates returning specific `CommonError` variants for simulated network issues.
 
@@ -61,7 +61,7 @@ discovery via the DHT.
 ## Message Signing
 
 All network messages should be authenticated. The helper function `sign_message`
-takes a `NetworkMessage`, the sender's `Did`, and a signing key to produce a
+takes a `ProtocolMessage`, the sender's `Did`, and a signing key to produce a
 `SignedMessage`. Peers can verify authenticity using
 `verify_message_signature`, which resolves the public key from the DID and
 checks the Ed25519 signature. The `StubNetworkService` verifies signatures for
@@ -70,7 +70,7 @@ checks the Ed25519 signature. The `StubNetworkService` verifies signatures for
 ## Public API Style
 
 This crate provides:
-*   Data structures (`PeerId`, `NetworkMessage`).
+*   Data structures (`PeerId`, `ProtocolMessage`, `MessagePayload`).
 *   A core trait (`NetworkService`) for P2P interactions.
 *   A concrete stub implementation (`StubNetworkService`) for testing.
 *   With the `libp2p` feature enabled, a full `Libp2pNetworkService` and DHT record APIs (`get_kademlia_record` and `put_kademlia_record`).

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -311,7 +311,7 @@ and set `storage_backend = "rocksdb"` in your configuration.
     *   **`icn-common`**: Core data structures (CIDs, DIDs, `DagBlock`, `NodeStatus`, etc.) and the central `CommonError` enum used throughout the workspace.
     *   **`icn-api`**: Defines functions that act as the API layer for node interactions. Currently, these are direct function calls but are designed to be adaptable for RPC.
     *   **`icn-dag`**: Implements L1 DAG block storage (currently an in-memory `HashMap`).
-    *   **`icn-network`**: Contains networking abstractions (`NetworkService` trait, `NetworkMessage` enum) and a `StubNetworkService` for testing.
+    *   **`icn-network`**: Contains networking abstractions (`NetworkService` trait, `ProtocolMessage` and `MessagePayload` types) and a `StubNetworkService` for testing.
     *   **`icn-identity`**: Provides an initial module for DID management and cryptographic functions.
     *   **`icn-node`**: The main binary executable that runs a persistent HTTP server for the ICN node API.
     *   **`icn-cli`**: The command-line interface client that interacts with `icn-node` via HTTP.


### PR DESCRIPTION
## Summary
- update references to `ProtocolMessage` and `MessagePayload`
- adjust CLI, onboarding and network docs
- update mesh lifecycle and success guide examples
- fix multi-node guide messaging terminology

## Testing
- `just validate` *(fails: command not found)*
- `cargo test --workspace --quiet` *(fails: unresolved import `icn_network::NetworkMessage`)*

------
https://chatgpt.com/codex/tasks/task_e_686af41ebd008324a36ec68601e0b88d