### PR TITLE
Add membership governance tests

### DIFF
--- a/crates/icn-api/src/governance_trait.rs
+++ b/crates/icn-api/src/governance_trait.rs
@@ -16,11 +16,24 @@ pub struct CastVoteRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)] // Added Clone
 #[serde(tag = "type", content = "data")]
 pub enum ProposalInputType {
-    SystemParameterChange { param: String, value: String },
-    MemberAdmission { did: String },
-    SoftwareUpgrade { version: String }, // Matches ProposalType more closely
-    GenericText { text: String },        // Matches ProposalType more closely
-                                         // Add more as needed
+    SystemParameterChange {
+        param: String,
+        value: String,
+    },
+    MemberAdmission {
+        did: String,
+    },
+    /// Remove an existing member from the cooperative
+    RemoveMember {
+        did: String,
+    },
+    SoftwareUpgrade {
+        version: String,
+    }, // Matches ProposalType more closely
+    GenericText {
+        text: String,
+    }, // Matches ProposalType more closely
+       // Add more as needed
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)] // Added Clone

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -253,6 +253,15 @@ impl GovernanceApi for GovernanceApiImpl {
                 })?;
                 ProposalType::NewMemberInvitation(member_did)
             }
+            ProposalInputType::RemoveMember { did } => {
+                let member_did = Did::from_str(&did).map_err(|e| {
+                    CommonError::InvalidInputError(format!(
+                        "Invalid member DID format for removal: {}. Error: {:?}",
+                        did, e
+                    ))
+                })?;
+                ProposalType::RemoveMember(member_did)
+            }
             ProposalInputType::SoftwareUpgrade { version } => {
                 ProposalType::SoftwareUpgrade(version)
             }

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1261,6 +1261,9 @@ async fn gov_submit_handler(
         icn_api::governance_trait::ProposalInputType::MemberAdmission { did } => {
             ("MemberAdmission".to_string(), did.into_bytes())
         }
+        icn_api::governance_trait::ProposalInputType::RemoveMember { did } => {
+            ("RemoveMember".to_string(), did.into_bytes())
+        }
         icn_api::governance_trait::ProposalInputType::SoftwareUpgrade { version } => {
             ("SoftwareUpgrade".to_string(), version.into_bytes())
         }

--- a/crates/icn-node/tests/governance_membership.rs
+++ b/crates/icn-node/tests/governance_membership.rs
@@ -1,0 +1,134 @@
+use icn_api::governance_trait::{CastVoteRequest, ProposalInputType, SubmitProposalRequest};
+use icn_common::Did;
+use icn_governance::{ProposalId, ProposalStatus};
+use icn_node::app_router_with_options;
+use reqwest::Client;
+use std::str::FromStr;
+use tokio::task;
+
+#[tokio::test]
+async fn add_and_remove_member_via_http() {
+    let (router, ctx) =
+        app_router_with_options(None, None, None, None, None, None, None, None, None).await;
+    let node_did = ctx.current_identity.clone();
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.add_member(node_did.clone());
+        gov.add_member(Did::from_str("did:example:alice").unwrap());
+        gov.set_quorum(1);
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let client = Client::new();
+    let new_member = "did:example:bob";
+    let submit_req = SubmitProposalRequest {
+        proposer_did: "did:example:alice".into(),
+        proposal: ProposalInputType::MemberAdmission {
+            did: new_member.into(),
+        },
+        description: "invite bob".into(),
+        duration_secs: 60,
+        quorum: None,
+        threshold: None,
+    };
+    let resp = client
+        .post(format!("http://{addr}/governance/submit"))
+        .json(&submit_req)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+    let pid: String = resp.json().await.unwrap();
+    let pid_struct = ProposalId(pid.clone());
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.open_voting(&pid_struct).unwrap();
+    }
+
+    let vote_req = CastVoteRequest {
+        voter_did: node_did.to_string(),
+        proposal_id: pid.clone(),
+        vote_option: "yes".into(),
+    };
+    let vresp = client
+        .post(format!("http://{addr}/governance/vote"))
+        .json(&vote_req)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(vresp.status(), reqwest::StatusCode::OK);
+
+    let close_resp = client
+        .post(format!("http://{addr}/governance/close"))
+        .json(&serde_json::json!({"proposal_id": pid.clone()}))
+        .send()
+        .await
+        .unwrap();
+    assert!(close_resp.status().is_success());
+
+    {
+        let gov = ctx.governance_module.lock().await;
+        assert!(gov.members().contains(&Did::from_str(new_member).unwrap()));
+        let prop = gov.get_proposal(&pid_struct).unwrap().unwrap();
+        assert_eq!(prop.status, ProposalStatus::Executed);
+    }
+
+    // Now test removal
+    let remove_req = SubmitProposalRequest {
+        proposer_did: "did:example:alice".into(),
+        proposal: ProposalInputType::RemoveMember {
+            did: new_member.into(),
+        },
+        description: "remove bob".into(),
+        duration_secs: 60,
+        quorum: None,
+        threshold: None,
+    };
+    let resp = client
+        .post(format!("http://{addr}/governance/submit"))
+        .json(&remove_req)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+    let rpid: String = resp.json().await.unwrap();
+    let rpid_struct = ProposalId(rpid.clone());
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.open_voting(&rpid_struct).unwrap();
+    }
+
+    let vresp = client
+        .post(format!("http://{addr}/governance/vote"))
+        .json(&CastVoteRequest {
+            voter_did: node_did.to_string(),
+            proposal_id: rpid.clone(),
+            vote_option: "yes".into(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(vresp.status(), reqwest::StatusCode::OK);
+
+    let close_resp = client
+        .post(format!("http://{addr}/governance/close"))
+        .json(&serde_json::json!({"proposal_id": rpid}))
+        .send()
+        .await
+        .unwrap();
+    assert!(close_resp.status().is_success());
+
+    {
+        let gov = ctx.governance_module.lock().await;
+        assert!(!gov.members().contains(&Did::from_str(new_member).unwrap()));
+        let prop = gov.get_proposal(&rpid_struct).unwrap().unwrap();
+        assert_eq!(prop.status, ProposalStatus::Executed);
+    }
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- allow RemoveMember proposals via API
- expose RemoveMember in node router
- test new-member and removal proposals via HTTP

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build timeout)*
- `cargo test --workspace --all-features` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686c0c01772c83248c59f47633261174