### PR TITLE
[docs] document rustfmt installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ When issues are created in the tracker, they should ideally be labeled with `goo
 4.  **Make your changes**. Ensure you add relevant tests and update documentation as needed.
 5.  **Run tests**: `cargo test --all` (or per-crate tests).
 6.  **Format your code**: `cargo fmt --all`.
+    If this command fails, install the formatter with `rustup component add rustfmt`.
 7.  **Lint your code**: `cargo clippy --all -- -D warnings` (or per-crate).
 8.  **Commit your changes**: Write clear, concise commit messages.
 9.  **Push to your branch**.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ icn-devnet/launch_federation.sh # build and test the federation containers
 export RUST_MIN_STACK=33554432
 ```
 
+Before running `just format` or `cargo fmt`, make sure the `rustfmt` component is installed:
+
+```bash
+rustup component add rustfmt
+```
+
 
 ### Enabling Peer Discovery and Persistent Storage
 


### PR DESCRIPTION
## Summary
- remind contributors how to install rustfmt for format checks

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-economics`)*
- `cargo test -p icn-ccl` *(fails to compile)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b47c710b083249102b0e624b17dc7