### PR TITLE
Add Grafana dashboard for devnet

### DIFF
--- a/icn-devnet/README.md
+++ b/icn-devnet/README.md
@@ -166,6 +166,10 @@ The default Alertmanager configuration sends emails to
 `alerts@intercooperative.network`. Modify `alertmanager.yml` to customize
 receivers or routing rules.
 
+### Grafana Dashboards
+Dashboard JSON files are located in `grafana/`. After launching with monitoring, open Grafana at `http://localhost:3000`, click **Import**, and upload `grafana/icn-devnet-dashboard.json`.
+
+
 ### Development Mode
 
 ```bash

--- a/icn-devnet/grafana/icn-devnet-dashboard.json
+++ b/icn-devnet/grafana/icn-devnet-dashboard.json
@@ -1,0 +1,83 @@
+{
+  "uid": "icn-devnet",
+  "title": "ICN Devnet Overview",
+  "schemaVersion": 37,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "host_submit_mesh_job_calls",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":0, "y":0},
+      "targets": [{"expr": "host_submit_mesh_job_calls", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "host_get_pending_mesh_jobs_calls",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":12, "y":0},
+      "targets": [{"expr": "host_get_pending_mesh_jobs_calls", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "host_account_get_mana_calls",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":0, "y":8},
+      "targets": [{"expr": "host_account_get_mana_calls", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "host_account_spend_mana_calls",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":12, "y":8},
+      "targets": [{"expr": "host_account_spend_mana_calls", "refId": "A"}]
+    },
+    {
+      "type": "gauge",
+      "title": "Ping Last RTT (ms)",
+      "datasource": "Prometheus",
+      "gridPos": {"h":6, "w":6, "x":0, "y":16},
+      "fieldConfig": {"defaults": {"unit": "ms"}},
+      "targets": [{"expr": "ping_last_rtt_ms", "refId": "A"}]
+    },
+    {
+      "type": "gauge",
+      "title": "Ping Min RTT (ms)",
+      "datasource": "Prometheus",
+      "gridPos": {"h":6, "w":6, "x":6, "y":16},
+      "fieldConfig": {"defaults": {"unit": "ms"}},
+      "targets": [{"expr": "ping_min_rtt_ms", "refId": "A"}]
+    },
+    {
+      "type": "gauge",
+      "title": "Ping Max RTT (ms)",
+      "datasource": "Prometheus",
+      "gridPos": {"h":6, "w":6, "x":12, "y":16},
+      "fieldConfig": {"defaults": {"unit": "ms"}},
+      "targets": [{"expr": "ping_max_rtt_ms", "refId": "A"}]
+    },
+    {
+      "type": "gauge",
+      "title": "Ping Avg RTT (ms)",
+      "datasource": "Prometheus",
+      "gridPos": {"h":6, "w":6, "x":18, "y":16},
+      "fieldConfig": {"defaults": {"unit": "ms"}},
+      "targets": [{"expr": "ping_avg_rtt_ms", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "credit_mana_calls",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":0, "y":22},
+      "targets": [{"expr": "economics_credit_mana_calls", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "spend_mana_calls",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":12, "y":22},
+      "targets": [{"expr": "economics_spend_mana_calls", "refId": "A"}]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add default Grafana dashboard definition in icn-devnet
- document dashboard import instructions in icn-devnet README

## Testing
- `cargo test --all-features --workspace` *(fails: could not complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_686c1acb3b7c83249af2f635818b9c71