### PR TITLE
Fix governance sled feature and federation test gating

### DIFF
--- a/crates/icn-governance/Cargo.toml
+++ b/crates/icn-governance/Cargo.toml
@@ -22,6 +22,6 @@ sled = { version = "0.34" }
 
 [features]
 default = ["persist-sled"]
-persist-sled = ["dep:sled", "dep:serde", "dep:bincode"]
+persist-sled = ["dep:sled", "dep:serde", "dep:bincode", "serde"]
 federation = ["dep:icn-network"]
 serde = ["dep:serde"]

--- a/crates/icn-governance/tests/federation.rs
+++ b/crates/icn-governance/tests/federation.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "federation")]
+
 use icn_governance::request_federation_sync;
 use icn_network::{PeerId, StubNetworkService};
 


### PR DESCRIPTION
## Summary
- ensure `serde` feature is enabled when using the sled backend
- gate `federation` test module behind its feature flag

## Testing
- `cargo test -p icn-governance callback_runs_on_execute -- --nocapture` *(fails: Voting period not closed yet)*
- `cargo test -p icn-governance sled_round_trip -- --nocapture`
- `cargo test -p icn-governance sled_execute_persist -- --nocapture` *(fails: Voting period not closed yet)*
- `cargo test -p icn-governance vote_tally_and_execute -- --nocapture` *(fails: Voting period not closed yet)*
- `cargo test -p icn-governance -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686b628d47248324957d41956ec68c7e