### PR TITLE
Remove legacy NetworkMessage usage

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -19,7 +19,7 @@ use icn_dag::StorageService; // Import the trait
 use std::sync::{Arc, Mutex}; // To accept the storage service
                              // Added imports for network functionality
 use icn_network::{NetworkService, PeerId, StubNetworkService};
-use icn_protocol::ProtocolMessage;
+use icn_protocol::{ProtocolMessage, MessagePayload};
 // Added imports for governance functionality
 use icn_governance::{
     scoped_policy::{DagPayloadOp, PolicyCheckResult, ScopedPolicyEnforcer},

--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -10,7 +10,8 @@
 
 use icn_common::{CommonError, Did, NodeInfo};
 #[cfg(feature = "federation")]
-use icn_network::{MeshNetworkError, NetworkService, PeerId};
+#[allow(unused_imports)]
+use icn_network::{MeshNetworkError, NetworkService, PeerId, StubNetworkService};
 #[cfg(feature = "federation")]
 use icn_protocol::{MessagePayload, ProtocolMessage};
 use std::collections::{HashMap, HashSet};
@@ -1119,7 +1120,7 @@ impl fmt::Debug for GovernanceModule {
 /// Request federation data synchronization from a peer.
 ///
 /// This uses the provided [`NetworkService`] to send a
-/// [`NetworkMessage::FederationSyncRequest`] to `target_peer`.
+/// [`MessagePayload::FederationSyncRequest`] to `target_peer`.
 #[cfg(feature = "federation")]
 pub async fn request_federation_sync(
     service: &dyn NetworkService,


### PR DESCRIPTION
## Summary
- update imports to remove `NetworkMessage`
- broadcast protocol messages using generic gossip payloads
- tweak federation sync comment and imports

## Testing
- `cargo fmt --all -- --check` *(fails: produced diff)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: unused import in icn-network)*
- `cargo test --all-features --workspace` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686afea11348832481feb42fd2c2308e