### PR TITLE
Add monitoring helpers to justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ just lint     # run clippy
 just test     # execute all tests
 just build    # build all crates
 just devnet   # launch the containerized federation devnet
+just health-check # run federation health checks
+just status   # query node status
+just logs     # show recent devnet logs
+just metrics  # fetch node metrics
+just docs     # build documentation
 icn-devnet/launch_federation.sh # build and test the federation containers
 ```
 

--- a/justfile
+++ b/justfile
@@ -32,3 +32,23 @@ validate:
 # Run benchmarks for all crates
 bench:
     cargo bench --all-features --workspace
+
+# Run federation health checks
+health-check:
+    cargo test --test federation -- --exact test_federation_node_health --nocapture
+
+# Show node status via CLI
+status:
+    cargo run -p icn-cli -- status
+
+# View recent devnet logs (if running via Docker)
+logs:
+    cd icn-devnet && docker-compose logs --tail=50
+
+# Fetch Prometheus metrics from the default node
+metrics:
+    cargo run -p icn-cli -- metrics
+
+# Build documentation for all crates
+docs:
+    cargo doc --workspace --no-deps


### PR DESCRIPTION
## Summary
- add devnet status helpers in justfile
- document new `just` commands

## Testing
- `cargo fmt --all -- --check` *(fails: left behind trailing whitespace)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy error in icn-common)*
- `cargo test --all-features --workspace` *(aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686c7dad23b48324a2059396a735982a