### PR TITLE
Implement reputation-based resource pricing

### DIFF
--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -86,8 +86,13 @@ pub async fn host_submit_mesh_job(
             ))
         })?;
 
-    // 2. Call ResourcePolicyEnforcer::spend_mana(did, cost).
-    // This should use the RuntimeContext's spend_mana which is now async.
+    // 2. Adjust cost based on the submitter's reputation and spend mana.
+    let rep = ctx.reputation_store.get_reputation(&ctx.current_identity);
+    job_to_submit.cost_mana = icn_economics::price_by_reputation(
+        job_to_submit.cost_mana,
+        rep,
+    );
+
     ctx.spend_mana(&ctx.current_identity, job_to_submit.cost_mana)
         .await
         .map_err(|e| match e {


### PR DESCRIPTION
## Summary
- add `price_by_reputation` helper in `icn-economics`
- apply pricing adjustment when submitting mesh jobs
- test price calculation logic

## Testing
- `cargo test --all-features --workspace` *(fails: environment lacks required Rust components)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy component missing)*
- `cargo fmt --all -- --check` *(fails: rustfmt component missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b5ec4e1e48324b1a48ff5f7f3027b