### PR TITLE
Add CCL operator precedence tests

### DIFF
--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -40,7 +40,7 @@ expression = { logical_or }
 logical_or = { logical_and ~ (OR_OP ~ logical_and)* }
 logical_and = { equality ~ (AND_OP ~ equality)* }
 equality = { comparison ~ ((EQ_OP | NEQ_OP) ~ comparison)* }
-comparison = { addition ~ ((LT_OP | LTE_OP | GT_OP | GTE_OP) ~ addition)* }
+comparison = { addition ~ ((LTE_OP | LT_OP | GTE_OP | GT_OP) ~ addition)* }
 addition = { multiplication ~ ((ADD_OP | SUB_OP) ~ multiplication)* }
 multiplication = { unary ~ ((MUL_OP | DIV_OP) ~ unary)* }
 unary = { (NOT_OP | NEG_OP)? ~ primary }
@@ -53,10 +53,10 @@ MUL_OP = { "*" }
 DIV_OP = { "/" }
 EQ_OP  = { "==" }
 NEQ_OP = { "!=" }
-LT_OP  = { "<" }
 LTE_OP = { "<=" }
-GT_OP  = { ">" }
+LT_OP  = { "<" }
 GTE_OP = { ">=" }
+GT_OP  = { ">" }
 AND_OP = { "&&" }
 OR_OP  = { "||" }
 NOT_OP = { "!" }

--- a/icn-ccl/tests/operator_precedence.rs
+++ b/icn-ccl/tests/operator_precedence.rs
@@ -1,0 +1,104 @@
+use icn_ccl::{
+    ast::{
+        AstNode, ExpressionNode, StatementNode, PolicyStatementNode, BinaryOperator, UnaryOperator, ParameterNode, TypeAnnotationNode, BlockNode,
+    },
+    parser::parse_ccl_source,
+};
+
+#[test]
+fn arithmetic_mixed_precedence() {
+    let src = "fn run() -> Integer { return 1 + 2 * 3 - 4 / 2; }";
+    let ast = parse_ccl_source(src).expect("parse");
+    if let AstNode::Policy(items) = ast {
+        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) = &items[0] {
+            if let StatementNode::Return(expr) = &body.statements[0] {
+                let expected = ExpressionNode::BinaryOp {
+                    left: Box::new(ExpressionNode::BinaryOp {
+                        left: Box::new(ExpressionNode::IntegerLiteral(1)),
+                        operator: BinaryOperator::Add,
+                        right: Box::new(ExpressionNode::BinaryOp {
+                            left: Box::new(ExpressionNode::IntegerLiteral(2)),
+                            operator: BinaryOperator::Mul,
+                            right: Box::new(ExpressionNode::IntegerLiteral(3)),
+                        }),
+                    }),
+                    operator: BinaryOperator::Sub,
+                    right: Box::new(ExpressionNode::BinaryOp {
+                        left: Box::new(ExpressionNode::IntegerLiteral(4)),
+                        operator: BinaryOperator::Div,
+                        right: Box::new(ExpressionNode::IntegerLiteral(2)),
+                    }),
+                };
+                assert_eq!(expr, &expected);
+            } else {
+                panic!("expected return statement")
+            }
+        } else {
+            panic!("unexpected ast")
+        }
+    } else {
+        panic!("unexpected root")
+    }
+}
+
+#[test]
+fn nested_gte_comparisons() {
+    let src = "fn run(a: Integer, b: Integer, c: Integer) -> Bool { return a >= b >= c; }";
+    let ast = parse_ccl_source(src).expect("parse");
+    if let AstNode::Policy(items) = ast {
+        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) = &items[0] {
+            if let StatementNode::Return(expr) = &body.statements[0] {
+                let expected = ExpressionNode::BinaryOp {
+                    left: Box::new(ExpressionNode::BinaryOp {
+                        left: Box::new(ExpressionNode::Identifier("a".into())),
+                        operator: BinaryOperator::Gte,
+                        right: Box::new(ExpressionNode::Identifier("b".into())),
+                    }),
+                    operator: BinaryOperator::Gte,
+                    right: Box::new(ExpressionNode::Identifier("c".into())),
+                };
+                assert_eq!(expr, &expected);
+            } else { panic!("expected return") }
+        } else { panic!("unexpected ast") }
+    } else { panic!("unexpected root") }
+}
+
+#[test]
+fn unary_logic_combination() {
+    let src = "fn run(x: Bool, y: Integer, z: Integer) -> Bool { return !x || -y * 2 > 3 && z != 0; }";
+    let ast = parse_ccl_source(src).expect("parse");
+    if let AstNode::Policy(items) = ast {
+        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) = &items[0] {
+            if let StatementNode::Return(expr) = &body.statements[0] {
+                let expected = ExpressionNode::BinaryOp {
+                    left: Box::new(ExpressionNode::UnaryOp {
+                        operator: UnaryOperator::Not,
+                        operand: Box::new(ExpressionNode::Identifier("x".into())),
+                    }),
+                    operator: BinaryOperator::Or,
+                    right: Box::new(ExpressionNode::BinaryOp {
+                        left: Box::new(ExpressionNode::BinaryOp {
+                            left: Box::new(ExpressionNode::BinaryOp {
+                                left: Box::new(ExpressionNode::UnaryOp {
+                                    operator: UnaryOperator::Neg,
+                                    operand: Box::new(ExpressionNode::Identifier("y".into())),
+                                }),
+                                operator: BinaryOperator::Mul,
+                                right: Box::new(ExpressionNode::IntegerLiteral(2)),
+                            }),
+                            operator: BinaryOperator::Gt,
+                            right: Box::new(ExpressionNode::IntegerLiteral(3)),
+                        }),
+                        operator: BinaryOperator::And,
+                        right: Box::new(ExpressionNode::BinaryOp {
+                            left: Box::new(ExpressionNode::Identifier("z".into())),
+                            operator: BinaryOperator::Neq,
+                            right: Box::new(ExpressionNode::IntegerLiteral(0)),
+                        }),
+                    }),
+                };
+                assert_eq!(expr, &expected);
+            } else { panic!("expected return") }
+        } else { panic!("unexpected ast") }
+    } else { panic!("unexpected root") }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -39,6 +39,10 @@ path = "integration/policy_enforcer.rs"
 name = "parameter_change"
 path = "integration/parameter_change.rs"
 
+[[test]]
+name = "ccl_operator_precedence"
+path = "../icn-ccl/tests/operator_precedence.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary
- test precedence of arithmetic and logical operators in `icn-ccl`
- fix parsing of `>=` and `<=` by adjusting grammar operator order
- register the new CCL test in workspace test suite

## Testing
- `cargo test -p icn-ccl --test operator_precedence --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ca99407288324bb538b29002b6d6f