### PR TITLE
[node] remove unused imports

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -31,14 +31,14 @@ use icn_identity::{
 };
 use icn_mesh::{ActualMeshJob, JobId, JobSpec};
 #[allow(unused_imports)]
-use icn_network::{NetworkService, PeerId, StubNetworkService};
+use icn_network::{NetworkService, PeerId};
 use icn_protocol::{
     FederationJoinRequestMessage, GossipMessage, NodeCapabilities, ResourceRequirements,
 };
 use icn_protocol::{MessagePayload, ProtocolMessage};
 use icn_runtime::context::{
-    DefaultMeshNetworkService, RuntimeContext, StubDagStore as RuntimeStubDagStore,
-    StubMeshNetworkService, StubSigner as RuntimeStubSigner,
+    DefaultMeshNetworkService, RuntimeContext, StubMeshNetworkService,
+    StubSigner as RuntimeStubSigner,
 };
 use icn_runtime::{host_anchor_receipt, host_submit_mesh_job, ReputationUpdater};
 use prometheus_client::{encoding::text::encode, registry::Registry};


### PR DESCRIPTION
## Summary
- clean up `icn-node` imports

## Testing
- `cargo check -p icn-node`
- `cargo check -p icn-node --features with-libp2p`
- `cargo fmt --all -- --check` *(fails: shows formatting diffs)*
- `cargo test --all-features --workspace` *(failed: process timed out)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686c00151a888324b8b4f60249315e41