### PR TITLE
Update metrics docs to use prometheus_client

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -270,12 +270,17 @@ error!("Critical failures");
 
 ### Metrics Collection
 ```rust
-// Use metrics for performance tracking
-use metrics::{counter, histogram, gauge};
+// Use prometheus_client for performance tracking
+use once_cell::sync::Lazy;
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
 
-counter!("mesh.jobs.submitted").increment(1);
-histogram!("mesh.job.execution_time").record(duration);
-gauge!("mesh.pending_jobs").set(pending_count as f64);
+static JOBS_SUBMITTED: Lazy<Counter> = Lazy::new(Counter::default);
+static JOB_EXEC_TIME: Lazy<Histogram> = Lazy::new(Histogram::default);
+static PENDING_JOBS: Lazy<Gauge<f64>> = Lazy::new(Gauge::default);
+
+JOBS_SUBMITTED.inc();
+JOB_EXEC_TIME.observe(duration.as_secs_f64());
+PENDING_JOBS.set(pending_count as f64);
 ```
 
 ---

--- a/.cursor/rules/troubleshooting.mdc
+++ b/.cursor/rules/troubleshooting.mdc
@@ -559,25 +559,31 @@ impl HealthChecker {
 ### Metrics Collection
 ```rust
 // Structured metrics for monitoring
-use metrics::{counter, histogram, gauge};
+use once_cell::sync::Lazy;
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
 
 pub struct ICNMetrics;
 
+static JOB_SUBMITTED: Lazy<Counter> = Lazy::new(Counter::default);
+static JOB_DURATION: Lazy<Histogram> = Lazy::new(Histogram::default);
+static MANA_BALANCE: Lazy<Gauge<f64>> = Lazy::new(Gauge::default);
+static NETWORK_PEERS: Lazy<Gauge<f64>> = Lazy::new(Gauge::default);
+
 impl ICNMetrics {
     pub fn record_job_submitted() {
-        counter!("icn.jobs.submitted").increment(1);
+        JOB_SUBMITTED.inc();
     }
-    
+
     pub fn record_job_duration(duration: Duration) {
-        histogram!("icn.job.duration").record(duration.as_secs_f64());
+        JOB_DURATION.observe(duration.as_secs_f64());
     }
-    
-    pub fn record_mana_balance(did: &Did, balance: u64) {
-        gauge!("icn.mana.balance", "did" => did.to_string()).set(balance as f64);
+
+    pub fn record_mana_balance(balance: u64) {
+        MANA_BALANCE.set(balance as f64);
     }
-    
+
     pub fn record_network_peers(count: usize) {
-        gauge!("icn.network.peer_count").set(count as f64);
+        NETWORK_PEERS.set(count as f64);
     }
 }
 ```


### PR DESCRIPTION
## Summary
- use `prometheus_client` examples instead of `metrics` macros in dev workflow
- update troubleshooting guide metrics snippet
- refresh execution plan metrics section

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test --all-features --workspace` *(failed: build errors)*
- `cargo test -p icn-ccl` *(failed: build errors)*


------
https://chatgpt.com/codex/tasks/task_e_686c0e3131e08324a497236f25a3e25e