### PR TITLE
[devnet] require larger stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ just build    # build all crates
 just devnet   # launch the containerized federation devnet
 icn-devnet/launch_federation.sh # build and test the federation containers
 # If building the devnet Docker images manually, ensure a larger stack size:
-export RUST_MIN_STACK=33554432
+# 64 MiB required
+export RUST_MIN_STACK=67108864
 ```
 
 
@@ -170,7 +171,7 @@ Development has progressed through several major phases:
 4. **Phase&nbsp;3 – HTTP Gateway**: all runtime functionality is accessible over REST endpoints.
 5. **Phase&nbsp;4 – Federation Devnet**: containerized devnet demonstrating a three‑node federation.
   Run `icn-devnet/launch_federation.sh` to build and test the federation locally.
-  The Docker build sets `RUST_MIN_STACK=33554432` to avoid stack overflow during compilation.
+  The Docker build sets `RUST_MIN_STACK=67108864` (64 MiB) to avoid stack overflow during compilation.
 
 Future planning and outstanding tasks are tracked on the
 [issue tracker](https://github.com/InterCooperative/icn-core/issues).

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -19,7 +19,9 @@ use icn_dag::StorageService; // Import the trait
 use std::sync::{Arc, Mutex}; // To accept the storage service
                              // Added imports for network functionality
 use icn_network::{NetworkService, PeerId, StubNetworkService};
-use icn_protocol::{MessagePayload, ProtocolMessage};
+#[cfg(test)]
+use icn_protocol::MessagePayload;
+use icn_protocol::ProtocolMessage;
 // Added imports for governance functionality
 use icn_governance::{
     scoped_policy::{DagPayloadOp, PolicyCheckResult, ScopedPolicyEnforcer},

--- a/crates/icn-economics/src/ledger.rs
+++ b/crates/icn-economics/src/ledger.rs
@@ -70,13 +70,13 @@ impl FileManaLedger {
             .truncate(true)
             .open(&tmp_path)
             .map_err(|e| {
-                CommonError::IoError(format!("Failed to open ledger file {:?}: {e}", tmp_path))
+                CommonError::IoError(format!("Failed to open ledger file {tmp_path:?}: {e}"))
             })?;
         file.write_all(serialized.as_bytes()).map_err(|e| {
-            CommonError::IoError(format!("Failed to write ledger file {:?}: {e}", tmp_path))
+            CommonError::IoError(format!("Failed to write ledger file {tmp_path:?}: {e}"))
         })?;
         file.sync_all().map_err(|e| {
-            CommonError::IoError(format!("Failed to sync ledger file {:?}: {e}", tmp_path))
+            CommonError::IoError(format!("Failed to sync ledger file {tmp_path:?}: {e}"))
         })?;
         drop(file);
         rename(&tmp_path, &self.path).map_err(|e| {
@@ -252,12 +252,10 @@ impl SledManaLedger {
     pub fn all_accounts(&self) -> Vec<Did> {
         use std::str::FromStr;
         let mut accounts = Vec::new();
-        for result in self.tree.iter() {
-            if let Ok((key, _)) = result {
-                if let Ok(did_str) = std::str::from_utf8(&key) {
-                    if let Ok(did) = Did::from_str(did_str) {
-                        accounts.push(did);
-                    }
+        for (key, _) in self.tree.iter().flatten() {
+            if let Ok(did_str) = std::str::from_utf8(&key) {
+                if let Ok(did) = Did::from_str(did_str) {
+                    accounts.push(did);
                 }
             }
         }

--- a/crates/icn-economics/src/ledger/rocksdb.rs
+++ b/crates/icn-economics/src/ledger/rocksdb.rs
@@ -68,12 +68,10 @@ impl RocksdbManaLedger {
         use rocksdb::IteratorMode;
         use std::str::FromStr;
         let mut accounts = Vec::new();
-        for item in self.db.iterator(IteratorMode::Start) {
-            if let Ok((key, _)) = item {
-                if let Ok(did_str) = std::str::from_utf8(&key) {
-                    if let Ok(did) = Did::from_str(did_str) {
-                        accounts.push(did);
-                    }
+        for (key, _) in self.db.iterator(IteratorMode::Start).flatten() {
+            if let Ok(did_str) = std::str::from_utf8(&key) {
+                if let Ok(did) = Did::from_str(did_str) {
+                    accounts.push(did);
                 }
             }
         }

--- a/crates/icn-economics/src/ledger/sqlite.rs
+++ b/crates/icn-economics/src/ledger/sqlite.rs
@@ -85,11 +85,9 @@ impl SqliteManaLedger {
         match rows_result {
             Ok(rows) => {
                 let mut accounts = Vec::new();
-                for row_result in rows {
-                    if let Ok(did_string) = row_result {
-                        if let Ok(did) = Did::from_str(&did_string) {
-                            accounts.push(did);
-                        }
+                for did_string in rows.flatten() {
+                    if let Ok(did) = Did::from_str(&did_string) {
+                        accounts.push(did);
                     }
                 }
                 accounts

--- a/icn-devnet/Dockerfile
+++ b/icn-devnet/Dockerfile
@@ -29,7 +29,8 @@ COPY tests/ ./tests/
 
 # Build the ICN node binary
 # Increase rustc stack size to avoid segfaults during optimized builds
-ENV RUST_MIN_STACK=33554432
+# 64 MiB is required for some build steps
+ENV RUST_MIN_STACK=67108864
 RUN cargo build --release -p icn-node --features with-libp2p
 
 # Runtime stage


### PR DESCRIPTION
## Summary
- bump RUST_MIN_STACK in devnet Dockerfile to 64 MiB
- update README to mention 64 MiB requirement
- fix unused import clippy lint
- clean up ledger file formatting lints

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused import and trait errors)*
- `cargo test --all-features --workspace` *(fails: trait bounds and method errors)*
- `cargo test -p icn-ccl` *(fails: mismatched types)*
- `just test-ccl-contracts` *(fails: `just` not found)*
- `just test-covm-execution` *(fails: `just` not found)*
- `just devnet` *(fails: Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b47c09ab0832480a4800ce8338ca8