### PR TITLE
[economics] remove unused persist

### DIFF
--- a/crates/icn-economics/src/ledger.rs
+++ b/crates/icn-economics/src/ledger.rs
@@ -88,11 +88,6 @@ impl FileManaLedger {
         Ok(())
     }
 
-    fn persist(&self) -> Result<(), CommonError> {
-        let balances = self.balances.lock().unwrap();
-        self.persist_locked(&balances)
-    }
-
     /// Return the current mana balance for `account`.
     pub fn get_balance(&self, account: &Did) -> u64 {
         let balances = self.balances.lock().unwrap();


### PR DESCRIPTION
## Summary
- remove the unused `persist` method from `FileManaLedger`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build took too long)*
- `cargo test --all-features --workspace` *(failed: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_686b3171824c832490505d9bf59a3991