### PR TITLE
Add DAG backup guide

### DIFF
--- a/.cursor/rules/troubleshooting.mdc
+++ b/.cursor/rules/troubleshooting.mdc
@@ -239,6 +239,8 @@ icn-cli dag repair --block <block-id>
 # Backup and restore
 icn-cli dag backup --path ./dag-backup
 icn-cli dag restore --path ./dag-backup
+# Detailed instructions:
+# [DAG Backup and Restore](../../docs/deployment-guide.md#dag-backup-and-restore)
 ```
 
 ### Performance Issues

--- a/PHASE_5_EXECUTION_PLAN.md
+++ b/PHASE_5_EXECUTION_PLAN.md
@@ -251,7 +251,7 @@ where
 - [ ] ✅ Monitoring runbook and alert response procedures
 - [ ] ✅ Security audit and penetration testing report
 - [ ] ✅ Performance benchmarking results
-- [ ] ✅ Disaster recovery and backup procedures
+- [ ] ✅ Disaster recovery and backup procedures ([DAG backup docs](docs/deployment-guide.md#dag-backup-and-restore))
 
 ---
 
@@ -284,7 +284,7 @@ where
 ### **Technical Risks**
 1. **Performance Degradation**: Replace stubs incrementally, benchmark each change
 2. **Security Vulnerabilities**: Security review for each major component
-3. **Data Loss**: Implement backup/restore before persistence changes
+3. **Data Loss**: Implement backup/restore before persistence changes. See the [DAG Backup and Restore guide](docs/deployment-guide.md#dag-backup-and-restore).
 4. **Network Partitions**: Test split-brain scenarios extensively
 
 ### **Project Risks**

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -53,3 +53,51 @@ api_key = "node1secret"
 tls_cert_path = "./cert.pem"
 tls_key_path = "./key.pem"
 ```
+
+## DAG Backup and Restore
+
+Use `icn-cli` to export and re-import the node's DAG storage. The same commands
+work with any storage backend. After restoring, run `icn-cli dag verify` to
+confirm integrity.
+
+### RocksDB
+
+```bash
+# Node configured with RocksDB
+icn-node --storage-backend rocksdb --storage-path ./icn_data/rocksdb
+
+# Backup DAG data
+icn-cli dag backup --path ./backups/rocksdb
+
+# Restore and verify
+icn-cli dag restore --path ./backups/rocksdb
+icn-cli dag verify
+```
+
+### Sled
+
+```bash
+# Node configured with Sled
+icn-node --storage-backend sled --storage-path ./icn_data/node1.sled
+
+# Backup DAG data
+icn-cli dag backup --path ./backups/sled
+
+# Restore and verify
+icn-cli dag restore --path ./backups/sled
+icn-cli dag verify
+```
+
+### SQLite
+
+```bash
+# Node configured with SQLite
+icn-node --storage-backend sqlite --storage-path ./icn_data/dag.sqlite
+
+# Backup DAG data
+icn-cli dag backup --path ./backups/sqlite
+
+# Restore and verify
+icn-cli dag restore --path ./backups/sqlite
+icn-cli dag verify
+```

--- a/icn-devnet/README.md
+++ b/icn-devnet/README.md
@@ -215,6 +215,8 @@ curl http://localhost:5001/mesh/jobs/$job_id
 - Check Dockerfile dependencies
 - Clear Docker build cache: `docker system prune -a`
 
+For persistent deployments see the [DAG Backup and Restore guide](../docs/deployment-guide.md#dag-backup-and-restore).
+
 ### Logs
 
 ```bash


### PR DESCRIPTION
## Summary
- document DAG backup and restore commands in `docs/deployment-guide.md`
- link new section from phase plan and troubleshooting docs
- cross reference backup guide from devnet troubleshooting

## Testing
- `just validate` *(fails: recipe `format`)*
- `cargo test --workspace --all-features` *(fails to compile `icn-runtime` tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c002e7728832491742605b659b09e