### PR TITLE
Add DAG integrity checker

### DIFF
--- a/crates/icn-dag/src/rocksdb_store.rs
+++ b/crates/icn-dag/src/rocksdb_store.rs
@@ -69,4 +69,27 @@ impl StorageService<DagBlock> for RocksDagStore {
         })?;
         Ok(result.is_some())
     }
+
+    fn list_blocks(&self) -> Result<Vec<DagBlock>, CommonError> {
+        use rocksdb::IteratorMode;
+        let mut blocks = Vec::new();
+        for item in self.db.iterator(IteratorMode::Start) {
+            let (_key, val) = item.map_err(|e| {
+                CommonError::DatabaseError(format!("Iteration error: {}", e))
+            })?;
+            let block: DagBlock = bincode::deserialize(&val).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
+            })?;
+            blocks.push(block);
+        }
+        Ok(blocks)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
 }

--- a/crates/icn-dag/src/sled_store.rs
+++ b/crates/icn-dag/src/sled_store.rs
@@ -90,4 +90,27 @@ impl StorageService<DagBlock> for SledDagStore {
         })?;
         Ok(exists)
     }
+
+    fn list_blocks(&self) -> Result<Vec<DagBlock>, CommonError> {
+        let tree = self.tree()?;
+        let mut blocks = Vec::new();
+        for item in tree.iter() {
+            let (_, val) = item.map_err(|e| {
+                CommonError::DatabaseError(format!("Iteration error: {}", e))
+            })?;
+            let block: DagBlock = bincode::deserialize(&val).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
+            })?;
+            blocks.push(block);
+        }
+        Ok(blocks)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
 }

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -101,6 +101,13 @@ async fn finalize_proposal(ctx: &RuntimeContext, pid: &str) -> Result<(), icn_ru
 `spawn_mana_regenerator` to start a background task that credits every
 account with a fixed amount on a configurable interval.
 
+## DAG Integrity Checker
+
+To detect storage corruption, call `spawn_integrity_checker` with a check
+interval. The task runs `icn_dag::verify_all` over the configured DAG store
+and logs an error if verification fails. You may adjust the interval and
+implement a custom repair strategy if desired.
+
 ## DAG Storage
 
 `RuntimeContext` selects a storage backend for receipts and other DAG data. When

--- a/crates/icn-runtime/tests/integrity_checker.rs
+++ b/crates/icn-runtime/tests/integrity_checker.rs
@@ -1,0 +1,45 @@
+use icn_runtime::context::RuntimeContext;
+use icn_common::{compute_merkle_cid, DagBlock, Did};
+
+fn create_block(id: &str) -> DagBlock {
+    let data = format!("data {id}").into_bytes();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig = None;
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig, &None);
+    DagBlock {
+        cid,
+        data,
+        links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig,
+        scope: None,
+    }
+}
+
+#[tokio::test]
+async fn integrity_checker_detects_corruption() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:intcheck", 0).unwrap();
+    let block = create_block("good");
+    {
+        let mut store = ctx.dag_store.lock().await;
+        #[cfg(feature = "async")]
+        store.put(&block).await.unwrap();
+        #[cfg(not(feature = "async"))]
+        store.put(&block).unwrap();
+    }
+    assert!(ctx.integrity_check_once().await.is_ok());
+    {
+        let mut store = ctx.dag_store.lock().await;
+        let stub = store
+            .as_any_mut()
+            .downcast_mut::<icn_runtime::context::StubDagStore>()
+            .unwrap();
+        if let Some(b) = stub.get_mut(&block.cid) {
+            b.data[0] ^= 0xFF;
+        }
+    }
+    let result = ctx.integrity_check_once().await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- verify stored DAG data via `icn_dag::verify_all`
- spawn a runtime integrity checker task
- test detection of corrupted blocks
- document checker configuration

## Testing
- `cargo test -p icn-runtime --test integrity_checker --quiet`
- `cargo check -p icn-dag --quiet`
- `cargo test -p icn-dag --quiet` *(fails: timed out / not run)*

------
https://chatgpt.com/codex/tasks/task_e_686c002e4b508324bbf665b7d8739ba4