### PR TITLE
[docs] fix changelog repo links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - First version of crate skeletons.
 
-[Unreleased]: https://github.com/USERNAME/icn-core/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/USERNAME/icn-core/releases/tag/v0.2.0
-[0.1.0]: https://github.com/USERNAME/icn-core/releases/tag/v0.1.0 
+[Unreleased]: https://github.com/InterCooperative/icn-core/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/InterCooperative/icn-core/releases/tag/v0.2.0
+[0.1.0]: https://github.com/InterCooperative/icn-core/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- point changelog version links at InterCooperative/icn-core repo

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy found warnings)*
- `cargo test --all-features --workspace --no-run` *(aborted: build errors)*
- `cargo test -p icn-ccl --no-run` *(fails: could not compile `icn-runtime`)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c7db35f588324bfcc50cec6cf57b1