### PR TITLE
[icn-node] add bin target

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -50,3 +50,7 @@ tempfile = "3"
 icn-ccl = { path = "../../icn-ccl" }
 rcgen = "0.9"
 prometheus-parse = "0.2"
+
+[[bin]]
+name = "icn-node"
+path = "src/node.rs"


### PR DESCRIPTION
## Summary
- declare icn-node's main executable in Cargo config so Docker builds a binary

## Testing
- `cargo fmt --all -- --check`
- *(partial) `cargo clippy --all-targets --all-features -- -D warnings`* (failed to complete due to resource constraints)

------
https://chatgpt.com/codex/tasks/task_e_686b2829bae48324839ea74c69f0c367