### PR TITLE
[icn-runtime] Add Ed25519 signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-node mesh job execution pipeline with signed receipts anchored to the DAG.
 - HTTP gateway enabling REST job submission and status queries.
 - Containerized 3-node federation devnet with Docker and integration tests.
+- `Ed25519Signer` replaces `StubSigner` for production runtime; tests may continue using `StubSigner`.
 
 ### Changed
 

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -37,7 +37,7 @@ use icn_protocol::{
 };
 use icn_protocol::{MessagePayload, ProtocolMessage};
 use icn_runtime::context::{
-    DefaultMeshNetworkService, RuntimeContext, StubMeshNetworkService,
+    DefaultMeshNetworkService, Ed25519Signer, RuntimeContext, StubMeshNetworkService,
     StubSigner as RuntimeStubSigner,
 };
 use icn_runtime::{host_anchor_receipt, host_submit_mesh_job, ReputationUpdater};
@@ -791,7 +791,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         info!("Using local libp2p networking (P2P disabled)");
-        let signer = Arc::new(RuntimeStubSigner::new_with_keys(node_sk, node_pk));
+        let signer = Arc::new(Ed25519Signer::new_with_keys(node_sk, node_pk));
         let dag_store_for_rt = match config.init_dag_store() {
             Ok(store) => store,
             Err(e) => {

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -61,6 +61,7 @@ use icn_identity::{
     SIGNATURE_LENGTH,
 };
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 // Counter for generating unique (within this runtime instance) job IDs for stubs
 pub static NEXT_JOB_ID: AtomicU32 = AtomicU32::new(1);
@@ -1763,7 +1764,7 @@ impl RuntimeContext {
 
         // Generate keys for this node
         let (sk, pk) = generate_ed25519_keypair();
-        let signer = Arc::new(StubSigner::new_with_keys(sk, pk));
+        let signer = Arc::new(Ed25519Signer::new_with_keys(sk, pk));
 
         // Create real libp2p network service with proper config
         let mut config = NetworkConfig {
@@ -2107,6 +2108,90 @@ impl Signer for StubSigner {
     fn did(&self) -> Did {
         // Assuming self.did_string is a valid DID string like "did:key:z..."
         Did::from_str(&self.did_string).expect("Failed to parse internally generated DID string")
+    }
+
+    fn verifying_key_ref(&self) -> &VerifyingKey {
+        &self.pk
+    }
+}
+
+/// Production signer using an Ed25519 keypair with memory zeroization.
+#[derive(Debug)]
+pub struct Ed25519Signer {
+    sk: Zeroizing<SigningKey>,
+    pk: VerifyingKey,
+    did: Did,
+}
+
+impl Ed25519Signer {
+    /// Create a signer from an Ed25519 [`SigningKey`].
+    pub fn new(sk: SigningKey) -> Self {
+        let pk = sk.verifying_key();
+        let did = Did::from_str(&did_key_from_verifying_key(&pk))
+            .expect("Failed to construct DID from verifying key");
+        Self {
+            sk: Zeroizing::new(sk),
+            pk,
+            did,
+        }
+    }
+
+    /// Create from a precomputed keypair.
+    pub fn new_with_keys(sk: SigningKey, pk: VerifyingKey) -> Self {
+        let did = Did::from_str(&did_key_from_verifying_key(&pk))
+            .expect("Failed to construct DID from verifying key");
+        Self {
+            sk: Zeroizing::new(sk),
+            pk,
+            did,
+        }
+    }
+
+    /// Expose verifying key reference.
+    pub fn verifying_key_ref(&self) -> &VerifyingKey {
+        &self.pk
+    }
+}
+
+impl Signer for Ed25519Signer {
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, HostAbiError> {
+        Ok(sign_message(&self.sk, payload).to_bytes().to_vec())
+    }
+
+    fn verify(
+        &self,
+        payload: &[u8],
+        signature_bytes: &[u8],
+        public_key_bytes: &[u8],
+    ) -> Result<bool, HostAbiError> {
+        let pk_array: [u8; 32] = public_key_bytes.try_into().map_err(|_| {
+            HostAbiError::InvalidParameters("Public key bytes not 32 bytes long".to_string())
+        })?;
+        let verifying_key = VerifyingKey::from_bytes(&pk_array).map_err(|e| {
+            HostAbiError::CryptoError(format!("Failed to create verifying key: {e}"))
+        })?;
+
+        let signature_array: [u8; SIGNATURE_LENGTH] = signature_bytes.try_into().map_err(|_| {
+            HostAbiError::InvalidParameters(format!(
+                "Signature not {} bytes long",
+                SIGNATURE_LENGTH
+            ))
+        })?;
+        let signature = EdSignature::from_bytes(&signature_array);
+
+        Ok(identity_verify_signature(
+            &verifying_key,
+            payload,
+            &signature,
+        ))
+    }
+
+    fn public_key_bytes(&self) -> Vec<u8> {
+        self.pk.as_bytes().to_vec()
+    }
+
+    fn did(&self) -> Did {
+        self.did.clone()
     }
 
     fn verifying_key_ref(&self) -> &VerifyingKey {

--- a/docs/secure_signer_migration.md
+++ b/docs/secure_signer_migration.md
@@ -1,0 +1,9 @@
+# Migrating from `StubSigner`
+
+`RuntimeContext::new_with_real_libp2p` and the default node startup now use
+`Ed25519Signer` which performs real cryptographic signing and zeroizes the
+private key on drop. Tests relying on `StubSigner` continue to work because the
+stub type is still available under `icn_runtime::context::StubSigner`.
+
+For existing tests simply keep constructing `StubSigner` directly. Production
+code should prefer `Ed25519Signer`.


### PR DESCRIPTION
## Summary
- implement `Ed25519Signer` that zeroizes the private key
- use the new signer in `RuntimeContext::new_with_real_libp2p`
- initialize nodes with `Ed25519Signer`
- document migration steps from `StubSigner`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation timed out)*
- `cargo test --all-features` *(failed: compilation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686c08c9a794832494aade2644505e38