### PR TITLE
[network] remove NetworkMessage references

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -19,7 +19,7 @@ use icn_dag::StorageService; // Import the trait
 use std::sync::{Arc, Mutex}; // To accept the storage service
                              // Added imports for network functionality
 use icn_network::{NetworkService, PeerId, StubNetworkService};
-use icn_protocol::{ProtocolMessage, MessagePayload};
+use icn_protocol::{MessagePayload, ProtocolMessage};
 // Added imports for governance functionality
 use icn_governance::{
     scoped_policy::{DagPayloadOp, PolicyCheckResult, ScopedPolicyEnforcer},

--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -13,7 +13,9 @@ use icn_common::{CommonError, Did, NodeInfo};
 #[allow(unused_imports)]
 use icn_network::{MeshNetworkError, NetworkService, PeerId, StubNetworkService};
 #[cfg(feature = "federation")]
-use icn_protocol::{FederationSyncRequestMessage, MessagePayload, ProtocolMessage};
+use icn_protocol::FederationSyncRequestMessage;
+#[cfg(feature = "federation")]
+use icn_protocol::{MessagePayload, ProtocolMessage};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 #[cfg(feature = "persist-sled")]

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -32,7 +32,10 @@ use icn_identity::{
 use icn_mesh::{ActualMeshJob, JobId, JobSpec};
 #[allow(unused_imports)]
 use icn_network::{NetworkService, PeerId, StubNetworkService};
-use icn_protocol::{ProtocolMessage, MessagePayload, GossipMessage, FederationJoinRequestMessage, NodeCapabilities, ResourceRequirements};
+use icn_protocol::{
+    FederationJoinRequestMessage, GossipMessage, NodeCapabilities, ResourceRequirements,
+};
+use icn_protocol::{MessagePayload, ProtocolMessage};
 use icn_runtime::context::{
     RuntimeContext, StubDagStore as RuntimeStubDagStore, StubMeshNetworkService,
     StubSigner as RuntimeStubSigner,

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -9,7 +9,8 @@ use downcast_rs::{impl_downcast, DowncastSync};
 use icn_network::libp2p_service::Libp2pNetworkService as ActualLibp2pNetworkService;
 #[allow(unused_imports)]
 use icn_network::{NetworkService, PeerId, StubNetworkService};
-use icn_protocol::{ProtocolMessage, MessagePayload, GossipMessage};
+use icn_protocol::GossipMessage;
+use icn_protocol::{MessagePayload, ProtocolMessage};
 
 #[cfg(not(any(
     feature = "persist-sled",
@@ -374,9 +375,8 @@ impl MeshNetworkService for DefaultMeshNetworkService {
     }
 
     async fn announce_job(&self, job: &ActualMeshJob) -> Result<(), HostAbiError> {
-        let payload_bytes = bincode::serialize(job).map_err(|e| {
-            HostAbiError::NetworkError(format!("Failed to serialize job: {}", e))
-        })?;
+        let payload_bytes = bincode::serialize(job)
+            .map_err(|e| HostAbiError::NetworkError(format!("Failed to serialize job: {}", e)))?;
         let job_message = ProtocolMessage::new(
             MessagePayload::GossipMessage(GossipMessage {
                 topic: "mesh_job_announcement".to_string(),


### PR DESCRIPTION
## Summary
- clean up leftover NetworkMessage imports
- import ProtocolMessage/MessagePayload across crates

## Testing
- `cargo fmt --all -- --check` *(fails: diff in unrelated files)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to complete: job aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686b07bfc8148324bee1f083629c5d24