### PR TITLE
[icn-ccl] fix comparison operator ordering

### DIFF
--- a/icn-ccl/src/cli.rs
+++ b/icn-ccl/src/cli.rs
@@ -280,6 +280,13 @@ fn expr_to_string(expr: &ExpressionNode) -> String {
                 expr_to_string(right)
             )
         }
+        ExpressionNode::UnaryOp { operator, operand } => {
+            let op = match operator {
+                crate::ast::UnaryOperator::Not => "!",
+                crate::ast::UnaryOperator::Neg => "-",
+            };
+            format!("({}{})", op, expr_to_string(operand))
+        }
         ExpressionNode::ArrayAccess { array, index } => {
             format!("{}[{}]", expr_to_string(array), expr_to_string(index))
         }

--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -50,10 +50,10 @@ MUL_OP = { "*" }
 DIV_OP = { "/" }
 EQ_OP  = { "==" }
 NEQ_OP = { "!=" }
-LT_OP  = { "<" }
 LTE_OP = { "<=" }
-GT_OP  = { ">" }
+LT_OP  = { "<" }
 GTE_OP = { ">=" }
+GT_OP  = { ">" }
 AND_OP = { "&&" }
 OR_OP  = { "||" }
 NOT_OP = { "!" }

--- a/icn-ccl/tests/ast_pair.rs
+++ b/icn-ccl/tests/ast_pair.rs
@@ -139,3 +139,63 @@ fn test_pair_to_ast_statement_return() {
     });
     assert_eq!(ast, expected);
 }
+
+#[test]
+fn test_pair_to_ast_gte_comparison() {
+    let src = "fn cmp(a: Integer, b: Integer) -> Bool { return a >= b; }";
+    let mut pairs = CclParser::parse(Rule::function_definition, src).unwrap();
+    let pair = pairs.next().unwrap();
+    let ast = ast::pair_to_ast(pair).unwrap();
+    let expected = AstNode::FunctionDefinition {
+        name: "cmp".to_string(),
+        parameters: vec![
+            ParameterNode {
+                name: "a".to_string(),
+                type_ann: TypeAnnotationNode::Integer,
+            },
+            ParameterNode {
+                name: "b".to_string(),
+                type_ann: TypeAnnotationNode::Integer,
+            },
+        ],
+        return_type: TypeAnnotationNode::Bool,
+        body: BlockNode {
+            statements: vec![StatementNode::Return(ExpressionNode::BinaryOp {
+                left: Box::new(ExpressionNode::Identifier("a".to_string())),
+                operator: BinaryOperator::Gte,
+                right: Box::new(ExpressionNode::Identifier("b".to_string())),
+            })],
+        },
+    };
+    assert_eq!(ast, expected);
+}
+
+#[test]
+fn test_pair_to_ast_lte_comparison() {
+    let src = "fn cmp(a: Integer, b: Integer) -> Bool { return a <= b; }";
+    let mut pairs = CclParser::parse(Rule::function_definition, src).unwrap();
+    let pair = pairs.next().unwrap();
+    let ast = ast::pair_to_ast(pair).unwrap();
+    let expected = AstNode::FunctionDefinition {
+        name: "cmp".to_string(),
+        parameters: vec![
+            ParameterNode {
+                name: "a".to_string(),
+                type_ann: TypeAnnotationNode::Integer,
+            },
+            ParameterNode {
+                name: "b".to_string(),
+                type_ann: TypeAnnotationNode::Integer,
+            },
+        ],
+        return_type: TypeAnnotationNode::Bool,
+        body: BlockNode {
+            statements: vec![StatementNode::Return(ExpressionNode::BinaryOp {
+                left: Box::new(ExpressionNode::Identifier("a".to_string())),
+                operator: BinaryOperator::Lte,
+                right: Box::new(ExpressionNode::Identifier("b".to_string())),
+            })],
+        },
+    };
+    assert_eq!(ast, expected);
+}


### PR DESCRIPTION
## Summary
- ensure longer comparison operator tokens come first
- test parser behavior for `>=` and `<=`
- handle unary operators in CLI AST printer

## Testing
- `cargo clippy -p icn-ccl -- -D warnings`
- `cargo test -p icn-ccl` *(fails: could not compile `icn-runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_686c9fb305908324b99f7c5e1f7c27f6