### PR TITLE
Enable cross-node runtime test

### DIFF
--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -23,6 +23,7 @@ mod runtime_host_abi_tests {
     use log::{debug, info};
     use std::str::FromStr;
     use std::sync::Arc;
+    use tempfile::tempdir;
     use tokio::time::{sleep, timeout, Duration};
 
     /// Helper to create a RuntimeContext with real libp2p networking
@@ -34,10 +35,20 @@ mod runtime_host_abi_tests {
         let identity_did_str = format!("did:key:z6Mkv{}", identity_name);
         let identity_did = Did::from_str(&identity_did_str)?;
 
-        let runtime_ctx =
-            RuntimeContext::new_with_libp2p_network(&identity_did_str, bootstrap_peers)
-                .await
-                .map_err(|e| anyhow::anyhow!("Failed to create runtime context: {}", e))?;
+        let tmp = tempdir()?;
+        let base = tmp.into_path();
+        let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
+
+        let runtime_ctx = RuntimeContext::new_with_real_libp2p(
+            &identity_did_str,
+            listen,
+            bootstrap_peers,
+            base.join("dag"),
+            base.join("mana"),
+            base.join("reputation"),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create runtime context: {}", e))?;
 
         // Set initial mana balance
         runtime_ctx
@@ -77,7 +88,6 @@ mod runtime_host_abi_tests {
     }
 
     #[tokio::test]
-    #[ignore = "Runtime-driven cross-node job execution using Host ABI"]
     async fn test_runtime_host_abi_cross_node_execution() -> Result<()> {
         info!("🚀 [RUNTIME-INTEGRATION] Starting Host ABI cross-node job execution test");
 


### PR DESCRIPTION
## Summary
- use `new_with_real_libp2p` in runtime cross-node test
- remove `#[ignore]` from `test_runtime_host_abi_cross_node_execution` so it runs when libp2p is enabled

## Testing
- `cargo test --features enable-libp2p -p icn-runtime --test cross_node_job_execution -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686c0027f7888324b6abc24997ddd45a