### PR TITLE
[devnet] add newline to Dockerfile

### DIFF
--- a/icn-devnet/Dockerfile
+++ b/icn-devnet/Dockerfile
@@ -64,4 +64,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:7845/info || exit 1
 
 # Use entrypoint script
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"] 
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- add newline at EOF in icn-devnet Dockerfile

## Testing
- `cargo fmt --all -- --check` *(fails: produced diffs)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-economics`)*
- `cargo test --all-features --workspace` *(failed to run due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686b47c2693483249d2997508b1a87e7