### PR TITLE
[dag] persist store for libp2p

### DIFF
--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -533,14 +533,12 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_in_memory_dag_store_service() {
         let mut store = InMemoryDagStore::new(); // Make store mutable
         test_storage_service_suite(&mut store); // Pass as mutable reference
     }
 
     #[test]
-    #[ignore]
     fn test_file_dag_store_service() {
         let dir = tempdir().unwrap();
         let mut store = FileDagStore::new(dir.path().to_path_buf()).unwrap();
@@ -587,7 +585,6 @@ mod tests {
 
     #[cfg(feature = "async")]
     #[tokio::test]
-    #[ignore]
     async fn test_tokio_file_dag_store_service() {
         let dir = tempdir().unwrap();
         let mut store = TokioFileDagStore::new(dir.path().to_path_buf()).unwrap();
@@ -633,7 +630,6 @@ mod tests {
 
     #[cfg(feature = "persist-sled")]
     #[test]
-    #[ignore]
     fn test_sled_dag_store_service() {
         let dir = tempdir().unwrap();
         let mut store = sled_store::SledDagStore::new(dir.path().to_path_buf()).unwrap();
@@ -649,7 +645,6 @@ mod tests {
 
     #[cfg(feature = "persist-sqlite")]
     #[test]
-    #[ignore]
     fn test_sqlite_dag_store_service() {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("dag.sqlite");
@@ -666,7 +661,6 @@ mod tests {
 
     #[cfg(feature = "persist-rocksdb")]
     #[test]
-    #[ignore]
     fn test_rocks_dag_store_service() {
         let dir = tempdir().unwrap();
         let db_path = dir.path().join("rocks");
@@ -682,7 +676,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_process_dag_data() {
         let node_info = NodeInfo {
             name: "TestDAGNode".to_string(),
@@ -703,7 +696,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_traversal_index() {
         use crate::index::DagTraversalIndex;
         let mut index = DagTraversalIndex::new();

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -748,6 +748,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
                 &node_did_string,
                 listen_addrs,
                 bootstrap_peers,
+                config.storage_path.clone(),
                 config.mana_ledger_path.clone(),
                 config.reputation_db_path.clone(),
             )

--- a/crates/icn-runtime/examples/libp2p_demo.rs
+++ b/crates/icn-runtime/examples/libp2p_demo.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         node_identity,
         vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()],
         None, // No bootstrap peers for this demo
+        std::path::PathBuf::from("./dag_demo"),
         std::path::PathBuf::from("./mana_ledger.sled"),
         std::path::PathBuf::from("./reputation.sled"),
     )

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1725,6 +1725,7 @@ impl RuntimeContext {
         identity_str: &str,
         listen_addresses: Vec<Multiaddr>,
         bootstrap_peers: Option<Vec<(Libp2pPeerId, Multiaddr)>>,
+        dag_store_path: PathBuf,
         mana_ledger_path: PathBuf,
         reputation_store_path: PathBuf,
     ) -> Result<Arc<Self>, CommonError> {
@@ -1763,20 +1764,17 @@ impl RuntimeContext {
             libp2p_service.clone() as Arc<dyn NetworkService>
         ));
 
-        // Create stub DAG store for now (can be enhanced later)
-        let dag_store = Arc::new(TokioMutex::new(StubDagStore::new()));
-
-        // Create RuntimeContext with real networking - this returns Arc<Self>
-        let ctx = Self::new_with_ledger_path(
+        // Create RuntimeContext with real networking and persistent DAG storage
+        let ctx = Self::new_with_paths(
             identity,
             mesh_service,
             signer,
             Arc::new(KeyDidResolver),
-            dag_store,
+            dag_store_path,
             mana_ledger_path,
             reputation_store_path,
             None,
-        );
+        )?;
 
         info!("RuntimeContext with real libp2p networking created successfully");
         Ok(ctx)

--- a/crates/icn-runtime/tests/integration/cross_node_governance.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_governance.rs
@@ -18,6 +18,7 @@ mod cross_node_governance {
             &id,
             listen,
             bootstrap,
+            std::path::PathBuf::from("./dag_store"),
             std::path::PathBuf::from("./mana_ledger.sled"),
             std::path::PathBuf::from("./reputation.sled"),
         )

--- a/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_job_execution.rs
@@ -59,6 +59,7 @@ mod cross_node_tests {
             &identity_str,
             listen,
             bootstrap_peers,
+            std::path::PathBuf::from("./dag_store"),
             std::path::PathBuf::from("./mana_ledger.sled"),
             std::path::PathBuf::from("./reputation.sled"),
         )

--- a/crates/icn-runtime/tests/integration/libp2p_integration.rs
+++ b/crates/icn-runtime/tests/integration/libp2p_integration.rs
@@ -19,6 +19,7 @@ mod libp2p_integration_tests {
             node_identity,
             listen,
             None,  // No bootstrap peers for this simple test
+            std::path::PathBuf::from("./dag_demo"),
             std::path::PathBuf::from("./mana_ledger.sled"),
             std::path::PathBuf::from("./reputation.sled"),
         )
@@ -74,6 +75,7 @@ mod libp2p_integration_tests {
             node_identity,
             listen,
             Some(bootstrap_peers),
+            std::path::PathBuf::from("./dag_demo"),
             std::path::PathBuf::from("./mana_ledger.sled"),
             std::path::PathBuf::from("./reputation.sled"),
         )

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -785,6 +785,7 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
             &identity_str,
             listen,
             bootstrap_peers,
+            std::path::PathBuf::from("./dag_store"),
             std::path::PathBuf::from("./mana_ledger.sled"),
             std::path::PathBuf::from("./reputation.sled"),
         )

--- a/tests/integration/icn_node_end_to_end.rs
+++ b/tests/integration/icn_node_end_to_end.rs
@@ -42,6 +42,7 @@ mod icn_node_end_to_end {
             &did,
             listen,
             bootstrap,
+            std::path::PathBuf::from(format!("./dag_{suffix}")),
             std::path::PathBuf::from(format!("./mana_{suffix}.sled")),
             std::path::PathBuf::from(format!("./rep_{suffix}.sled")),
         )

--- a/tests/integration/libp2p_job_pipeline.rs
+++ b/tests/integration/libp2p_job_pipeline.rs
@@ -206,6 +206,7 @@ mod libp2p_job_pipeline {
             "did:key:z6MktestA",
             listen.clone(),
             None,
+            std::path::PathBuf::from("./dag_a"),
             std::path::PathBuf::from("./mana_a.sled"),
             std::path::PathBuf::from("./rep_a.sled"),
         )
@@ -228,6 +229,7 @@ mod libp2p_job_pipeline {
             "did:key:z6MktestB",
             listen,
             Some(vec![(peer_a, addr_a.clone())]),
+            std::path::PathBuf::from("./dag_b"),
             std::path::PathBuf::from("./mana_b.sled"),
             std::path::PathBuf::from("./rep_b.sled"),
         )

--- a/tests/integration/multi_node_libp2p.rs
+++ b/tests/integration/multi_node_libp2p.rs
@@ -42,6 +42,7 @@ mod multi_node_libp2p {
             &identity_str,
             listen,
             bootstrap_peers,
+            std::path::PathBuf::from("./dag_store"),
             std::path::PathBuf::from("./mana_ledger.sled"),
             std::path::PathBuf::from("./reputation.sled"),
         )


### PR DESCRIPTION
## Summary
- switch `new_with_real_libp2p` to use persistent DAG storage
- wire node startup to pass DAG path
- update tests/examples for new parameter
- enable DAG persistence tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails to run: component not fully installed)*
- `cargo test` *(fails to run: clippy build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686be5e9d7b483248f4f7369ec62c94c