### PR TITLE
[devnet] add alertmanager integration

### DIFF
--- a/icn-devnet/README.md
+++ b/icn-devnet/README.md
@@ -77,6 +77,7 @@ curl http://localhost:5001/mesh/jobs
 - **ICN Nodes**: 3 containerized nodes with HTTP APIs and P2P networking
 - **Prometheus**: Metrics collection (optional, with `--profile monitoring`)
 - **Grafana**: Dashboard visualization (optional, with `--profile monitoring`)
+- **Alertmanager**: Alert routing (optional, with `--profile monitoring`)
 
 ## 📋 Configuration
 
@@ -105,6 +106,7 @@ Each node is configured via environment variables:
 | Node C P2P | 4003 | 4001 | libp2p networking |
 | Prometheus | 9090 | 9090 | Metrics (optional) |
 | Grafana | 3000 | 3000 | Dashboard (optional) |
+| Alertmanager | 9093 | 9093 | Alert routing (optional) |
 
 ### Example `docker-compose.yml`
 
@@ -151,13 +153,18 @@ docker-compose down --volumes --remove-orphans
 ### With Monitoring
 
 ```bash
-# Start with Prometheus and Grafana
+# Start with Prometheus, Grafana, and Alertmanager
 docker-compose --profile monitoring up -d
 
 # Access monitoring
 # Prometheus: http://localhost:9090
 # Grafana: http://localhost:3000 (admin/icnfederation)
+# Alertmanager: http://localhost:9093
 ```
+
+The default Alertmanager configuration sends emails to
+`alerts@intercooperative.network`. Modify `alertmanager.yml` to customize
+receivers or routing rules.
 
 ### Development Mode
 

--- a/icn-devnet/alert.rules.yml
+++ b/icn-devnet/alert.rules.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: icn-example
+    rules:
+      - alert: FederationNodeDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "ICN node down"
+          description: "The node {{ $labels.instance }} has no heartbeat for 1 minute."

--- a/icn-devnet/alertmanager.yml
+++ b/icn-devnet/alertmanager.yml
@@ -1,0 +1,14 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: icn-alerts
+  group_by: ['alertname', 'instance']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+
+receivers:
+  - name: icn-alerts
+    email_configs:
+      - to: alerts@intercooperative.network

--- a/icn-devnet/docker-compose.yml
+++ b/icn-devnet/docker-compose.yml
@@ -114,6 +114,20 @@ services:
       - icn-federation
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./alert.rules.yml:/etc/prometheus/alert.rules.yml
+    profiles:
+      - monitoring
+
+  # Optional: Alertmanager for routing alerts
+  alertmanager:
+    image: prom/alertmanager:latest
+    container_name: icn-alertmanager
+    ports:
+      - "9093:9093"
+    networks:
+      - icn-federation
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml
     profiles:
       - monitoring
 

--- a/icn-devnet/prometheus.yml
+++ b/icn-devnet/prometheus.yml
@@ -2,6 +2,15 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - 'alertmanager:9093'
+
+rule_files:
+  - alert.rules.yml
+
 scrape_configs:
   - job_name: 'icn-federation'
     static_configs:


### PR DESCRIPTION
## Summary
- create `alertmanager.yml` with email routing
- provide example alert rule file
- integrate Alertmanager container in `docker-compose.yml`
- update Prometheus config to send alerts
- document alert setup and contacts in devnet README

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: unresolved imports in icn-api, icn-runtime, etc.)*
- `cargo test --all-features --workspace` *(interrupted due to long build time)*
- `cargo test -p icn-ccl` *(failed: unresolved import `zeroize`)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c0e32440c8324821e43f7d893f28f