### PR TITLE
[runtime] add Ed25519 signer and integrate

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -37,7 +37,7 @@ use icn_protocol::{
 };
 use icn_protocol::{MessagePayload, ProtocolMessage};
 use icn_runtime::context::{
-    DefaultMeshNetworkService, RuntimeContext, StubDagStore as RuntimeStubDagStore,
+    DefaultMeshNetworkService, Ed25519Signer, RuntimeContext, StubDagStore as RuntimeStubDagStore,
     StubMeshNetworkService, StubSigner as RuntimeStubSigner,
 };
 use icn_runtime::{host_anchor_receipt, host_submit_mesh_job, ReputationUpdater};
@@ -791,7 +791,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         info!("Using local libp2p networking (P2P disabled)");
-        let signer = Arc::new(RuntimeStubSigner::new_with_keys(node_sk, node_pk));
+        let signer = Arc::new(Ed25519Signer::new_with_keys(node_sk, node_pk));
         let dag_store_for_rt = match config.init_dag_store() {
             Ok(store) => store,
             Err(e) => {

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -34,6 +34,7 @@ prometheus-client = "0.22"
 clap = { version = "4.0", features = ["derive"], optional = true }
 icn-ccl = { path = "../../icn-ccl" }
 sha2 = "0.10"
+zeroize = "1.8"
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -19,7 +19,7 @@ pub mod memory;
 pub mod metrics;
 
 // Re-export important types for convenience
-pub use context::{HostAbiError, RuntimeContext, Signer};
+pub use context::{Ed25519Signer, HostAbiError, RuntimeContext, Signer};
 #[cfg(feature = "async")]
 pub use icn_dag::AsyncStorageService as StorageService;
 #[cfg(not(feature = "async"))]
@@ -88,10 +88,7 @@ pub async fn host_submit_mesh_job(
 
     // 2. Adjust cost based on the submitter's reputation and spend mana.
     let rep = ctx.reputation_store.get_reputation(&ctx.current_identity);
-    job_to_submit.cost_mana = icn_economics::price_by_reputation(
-        job_to_submit.cost_mana,
-        rep,
-    );
+    job_to_submit.cost_mana = icn_economics::price_by_reputation(job_to_submit.cost_mana, rep);
 
     ctx.spend_mana(&ctx.current_identity, job_to_submit.cost_mana)
         .await

--- a/docs/migration-signers.md
+++ b/docs/migration-signers.md
@@ -1,0 +1,5 @@
+# Signer Migration Notes
+
+RuntimeContext and the ICN node now default to `Ed25519Signer` when real libp2p networking is used. This signer keeps the private key in a `Zeroizing` wrapper to ensure the bytes are cleared on drop.
+
+The previous `StubSigner` remains for tests. Existing tests and examples that construct `StubSigner` continue to work without modification.


### PR DESCRIPTION
## Summary
- add `Ed25519Signer` with zeroizing key storage
- switch `RuntimeContext::new_with_real_libp2p` to use the real signer
- update node initialization to use `Ed25519Signer`
- document migration notes

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: compilation interrupted)*
- `cargo test --all-features` *(fails: compilation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686c0018a7b08324bfc72fec301d06e4