### PR TITLE
Add Prometheus metrics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ rustup component add rustfmt
 
 For multi-node testing instructions, see [Libp2p Integration Tests](MULTI_NODE_GUIDE.md#libp2p-integration-tests).
 
+### Metrics & Observability
+
+ICN crates expose Prometheus metrics using the `prometheus-client` crate. When
+running `icn-node` with the embedded HTTP server enabled, scrape metrics at the
+`/metrics` endpoint. Counters such as `host_submit_mesh_job_calls` and gauges for
+network latency are collected automatically.
+
 ## ICN Philosophy & Design Principles
 
 ### **Core Values**


### PR DESCRIPTION
## Summary
- document metrics usage in README

## Testing
- `just validate` *(fails: Recipe `format` failed)*

------
https://chatgpt.com/codex/tasks/task_e_686c1acab2bc8324b0f64b6f4ded0633