### PR TITLE
[network] update message imports

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -19,7 +19,7 @@ use icn_dag::StorageService; // Import the trait
 use std::sync::{Arc, Mutex}; // To accept the storage service
                              // Added imports for network functionality
 use icn_network::{NetworkService, PeerId, StubNetworkService};
-use icn_protocol::ProtocolMessage;
+use icn_protocol::{ProtocolMessage, MessagePayload};
 // Added imports for governance functionality
 use icn_governance::{
     scoped_policy::{DagPayloadOp, PolicyCheckResult, ScopedPolicyEnforcer},

--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -12,7 +12,9 @@ use icn_common::{CommonError, Did, NodeInfo};
 #[cfg(feature = "federation")]
 use icn_network::{MeshNetworkError, NetworkService, PeerId};
 #[cfg(feature = "federation")]
-use icn_protocol::{MessagePayload, ProtocolMessage};
+use icn_protocol::{
+    MessagePayload, ProtocolMessage, FederationSyncRequestMessage, SyncDataType,
+};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 #[cfg(feature = "persist-sled")]
@@ -1119,16 +1121,23 @@ impl fmt::Debug for GovernanceModule {
 /// Request federation data synchronization from a peer.
 ///
 /// This uses the provided [`NetworkService`] to send a
-/// [`NetworkMessage::FederationSyncRequest`] to `target_peer`.
+/// [`ProtocolMessage`] with [`MessagePayload::FederationSyncRequest`] to `target_peer`.
 #[cfg(feature = "federation")]
 pub async fn request_federation_sync(
     service: &dyn NetworkService,
     target_peer: &PeerId,
     since_timestamp: Option<u64>,
 ) -> Result<(), CommonError> {
-    let payload = since_timestamp
-        .map(|ts| Did::new("sync", &ts.to_string()))
-        .unwrap_or_default();
+    let payload = FederationSyncRequestMessage {
+        federation_id: "default".to_string(),
+        since_timestamp,
+        sync_types: vec![
+            SyncDataType::Members,
+            SyncDataType::Proposals,
+            SyncDataType::Jobs,
+            SyncDataType::Reputation,
+        ],
+    };
 
     let msg = ProtocolMessage::new(
         MessagePayload::FederationSyncRequest(payload),

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -17,8 +17,7 @@ pub mod metrics;
 
 use async_trait::async_trait;
 use downcast_rs::{impl_downcast, DowncastSync};
-use icn_common::{Cid, DagBlock, Did, NodeInfo};
-use icn_identity::{ExecutionReceipt, SignatureBytes};
+use icn_common::{Cid, Did, NodeInfo};
 use icn_protocol::{MessagePayload, ProtocolMessage};
 #[cfg(feature = "libp2p")]
 use libp2p::PeerId as Libp2pPeerId;

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -30,7 +30,8 @@ use icn_identity::{
     ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes,
 };
 use icn_mesh::{ActualMeshJob, JobId, JobSpec};
-use icn_network::{NetworkMessage, NetworkService};
+use icn_network::{NetworkService, PeerId, StubNetworkService};
+use icn_protocol::{ProtocolMessage, MessagePayload, FederationJoinRequestMessage, GossipMessage};
 use icn_runtime::context::{
     RuntimeContext, StubDagStore as RuntimeStubDagStore, StubMeshNetworkService,
     StubSigner as RuntimeStubSigner,
@@ -1741,10 +1742,25 @@ async fn federation_join_handler(
     }
     #[cfg(feature = "enable-libp2p")]
     if let Ok(service) = state.runtime_context.get_libp2p_service() {
+        let join_msg = FederationJoinRequestMessage {
+            requesting_node: state.runtime_context.current_identity.clone(),
+            federation_id: "default".to_string(),
+            node_capabilities: icn_protocol::NodeCapabilities {
+                compute_resources: icn_protocol::ResourceRequirements::default(),
+                supported_job_kinds: vec![],
+                network_bandwidth_mbps: 0,
+                storage_capacity_gb: 0,
+                uptime_percentage: 0.0,
+            },
+            referral_from: None,
+        };
+        let msg = ProtocolMessage::new(
+            MessagePayload::FederationJoinRequest(join_msg),
+            state.runtime_context.current_identity.clone(),
+            None,
+        );
         if let Err(e) = service
-            .broadcast_message(NetworkMessage::FederationJoinRequest(
-                state.runtime_context.current_identity.clone(),
-            ))
+            .broadcast_message(msg)
             .await
         {
             error!("Failed to broadcast join: {:?}", e);
@@ -1772,9 +1788,14 @@ async fn federation_leave_handler(
     #[cfg(feature = "enable-libp2p")]
     if let Ok(service) = state.runtime_context.get_libp2p_service() {
         if let Err(e) = service
-            .broadcast_message(NetworkMessage::GossipSub(
-                "federation_leave".to_string(),
-                payload.peer.clone().into_bytes(),
+            .broadcast_message(ProtocolMessage::new(
+                MessagePayload::GossipMessage(GossipMessage {
+                    topic: "federation_leave".to_string(),
+                    payload: payload.peer.clone().into_bytes(),
+                    ttl: 60,
+                }),
+                state.runtime_context.current_identity.clone(),
+                None,
             ))
             .await
         {


### PR DESCRIPTION
## Summary
- switch to new `ProtocolMessage`/`MessagePayload` types
- update runtime and node message creation
- adjust federation sync helper
- fix unused imports in network crate

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build took too long)*
- `cargo test --workspace --all-features --no-run` *(failed: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_686afea43da083249dfd739bb25135d0