### PR TITLE
Add Grafana dashboard for devnet monitoring

### DIFF
--- a/icn-devnet/README.md
+++ b/icn-devnet/README.md
@@ -166,6 +166,14 @@ The default Alertmanager configuration sends emails to
 `alerts@intercooperative.network`. Modify `alertmanager.yml` to customize
 receivers or routing rules.
 
+### Grafana Dashboards
+
+Pre-built dashboards are available under `grafana/`.
+
+1. Start the monitoring profile with `docker-compose --profile monitoring up -d`.
+2. Open Grafana at [http://localhost:3000](http://localhost:3000) (admin/icnfederation).
+3. Navigate to **Dashboards → Import** and upload `grafana/icn-devnet-overview.json`.
+
 ### Development Mode
 
 ```bash

--- a/icn-devnet/grafana/icn-devnet-overview.json
+++ b/icn-devnet/grafana/icn-devnet-overview.json
@@ -1,0 +1,48 @@
+{
+  "uid": "icn-devnet-overview",
+  "title": "ICN Devnet Overview",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Submit Mesh Job Calls",
+      "id": 1,
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "host_submit_mesh_job_calls" }],
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 0 }
+    },
+    {
+      "type": "stat",
+      "title": "Spend Mana Calls",
+      "id": 2,
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "host_account_spend_mana_calls" }],
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 0 }
+    },
+    {
+      "type": "gauge",
+      "title": "Ping Avg RTT (ms)",
+      "id": 3,
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "PING_AVG_RTT_MS" }],
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 4 }
+    },
+    {
+      "type": "gauge",
+      "title": "Ping Max RTT (ms)",
+      "id": 4,
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "PING_MAX_RTT_MS" }],
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 4 }
+    },
+    {
+      "type": "stat",
+      "title": "Credit Mana Calls",
+      "id": 5,
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "economics_credit_mana_calls" }],
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 4 }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a simple Grafana dashboard definition under `icn-devnet/grafana/`
- document how to import dashboards in the devnet README

## Testing
- `just validate` *(fails: `cargo fmt --check`)*

------
https://chatgpt.com/codex/tasks/task_e_686c1aeee37c8324b46527e97b98dd67