### PR TITLE
[dag] enable backend tests

### DIFF
--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -42,6 +42,24 @@ let store = TokioFileDagStore::new(PathBuf::from("./dag")).unwrap();
 let dag_store = Mutex::new(store); // implement AsyncStorageService
 ```
 
+## Running Persistence Tests
+
+Integration tests for each storage backend are gated by their corresponding
+`persist-*` feature. Enable the feature when running `cargo test`:
+
+```bash
+# sled backend (enabled by default)
+cargo test -p icn-dag --features persist-sled --test sled_backend
+
+# SQLite backend
+cargo test -p icn-dag --no-default-features --features persist-sqlite \
+  --test sqlite_backend
+
+# RocksDB backend
+cargo test -p icn-dag --no-default-features --features persist-rocksdb \
+  --test rocks_backend
+```
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-dag/tests/rocks_backend.rs
+++ b/crates/icn-dag/tests/rocks_backend.rs
@@ -53,7 +53,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn rocksdb_round_trip() {
         let dir = tempdir().unwrap();
         let path: PathBuf = dir.path().join("rocks");

--- a/crates/icn-dag/tests/sled_backend.rs
+++ b/crates/icn-dag/tests/sled_backend.rs
@@ -55,7 +55,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn sled_round_trip() {
         let dir = tempdir().unwrap();
         let mut store = SledDagStore::new(dir.path().to_path_buf()).unwrap();

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -85,6 +85,19 @@ Binaries will be placed in the `target/debug/` or `target/release/` directory at
     # Or just part of the name
     cargo test <partial_test_name>
     ```
+*   **Run persistence tests for DAG backends:**
+    ```bash
+    # sled backend (enabled by default)
+    cargo test -p icn-dag --features persist-sled --test sled_backend
+
+    # SQLite backend
+    cargo test -p icn-dag --no-default-features --features persist-sqlite \
+      --test sqlite_backend
+
+    # RocksDB backend
+    cargo test -p icn-dag --no-default-features --features persist-rocksdb \
+      --test rocks_backend
+    ```
 
 ### 3.3. Linting & Formatting
 


### PR DESCRIPTION
## Summary
- enable sled and rocksdb DAG backend tests
- document how to run persistence tests per backend

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: environment limitations)*
- `cargo test --all-features --workspace` *(failed: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686c001a5d1c8324985b6307797d6bd8