### PR TITLE
[tests] switch to ProtocolMessage

### DIFF
--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -12,7 +12,7 @@ use icn_common::{CommonError, Did, NodeInfo};
 #[cfg(feature = "federation")]
 use icn_network::{MeshNetworkError, NetworkService, PeerId};
 #[cfg(feature = "federation")]
-use icn_protocol::{MessagePayload, ProtocolMessage};
+use icn_protocol::{FederationSyncRequestMessage, MessagePayload, ProtocolMessage};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 #[cfg(feature = "persist-sled")]
@@ -1126,9 +1126,11 @@ pub async fn request_federation_sync(
     target_peer: &PeerId,
     since_timestamp: Option<u64>,
 ) -> Result<(), CommonError> {
-    let payload = since_timestamp
-        .map(|ts| Did::new("sync", &ts.to_string()))
-        .unwrap_or_default();
+    let payload = FederationSyncRequestMessage {
+        federation_id: "default".to_string(),
+        since_timestamp,
+        sync_types: vec![],
+    };
 
     let msg = ProtocolMessage::new(
         MessagePayload::FederationSyncRequest(payload),

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -17,8 +17,7 @@ pub mod metrics;
 
 use async_trait::async_trait;
 use downcast_rs::{impl_downcast, DowncastSync};
-use icn_common::{Cid, DagBlock, Did, NodeInfo};
-use icn_identity::{ExecutionReceipt, SignatureBytes};
+use icn_common::{Cid, Did, NodeInfo};
 use icn_protocol::{MessagePayload, ProtocolMessage};
 #[cfg(feature = "libp2p")]
 use libp2p::PeerId as Libp2pPeerId;

--- a/crates/icn-network/tests/error_variants.rs
+++ b/crates/icn-network/tests/error_variants.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "libp2p")]
 mod error_variants {
     use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
-    use icn_network::{decode_network_message, MeshNetworkError};
+    use icn_network::{decode_protocol_message, MeshNetworkError};
 
     #[tokio::test]
     async fn handshake_error_on_zero_timeout() {
@@ -20,7 +20,7 @@ mod error_variants {
     #[test]
     fn decode_message_error() {
         let bytes = vec![1u8, 2, 3];
-        match decode_network_message(&bytes) {
+        match decode_protocol_message(&bytes) {
             Err(MeshNetworkError::MessageDecodeFailed(_)) => {}
             other => panic!("unexpected result: {other:?}"),
         }

--- a/crates/icn-network/tests/federation_sync.rs
+++ b/crates/icn-network/tests/federation_sync.rs
@@ -12,7 +12,8 @@ mod federation_sync {
     use icn_common::Did;
     use icn_governance::request_federation_sync;
     use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
-    use icn_network::{NetworkMessage, NetworkService, PeerId};
+    use icn_network::{NetworkService, PeerId};
+    use icn_protocol::{MessagePayload, ProtocolMessage};
     use tokio::time::{sleep, timeout, Duration};
 
     #[tokio::test]
@@ -48,13 +49,13 @@ mod federation_sync {
             .await
             .expect("send sync");
 
-        let msg = timeout(Duration::from_secs(5), sub_b.recv())
+        let msg: ProtocolMessage = timeout(Duration::from_secs(5), sub_b.recv())
             .await
             .expect("recv timeout")
             .expect("recv message");
 
-        match msg {
-            NetworkMessage::FederationSyncRequest(did) => {
+        match msg.payload {
+            MessagePayload::FederationSyncRequest(did) => {
                 assert_eq!(did, Did::new("sync", &ts.to_string()));
             }
             other => panic!("unexpected message: {:?}", other),

--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -18,7 +18,11 @@ mod libp2p_mesh_integration {
     use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes};
     use icn_mesh::{ActualMeshJob as Job, JobId, JobKind, JobSpec, MeshJobBid as Bid, Resources};
     use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
-    use icn_network::{NetworkMessage, NetworkService};
+    use icn_network::NetworkService;
+    use icn_protocol::{
+        ExecutionMetadata, GossipMessage, MeshBidSubmissionMessage, MeshJobAnnouncementMessage,
+        MeshJobAssignmentMessage, MeshReceiptSubmissionMessage, MessagePayload, ProtocolMessage,
+    };
     use icn_runtime::executor::{JobExecutor, SimpleExecutor};
     use libp2p::PeerId as Libp2pPeerId;
     use log::info;
@@ -153,9 +157,14 @@ mod libp2p_mesh_integration {
                         println!("✅ [DEBUG] Node B subscription successful");
 
                         // 5. Test simple gossipsub message
-                        let test_message = NetworkMessage::GossipSub(
-                            "test_topic".to_string(),
-                            b"hello_test".to_vec(),
+                        let test_message = ProtocolMessage::new(
+                            MessagePayload::GossipMessage(GossipMessage {
+                                topic: "test_topic".to_string(),
+                                payload: b"hello_test".to_vec(),
+                                ttl: 1,
+                            }),
+                            Did::new("key", "node_a"),
+                            None,
                         );
                         println!(
                             "🔧 [DEBUG] Node A broadcasting test message: {:?}",
@@ -379,7 +388,18 @@ mod libp2p_mesh_integration {
 
         // 7. Test mesh job announcement flow
         let job_to_announce = generate_dummy_job("test_job_01");
-        let job_announcement_msg = NetworkMessage::MeshJobAnnouncement(job_to_announce.clone());
+        let job_announcement_msg = ProtocolMessage::new(
+            MessagePayload::MeshJobAnnouncement(MeshJobAnnouncementMessage {
+                job_id: job_to_announce.id.clone(),
+                manifest_cid: job_to_announce.manifest_cid.clone(),
+                creator_did: job_to_announce.creator_did.clone(),
+                max_cost_mana: job_to_announce.cost_mana,
+                job_spec: job_to_announce.spec.clone(),
+                bid_deadline: 0,
+            }),
+            Did::new("key", "node_a"),
+            None,
+        );
         println!(
             "🔧 [test-mesh-network] Node A broadcasting job announcement for job ID: {}",
             job_to_announce.id
@@ -415,7 +435,18 @@ mod libp2p_mesh_integration {
                         &received_job.id,
                         "did:key:z6MkjchhcVbWZkAbNGRsM4ac3gR3eNnYtD9tYtFv9T9xL4xH",
                     );
-                    let bid_submission_msg = NetworkMessage::BidSubmission(bid_to_submit.clone());
+                    let bid_submission_msg = ProtocolMessage::new(
+                        MessagePayload::MeshBidSubmission(MeshBidSubmissionMessage {
+                            job_id: bid_to_submit.job_id.clone(),
+                            executor_did: bid_to_submit.executor_did.clone(),
+                            cost_mana: bid_to_submit.price_mana,
+                            estimated_duration_secs: 0,
+                            offered_resources: bid_to_submit.resources.clone(),
+                            reputation_score: 0,
+                        }),
+                        Did::new("key", "node_b"),
+                        None,
+                    );
 
                     let bid_broadcast_result = timeout(
                         Duration::from_secs(5),
@@ -439,7 +470,9 @@ mod libp2p_mesh_integration {
                         timeout(Duration::from_secs(15), node_a_receiver.recv()).await;
                     match received_on_a_res {
                         Ok(Some(network_message_a)) => {
-                            if let NetworkMessage::BidSubmission(received_bid) = network_message_a {
+                            if let MessagePayload::MeshBidSubmission(received_bid) =
+                                &network_message_a.payload
+                            {
                                 assert_eq!(
                                     received_bid.job_id, job_to_announce.id,
                                     "Node A received bid for incorrect job ID"
@@ -597,13 +630,24 @@ mod libp2p_mesh_integration {
         let job_id = test_job.id.clone();
 
         // Node A announces job
-        let announcement_msg = NetworkMessage::MeshJobAnnouncement(test_job.clone());
+        let announcement_msg = ProtocolMessage::new(
+            MessagePayload::MeshJobAnnouncement(MeshJobAnnouncementMessage {
+                job_id: test_job.id.clone(),
+                manifest_cid: test_job.manifest_cid.clone(),
+                creator_did: test_job.creator_did.clone(),
+                max_cost_mana: test_job.cost_mana,
+                job_spec: test_job.spec.clone(),
+                bid_deadline: 0,
+            }),
+            Did::new("key", "node_a"),
+            None,
+        );
         node_a.service.broadcast_message(announcement_msg).await?;
         info!("📢 [PIPELINE-REFACTORED] Job announced: {}", job_id);
 
         // Node B receives job announcement
         let received_job = wait_for_message(&mut node_b.receiver, 10, |msg| match msg {
-            NetworkMessage::MeshJobAnnouncement(job) => Some(job.clone()),
+            MessagePayload::MeshJobAnnouncement(job) => Some(job.clone()),
             _ => None,
         })
         .await?;
@@ -613,13 +657,24 @@ mod libp2p_mesh_integration {
         let executor_did = &job_config.creator_did; // For simplicity, using same DID
         let (sk, _pk) = generate_ed25519_keypair();
         let bid = create_test_bid(&job_id, executor_did, 80, &sk);
-        let bid_msg = NetworkMessage::BidSubmission(bid.clone());
+        let bid_msg = ProtocolMessage::new(
+            MessagePayload::MeshBidSubmission(MeshBidSubmissionMessage {
+                job_id: bid.job_id.clone(),
+                executor_did: bid.executor_did.clone(),
+                cost_mana: bid.price_mana,
+                estimated_duration_secs: 0,
+                offered_resources: bid.resources.clone(),
+                reputation_score: 0,
+            }),
+            Did::new("key", "node_b"),
+            None,
+        );
         node_b.service.broadcast_message(bid_msg).await?;
         info!("💰 [PIPELINE-REFACTORED] Bid submitted by Node B");
 
         // Node A receives bid
         let received_bid = wait_for_message(&mut node_a.receiver, 10, |msg| match msg {
-            NetworkMessage::BidSubmission(bid) => {
+            MessagePayload::MeshBidSubmission(bid) => {
                 if bid.job_id == job_id {
                     Some(bid.clone())
                 } else {
@@ -637,15 +692,26 @@ mod libp2p_mesh_integration {
         // === Phase 3: Job Assignment ===
         info!("🔧 [PIPELINE-REFACTORED] Phase 3: Job assignment...");
 
-        let assignment_msg =
-            NetworkMessage::JobAssignmentNotification(job_id.clone(), executor_did.clone());
+        let assignment_msg = ProtocolMessage::new(
+            MessagePayload::MeshJobAssignment(MeshJobAssignmentMessage {
+                job_id: job_id.clone(),
+                executor_did: executor_did.clone(),
+                agreed_cost_mana: 0,
+                completion_deadline: 0,
+                manifest_cid: None,
+            }),
+            Did::new("key", "node_a"),
+            None,
+        );
         node_a.service.broadcast_message(assignment_msg).await?;
         info!("📋 [PIPELINE-REFACTORED] Job assignment notification sent");
 
         // Node B receives assignment
         let (assigned_job_id, assigned_executor) =
             wait_for_message(&mut node_b.receiver, 10, |msg| match msg {
-                NetworkMessage::JobAssignmentNotification(job_id, executor_did) => {
+                MessagePayload::MeshJobAssignment(assign) => {
+                    let job_id = &assign.job_id;
+                    let executor_did = &assign.executor_did;
                     Some((job_id.clone(), executor_did.clone()))
                 }
                 _ => None,
@@ -669,13 +735,26 @@ mod libp2p_mesh_integration {
         // === Phase 5: Receipt Submission & Verification ===
         info!("🔧 [PIPELINE-REFACTORED] Phase 5: Receipt submission and verification...");
 
-        let receipt_msg = NetworkMessage::SubmitReceipt(execution_result.clone());
+        let receipt_msg = ProtocolMessage::new(
+            MessagePayload::MeshReceiptSubmission(MeshReceiptSubmissionMessage {
+                receipt: execution_result.clone(),
+                execution_metadata: ExecutionMetadata {
+                    wall_time_ms: 0,
+                    peak_memory_mb: 0,
+                    exit_code: 0,
+                    execution_logs: None,
+                },
+            }),
+            Did::new("key", "node_b"),
+            None,
+        );
         node_b.service.broadcast_message(receipt_msg).await?;
         info!("📤 [PIPELINE-REFACTORED] Receipt submitted");
 
         // Node A receives and verifies receipt
         let verified_receipt = wait_for_message(&mut node_a.receiver, 10, |msg| match msg {
-            NetworkMessage::SubmitReceipt(receipt) => {
+            MessagePayload::MeshReceiptSubmission(sub) => {
+                let receipt = &sub.receipt;
                 if receipt.job_id == job_id.clone().into()
                     && receipt.executor_did == assigned_executor
                 {
@@ -735,12 +814,23 @@ mod libp2p_mesh_integration {
         let job_id = test_job.id.clone();
 
         // Announce job
-        let announcement_msg = NetworkMessage::MeshJobAnnouncement(test_job.clone());
+        let announcement_msg = ProtocolMessage::new(
+            MessagePayload::MeshJobAnnouncement(MeshJobAnnouncementMessage {
+                job_id: test_job.id.clone(),
+                manifest_cid: test_job.manifest_cid.clone(),
+                creator_did: test_job.creator_did.clone(),
+                max_cost_mana: test_job.cost_mana,
+                job_spec: test_job.spec.clone(),
+                bid_deadline: 0,
+            }),
+            Did::new("key", "node_a"),
+            None,
+        );
         node_a.service.broadcast_message(announcement_msg).await?;
 
         // Verify reception
         let received_job = wait_for_message(&mut node_b.receiver, 5, |msg| match msg {
-            NetworkMessage::MeshJobAnnouncement(job) => Some(job.clone()),
+            MessagePayload::MeshJobAnnouncement(job) => Some(job.clone()),
             _ => None,
         })
         .await?;
@@ -751,12 +841,23 @@ mod libp2p_mesh_integration {
         // Submit bid
         let (sk, _pk) = generate_ed25519_keypair();
         let bid = create_test_bid(&job_id, &job_config.creator_did, 75, &sk);
-        let bid_msg = NetworkMessage::BidSubmission(bid.clone());
+        let bid_msg = ProtocolMessage::new(
+            MessagePayload::MeshBidSubmission(MeshBidSubmissionMessage {
+                job_id: bid.job_id.clone(),
+                executor_did: bid.executor_did.clone(),
+                cost_mana: bid.price_mana,
+                estimated_duration_secs: 0,
+                offered_resources: bid.resources.clone(),
+                reputation_score: 0,
+            }),
+            Did::new("key", "node_b"),
+            None,
+        );
         node_b.service.broadcast_message(bid_msg).await?;
 
         // Verify bid reception
         let received_bid = wait_for_message(&mut node_a.receiver, 5, |msg| match msg {
-            NetworkMessage::BidSubmission(bid) => {
+            MessagePayload::MeshBidSubmission(bid) => {
                 if bid.job_id == job_id {
                     Some(bid.clone())
                 } else {

--- a/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration/utils.rs
@@ -11,7 +11,8 @@ use icn_common::{Cid, Did};
 use icn_identity::{generate_ed25519_keypair, ExecutionReceipt, SignatureBytes, SigningKey};
 use icn_mesh::{ActualMeshJob as Job, JobId, JobKind, JobSpec, MeshJobBid as Bid, Resources};
 use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
-use icn_network::{NetworkMessage, NetworkService};
+use icn_network::NetworkService;
+use icn_protocol::{MessagePayload, ProtocolMessage};
 use icn_runtime::executor::{JobExecutor, SimpleExecutor};
 use libp2p::PeerId as Libp2pPeerId;
 use std::str::FromStr;
@@ -22,7 +23,7 @@ use tokio::time::{sleep, timeout, Duration};
 pub struct TestNode {
     pub service: Libp2pNetworkService,
     pub peer_id: String,
-    pub receiver: Receiver<NetworkMessage>,
+    pub receiver: Receiver<ProtocolMessage>,
 }
 
 /// Test job configuration
@@ -190,12 +191,12 @@ pub fn verify_receipt_signature_format(receipt: &ExecutionReceipt) -> Result<()>
 
 /// Waits for a specific message type with timeout
 pub async fn wait_for_message<F, T>(
-    receiver: &mut Receiver<NetworkMessage>,
+    receiver: &mut Receiver<ProtocolMessage>,
     timeout_secs: u64,
     matcher: F,
 ) -> Result<T>
 where
-    F: Fn(&NetworkMessage) -> Option<T>,
+    F: Fn(&ProtocolMessage) -> Option<T>,
 {
     timeout(Duration::from_secs(timeout_secs), async {
         loop {

--- a/crates/icn-network/tests/network_stats.rs
+++ b/crates/icn-network/tests/network_stats.rs
@@ -8,7 +8,8 @@
 #[cfg(feature = "libp2p")]
 mod network_stats {
     use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
-    use icn_network::{NetworkMessage, NetworkService};
+    use icn_network::NetworkService;
+    use icn_protocol::{GossipMessage, MessagePayload, ProtocolMessage};
     use std::time::Duration;
     use tokio::time::sleep;
 
@@ -34,13 +35,16 @@ mod network_stats {
 
         sleep(Duration::from_secs(2)).await;
 
-        node2
-            .broadcast_message(NetworkMessage::GossipSub(
-                "test".to_string(),
-                b"hello".to_vec(),
-            ))
-            .await
-            .expect("broadcast");
+        let gossip = ProtocolMessage::new(
+            MessagePayload::GossipMessage(GossipMessage {
+                topic: "test".to_string(),
+                payload: b"hello".to_vec(),
+                ttl: 1,
+            }),
+            icn_common::Did::new("key", "network_stats"),
+            None,
+        );
+        node2.broadcast_message(gossip).await.expect("broadcast");
 
         sleep(Duration::from_secs(2)).await;
 

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -16,7 +16,7 @@ mod runtime_host_abi_tests {
     use icn_common::{Cid, Did};
     use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt};
     use icn_mesh::{ActualMeshJob, JobId, JobKind, JobSpec};
-    use icn_network::{NetworkMessage, NetworkService};
+    use icn_network::NetworkService;
     use icn_runtime::context::RuntimeContext;
     use icn_runtime::{host_anchor_receipt, host_submit_mesh_job, ReputationUpdater};
     use libp2p::{Multiaddr, PeerId as Libp2pPeerId};

--- a/crates/icn-runtime/tests/integration/cross_node_governance.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_governance.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "enable-libp2p")]
 mod cross_node_governance {
     use icn_governance::Proposal;
-    use icn_network::{NetworkMessage, NetworkService};
+    use icn_network::NetworkService;
     use icn_runtime::context::RuntimeContext;
     use icn_runtime::{host_cast_governance_vote, host_create_governance_proposal};
     use libp2p::{Multiaddr, PeerId as Libp2pPeerId};


### PR DESCRIPTION
## Summary
- migrate network and runtime tests to `ProtocolMessage`
- adapt utilities to handle `ProtocolMessage`
- update federation sync and message signing tests
- adjust governance helper to use `FederationSyncRequestMessage`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed)*
- `cargo test --all-features --workspace` *(failed)*

------
https://chatgpt.com/codex/tasks/task_e_686aff671b748324933d94ed5a3e741a