### PR TITLE
[docs] add libp2p integration test instructions

### DIFF
--- a/MULTI_NODE_GUIDE.md
+++ b/MULTI_NODE_GUIDE.md
@@ -177,6 +177,24 @@ Planned features include:
   * `make localnet-start NODES=3`
   * `make localnet-stop`
   * `make localnet-logs NODE_ID=1`
+## Libp2p Integration Tests
+
+To verify cross-node job announcements, bidding, and the runtime pipeline you can run the workspace tests with libp2p enabled.
+
+1. **Build the full workspace** with libp2p support:
+
+```bash
+cargo build --workspace --features with-libp2p
+```
+
+2. **Run integration tests** that exercise multi-node messaging and execution:
+
+```bash
+cargo test --features enable-libp2p --workspace
+```
+
+Set `RUST_LOG=info` to see verbose logs. Tests that interact with the containerized devnet check the `ICN_DEVNET_RUNNING` environment variable. If it is unset, the test harness will automatically start `icn-devnet/launch_federation.sh`.
+
 
 ## Roadmap for Multi-Node Networking
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ rustup component add rustfmt
 4. Use `--storage-backend sqlite` or `file` with a dedicated `--storage-path` to
    persist DAG blocks and governance state across restarts.
 
+For multi-node testing instructions, see [Libp2p Integration Tests](MULTI_NODE_GUIDE.md#libp2p-integration-tests).
+
+
 ## Error Handling Philosophy
 
 This project prioritizes robust and clear error handling to improve developer experience and system reliability:


### PR DESCRIPTION
## Summary
- document how to build the workspace with `with-libp2p`
- explain running integration tests for job announcements, bidding and runtime pipeline
- note environment variables for these tests
- link new section from README

## Testing
- `cargo fmt --all -- --check` *(fails: diff output shown)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused import in icn-dag)*
- `cargo test --all-features --workspace --no-run` *(incomplete due to compile time)*

------
https://chatgpt.com/codex/tasks/task_e_686c002a13f48324afcbaa13f26aca91