### PR TITLE
Add DAG backup and verification utilities

### DIFF
--- a/crates/icn-dag/src/rocksdb_store.rs
+++ b/crates/icn-dag/src/rocksdb_store.rs
@@ -69,4 +69,18 @@ impl StorageService<DagBlock> for RocksDagStore {
         })?;
         Ok(result.is_some())
     }
+
+    fn iter(&self) -> Result<Vec<DagBlock>, CommonError> {
+        use rocksdb::IteratorMode;
+        let mut blocks = Vec::new();
+        for item in self.db.iterator(IteratorMode::Start) {
+            let (_k, v) =
+                item.map_err(|e| CommonError::DatabaseError(format!("Iteration error: {}", e)))?;
+            let block: DagBlock = bincode::deserialize(&v).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
+            })?;
+            blocks.push(block);
+        }
+        Ok(blocks)
+    }
 }

--- a/crates/icn-dag/src/sled_store.rs
+++ b/crates/icn-dag/src/sled_store.rs
@@ -90,4 +90,18 @@ impl StorageService<DagBlock> for SledDagStore {
         })?;
         Ok(exists)
     }
+
+    fn iter(&self) -> Result<Vec<DagBlock>, CommonError> {
+        let tree = self.tree()?;
+        let mut blocks = Vec::new();
+        for item in tree.iter() {
+            let (_k, v) =
+                item.map_err(|e| CommonError::DatabaseError(format!("Failed to iterate: {}", e)))?;
+            let block: DagBlock = bincode::deserialize(&v).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
+            })?;
+            blocks.push(block);
+        }
+        Ok(blocks)
+    }
 }


### PR DESCRIPTION
## Summary
- add iteration support to `StorageService` and `AsyncStorageService`
- implement `iter` for all storage backends
- add `backup`, `restore`, and `verify_all` utilities with async versions
- test backup/restore/verify flow

## Testing
- `cargo fmt --all`
- ❌ `cargo clippy --all-targets --all-features -- -D warnings` *(failed: command timed out)*
- ❌ `cargo test --all-features --workspace` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686c00309ad88324b0268e831394c9d1