### PR TITLE
Persist system parameters

### DIFF
--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -581,4 +581,14 @@ impl NodeConfig {
         };
         Ok(store)
     }
+
+    /// Persist this configuration to the given path in TOML format.
+    pub fn save_to_file(&self, path: &std::path::Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let toml_str = toml::to_string_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+        std::fs::write(path, toml_str)
+    }
 }

--- a/crates/icn-node/src/lib.rs
+++ b/crates/icn-node/src/lib.rs
@@ -4,4 +4,5 @@
 #![allow(special_module_name)]
 pub mod config;
 pub mod node;
+pub mod parameter_store;
 pub use node::{app_router, app_router_with_options, run_node};

--- a/crates/icn-node/src/parameter_store.rs
+++ b/crates/icn-node/src/parameter_store.rs
@@ -1,0 +1,57 @@
+use crate::config::NodeConfig;
+use icn_common::CommonError;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub struct ParameterStore {
+    path: PathBuf,
+    config: NodeConfig,
+}
+
+impl ParameterStore {
+    /// Load parameters from the given file path. If the file does not exist,
+    /// defaults are used.
+    pub fn load(path: PathBuf) -> Result<Self, CommonError> {
+        let config = if path.exists() {
+            NodeConfig::from_file(&path).map_err(|e| {
+                CommonError::ConfigError(format!("Failed to load parameter file: {e}"))
+            })?
+        } else {
+            NodeConfig::default()
+        };
+        Ok(Self { path, config })
+    }
+
+    pub fn open_rate_limit(&self) -> u64 {
+        self.config.open_rate_limit
+    }
+
+    /// Update a parameter and persist changes to disk.
+    pub fn set_parameter(&mut self, key: &str, value: &str) -> Result<(), CommonError> {
+        match key {
+            "open_rate_limit" => {
+                let val = value
+                    .parse::<u64>()
+                    .map_err(|e| CommonError::InvalidInputError(e.to_string()))?;
+                self.config.open_rate_limit = val;
+                self.save()?;
+                Ok(())
+            }
+            _ => Err(CommonError::InvalidInputError(format!(
+                "Unknown parameter {key}"
+            ))),
+        }
+    }
+
+    pub fn save(&self) -> Result<(), CommonError> {
+        self.config
+            .save_to_file(&self.path)
+            .map_err(|e| CommonError::IoError(e.to_string()))
+    }
+}
+
+impl ParameterStore {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}

--- a/crates/icn-node/tests/auth.rs
+++ b/crates/icn-node/tests/auth.rs
@@ -17,6 +17,9 @@ async fn api_key_required_for_requests() {
         None,
         None,
         None,
+        None,
+        None,
+        None,
     )
     .await;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -56,6 +59,7 @@ async fn bearer_token_required_for_requests() {
     let (router, _ctx) = app_router_with_options(
         None,
         Some("s3cr3t".into()),
+        None,
         None,
         None,
         None,
@@ -111,6 +115,7 @@ async fn tls_api_key_and_bearer_token() {
     let (router, _ctx) = app_router_with_options(
         Some("secret".into()),
         Some("token".into()),
+        None,
         None,
         None,
         None,

--- a/crates/icn-node/tests/dag_persistence.rs
+++ b/crates/icn-node/tests/dag_persistence.rs
@@ -22,6 +22,7 @@ async fn dag_persists_between_restarts_sled() {
         Some(dag_path.clone()),
         None,
         None,
+        None,
     )
     .await;
 
@@ -53,6 +54,7 @@ async fn dag_persists_between_restarts_sled() {
         Some(ledger_path.clone()),
         Some(StorageBackendType::Sled),
         Some(dag_path.clone()),
+        None,
         None,
         None,
     )

--- a/crates/icn-node/tests/governance.rs
+++ b/crates/icn-node/tests/governance.rs
@@ -9,7 +9,7 @@ use tokio::task;
 #[tokio::test]
 async fn submit_and_vote_proposal() {
     let (router, ctx) =
-        app_router_with_options(None, None, None, None, None, None, None, None, None).await;
+        app_router_with_options(None, None, None, None, None, None, None, None, None, None).await;
     {
         let mut gov = ctx.governance_module.lock().await;
         gov.add_member(Did::from_str("did:example:alice").unwrap());

--- a/crates/icn-node/tests/ledger.rs
+++ b/crates/icn-node/tests/ledger.rs
@@ -19,6 +19,7 @@ async fn ledger_persists_between_restarts() {
         None,
         None,
         None,
+        None,
     )
     .await;
     let did = Did::from_str("did:example:alice").unwrap();
@@ -32,6 +33,7 @@ async fn ledger_persists_between_restarts() {
         None,
         None,
         Some(ledger_path.clone()),
+        None,
         None,
         None,
         None,

--- a/crates/icn-node/tests/reputation.rs
+++ b/crates/icn-node/tests/reputation.rs
@@ -20,6 +20,7 @@ async fn reputation_persists_between_restarts() {
         None,
         Some(rep_path.clone()),
         None,
+        None,
     )
     .await;
     let did = Did::from_str("did:example:alice").unwrap();
@@ -36,6 +37,7 @@ async fn reputation_persists_between_restarts() {
         None,
         None,
         Some(rep_path.clone()),
+        None,
         None,
     )
     .await;


### PR DESCRIPTION
## Summary
- add `ParameterStore` for persisting mutable node parameters
- write configuration to disk whenever parameters change
- load stored parameters during startup
- update governance callback to persist system parameter updates
- test parameter persistence across restarts

## Testing
- `cargo test --all-features --workspace` *(fails: compilation did not finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_686c0c0193d0832481203c17d9af74ad