### PR TITLE
[network] enable libp2p tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,20 @@ jobs:
       - name: Build release (nightly only, for early detection of issues)
         if: matrix.rust == 'nightly'
         run: cargo build --release --all-features --workspace
+
+  libp2p_tests:
+    name: Libp2p Feature Tests
+    needs: test_and_lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - name: Run libp2p tests
+        run: cargo test -p icn-network --features libp2p

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -610,13 +610,11 @@ mod tests {
         let block_x_path = store2.block_path(&block_x.cid);
 
         // Corrupt the stored CID to simulate a mismatch
-        let mut file_contents = tokio::fs::read_to_string(&block_x_path).await.unwrap();
+        let mut file_contents = fs::read_to_string(&block_x_path).await.unwrap();
         let mut corrupted_block: DagBlock = serde_json::from_str(&file_contents).unwrap();
         corrupted_block.cid.hash_bytes[0] ^= 0xFF;
         file_contents = serde_json::to_string(&corrupted_block).unwrap();
-        tokio::fs::write(&block_x_path, file_contents)
-            .await
-            .unwrap();
+        fs::write(&block_x_path, file_contents).await.unwrap();
 
         match store2.get(&block_x.cid).await {
             Err(CommonError::InvalidInputError(msg)) => {

--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -89,7 +89,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test]
-    #[ignore = "Testing libp2p event loop debugging with comprehensive logging"]
     async fn test_minimal_gossipsub_connectivity() -> Result<(), anyhow::Error> {
         // Initialize logging (safe for multiple test calls)
         init_test_logger();
@@ -283,7 +282,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test]
-    #[ignore = "Enhanced job announcement test with proper network readiness checks"]
     async fn test_job_announcement_and_bid_submission() -> Result<(), anyhow::Error> {
         init_test_logger();
         println!("🔧 [test-mesh-network] Setting up Node A (Job Originator).");
@@ -612,7 +610,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test]
-    #[ignore = "Complete cross-node job execution pipeline test - REFACTORED"]
     async fn test_full_job_execution_pipeline_refactored() -> Result<()> {
         init_test_logger();
         info!("🚀 [PIPELINE-REFACTORED] Starting complete cross-node job execution pipeline test (using utilities)");


### PR DESCRIPTION
## Summary
- unignore libp2p integration tests
- patch async DAG test usage
- run libp2p integration tests in CI

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed)*
- `cargo test --all-features --workspace` *(failed)*
- `cargo test -p icn-ccl` *(failed)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*
- `cargo test -p icn-network --features libp2p` *(failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c002980e0832494e5d5341fc5c55f