### PR TITLE
Replace gas terminology with mana; adjust network phrasing

### DIFF
--- a/.cursor/rules/api-contracts.mdc
+++ b/.cursor/rules/api-contracts.mdc
@@ -343,7 +343,7 @@ pub trait NetworkService {
 
 ### Rust Client SDK
 ```rust
-/// High-level client for ICN network interaction
+/// High-level client for interacting with the network
 pub struct IcnClient {
     http_client: HttpClient,
     identity: ClientIdentity,

--- a/PHASE_2A_DEMO.md
+++ b/PHASE_2A_DEMO.md
@@ -1,4 +1,4 @@
-# Phase 2A Demo: Multi-Node ICN Network
+# Phase 2A Demo: Multi-Node ICN
 
 ## 🎯 Objective
 Demonstrate that two ICN nodes can discover each other via bootstrap peers and establish a P2P connection.

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -917,8 +917,8 @@ mod tests {
             payload_type: "test".to_string(),
             payload: b"hello".to_vec(),
             nonce: 0,
-            gas_limit: 100,
-            gas_price: 1,
+            mana_limit: 100,
+            mana_price: 1,
             signature: None,
         };
         let tx_json = serde_json::to_string(&tx).unwrap();

--- a/crates/icn-cli/tests/transaction_query.rs
+++ b/crates/icn-cli/tests/transaction_query.rs
@@ -25,8 +25,8 @@ async fn submit_transaction_and_query_data() {
         payload_type: "test".to_string(),
         payload: b"hello".to_vec(),
         nonce: 0,
-        gas_limit: 100,
-        gas_price: 1,
+        mana_limit: 100,
+        mana_price: 1,
         signature: None,
     };
     let tx_json = serde_json::to_string(&tx).unwrap();

--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -75,7 +75,7 @@ impl TimeProvider for FixedTimeProvider {
     }
 }
 
-/// Represents a generic error that can occur within the ICN network.
+/// Represents a generic error that can occur within the network.
 #[derive(Debug, Error, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum CommonError {
     #[error("Invalid input: {0}")]
@@ -537,9 +537,9 @@ pub struct Transaction {
     /// Nonce ensuring transaction uniqueness.
     pub nonce: u64,
     /// Maximum compute units the sender is willing to expend.
-    pub gas_limit: u64,
+    pub mana_limit: u64,
     /// Price per compute unit the sender is willing to pay.
-    pub gas_price: u64,
+    pub mana_price: u64,
     /// Optional Ed25519 signature of the transaction content.
     pub signature: Option<SignatureBytes>,
 }
@@ -581,8 +581,8 @@ impl Signable for Transaction {
         bytes.extend_from_slice(self.payload_type.as_bytes());
         bytes.extend_from_slice(&self.payload);
         bytes.extend_from_slice(&self.nonce.to_le_bytes());
-        bytes.extend_from_slice(&self.gas_limit.to_le_bytes());
-        bytes.extend_from_slice(&self.gas_price.to_le_bytes());
+        bytes.extend_from_slice(&self.mana_limit.to_le_bytes());
+        bytes.extend_from_slice(&self.mana_price.to_le_bytes());
         Ok(bytes)
     }
 }
@@ -705,8 +705,8 @@ mod tests {
             payload_type: "test_payload".to_string(),
             payload: b"some test data".to_vec(),
             nonce: 1,
-            gas_limit: 10,
-            gas_price: 1,
+            mana_limit: 10,
+            mana_price: 1,
             signature: Some(SignatureBytes(vec![0u8; ed25519_dalek::SIGNATURE_LENGTH])),
         };
         assert_eq!(transaction.sender_did, sender);

--- a/crates/icn-common/tests/signable.rs
+++ b/crates/icn-common/tests/signable.rs
@@ -16,8 +16,8 @@ fn transaction_sign_verify() {
         payload_type: "test".to_string(),
         payload: b"hello".to_vec(),
         nonce: 0,
-        gas_limit: 100,
-        gas_price: 1,
+        mana_limit: 100,
+        mana_price: 1,
         signature: None,
     };
 
@@ -39,8 +39,8 @@ fn transaction_serialization_roundtrip() {
         payload_type: "test".to_string(),
         payload: b"hello".to_vec(),
         nonce: 7,
-        gas_limit: 200,
-        gas_price: 2,
+        mana_limit: 200,
+        mana_price: 2,
         signature: None,
     };
 

--- a/crates/icn-economics/README.md
+++ b/crates/icn-economics/README.md
@@ -10,7 +10,7 @@ The `icn-economics` crate is responsible for:
 
 *   **Token Models:** Defining and managing the native digital assets of the ICN (e.g., Mana or other utility tokens).
 *   **Ledger Management:** Implementing or interfacing with the distributed ledger that records transactions and account balances.
-*   **Transaction Logic:** Defining the rules for valid transactions, including transfers, fees, and smart contract interactions related to economic activity.
+*   **Transaction Logic:** Defining the rules for valid transactions, including transfers, fees, and CCL contract interactions related to economic activity.
 *   **Incentive Mechanisms:** Potentially including staking, rewards, and other economic incentives for network participation.
 
 This crate is crucial for the sustainable operation and value exchange within the ICN.

--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -1,4 +1,4 @@
-# ICN Network (`icn-network`)
+# Networking for ICN (`icn-network`)
 
 This crate manages peer-to-peer (P2P) networking aspects for the InterCooperative Network (ICN).
 It defines the core networking abstractions, message types, and service interfaces. A lightweight stub service is available for tests, while production builds enable a libp2p-based implementation via the `libp2p` feature.

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -7,9 +7,9 @@
 #![allow(clippy::let_unit_value)]
 #![allow(clippy::clone_on_copy)]
 
-//! # ICN Network Crate - Production-Ready P2P Networking
-//! This crate manages peer-to-peer (P2P) networking aspects for the InterCooperative Network (ICN),
-//! using libp2p for distributed communication between ICN nodes.
+//! # Networking Crate for ICN - Production-Ready P2P Networking
+//! This crate manages peer-to-peer (P2P) networking aspects for ICN,
+//! using libp2p for distributed communication between nodes.
 
 pub mod error;
 pub use error::MeshNetworkError;

--- a/crates/icn-protocol/src/lib.rs
+++ b/crates/icn-protocol/src/lib.rs
@@ -1,10 +1,10 @@
 #![doc = include_str!("../README.md")]
 
 //! # ICN Protocol Crate
-//! This crate defines core message formats and protocol definitions for the ICN,
+//! This crate defines core message formats and protocol definitions for ICN,
 //! ensuring interoperability between different components and nodes.
-//! 
-//! This is the single source of truth for all ICN network protocol messages,
+//!
+//! This is the single source of truth for all network protocol messages,
 //! including mesh computing, governance, DAG operations, and federation management.
 
 use icn_common::{Cid, Did, DagBlock, CommonError, NodeInfo};
@@ -16,7 +16,7 @@ pub const ICN_PROTOCOL_VERSION: u32 = 1;
 
 // === Core Protocol Message Envelope ===
 
-/// Main protocol message envelope that wraps all ICN network communications
+/// Main protocol message envelope that wraps all ICN communications
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolMessage {
     /// Protocol version for compatibility checking

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -9,10 +9,10 @@ See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
 The `icn-runtime` crate is responsible for:
 
 *   **Execution Environment:** Defining and managing the environment where ICN's core logic or user-defined contracts/scripts run.
-*   **WASM Runtime (if applicable):** If ICN uses WebAssembly for smart contracts or extensible logic, this crate would host and manage the WASM execution engine (e.g., Wasmer, Wasmtime).
+*   **WASM Runtime (if applicable):** If ICN uses WebAssembly for CCL contracts or extensible logic, this crate would host and manage the WASM execution engine (e.g., Wasmer, Wasmtime).
 *   **Host Functions:** Providing a set of functions (host calls) that WASM modules or other sandboxed code can use to interact with the ICN node's capabilities (e.g., accessing storage, sending network messages, interacting with ledgers).
 *   **Sandboxing and Security:** Ensuring that executed code is properly isolated and cannot compromise the host node or the network.
-*   **Metering and Resource Limits:** Potentially implementing mechanisms to measure and limit the computational resources (e.g., gas) consumed by executed code.
+*   **Metering and Resource Limits:** Potentially implementing mechanisms to measure and limit the computational resources (e.g., mana) consumed by executed code.
 
 This crate is key to enabling safe and extensible functionality within ICN nodes.
 

--- a/icn-ccl/ACCOMPLISHMENTS.md
+++ b/icn-ccl/ACCOMPLISHMENTS.md
@@ -196,7 +196,7 @@ fn calculate_final_mana_cost(
 1. **Hot Deployment**: Live contract updates through governance
 2. **Cross-Contract Calls**: Inter-contract communication
 3. **Standard Library**: Common governance patterns
-4. **Gas Metering**: Mana consumption tracking
+4. **Mana Metering**: Mana consumption tracking
 
 ---
 

--- a/icn-ccl/demo_with_devnet.rs
+++ b/icn-ccl/demo_with_devnet.rs
@@ -99,7 +99,7 @@ fn main() {
     println!("  ✨ Governance as Code - Write bylaws in CCL");
     println!("  ⚡ Deterministic Execution - WASM compilation ensures consistency");
     println!("  🏛️ Policy Templates - Reusable governance patterns");
-    println!("  🔗 Mesh Integration - Deploy and execute across ICN network");
+    println!("  🔗 Mesh Integration - Deploy and execute across the network");
     println!("  🔒 Security - Sandboxed execution with resource limits");
     println!("  📜 Auditability - Source code hashing and receipts");
 }


### PR DESCRIPTION
## Summary
- drop `ICN Network` phrasing in several docs and examples
- replace remaining `gas` terminology with `mana`
- rename `gas_limit`/`gas_price` fields to `mana_limit`/`mana_price`
- update affected tests and docs

## Testing
- `cargo test -p icn-common --quiet`
- `cargo test --workspace --quiet` *(fails: could not compile `icn-runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_686c9858ad5c83248a8b143dff799b1e