### PR TITLE
[devnet] set RUST_MIN_STACK for Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ just test     # execute all tests
 just build    # build all crates
 just devnet   # launch the containerized federation devnet
 icn-devnet/launch_federation.sh # build and test the federation containers
+# If building the devnet Docker images manually, ensure a larger stack size:
+export RUST_MIN_STACK=16777216
 ```
 
 
@@ -168,6 +170,7 @@ Development has progressed through several major phases:
 4. **Phase&nbsp;3 – HTTP Gateway**: all runtime functionality is accessible over REST endpoints.
 5. **Phase&nbsp;4 – Federation Devnet**: containerized devnet demonstrating a three‑node federation.
    Run `icn-devnet/launch_federation.sh` to build and test the federation locally.
+   The Docker build sets `RUST_MIN_STACK=16777216` to avoid stack overflow.
 
 Future planning and outstanding tasks are tracked on the
 [issue tracker](https://github.com/InterCooperative/icn-core/issues).

--- a/icn-devnet/Dockerfile
+++ b/icn-devnet/Dockerfile
@@ -28,6 +28,7 @@ COPY icn-ccl/ ./icn-ccl/
 COPY tests/ ./tests/
 
 # Build the ICN node binary
+ENV RUST_MIN_STACK=16777216
 RUN cargo build --release -p icn-node --features with-libp2p
 
 # Runtime stage


### PR DESCRIPTION
## Summary
- adjust icn-devnet Dockerfile to export `RUST_MIN_STACK`
- mention stack size requirement in README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: uninlined-format-args)*
- `cargo test --all-features --workspace` *(terminated)*
- `docker-compose build` *(failed: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_686b3910baf4832485085f4099f5e78a