### PR TITLE
Reorder comparison rules in CCL grammar

### DIFF
--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -40,7 +40,7 @@ expression = { logical_or }
 logical_or = { logical_and ~ (OR_OP ~ logical_and)* }
 logical_and = { equality ~ (AND_OP ~ equality)* }
 equality = { comparison ~ ((EQ_OP | NEQ_OP) ~ comparison)* }
-comparison = { addition ~ ((LT_OP | LTE_OP | GT_OP | GTE_OP) ~ addition)* }
+comparison = { addition ~ ((LTE_OP | LT_OP | GTE_OP | GT_OP) ~ addition)* }
 addition = { multiplication ~ ((ADD_OP | SUB_OP) ~ multiplication)* }
 multiplication = { unary ~ ((MUL_OP | DIV_OP) ~ unary)* }
 unary = { (NOT_OP | NEG_OP)? ~ primary }
@@ -53,10 +53,10 @@ MUL_OP = { "*" }
 DIV_OP = { "/" }
 EQ_OP  = { "==" }
 NEQ_OP = { "!=" }
-LT_OP  = { "<" }
 LTE_OP = { "<=" }
-GT_OP  = { ">" }
+LT_OP  = { "<" }
 GTE_OP = { ">=" }
+GT_OP  = { ">" }
 AND_OP = { "&&" }
 OR_OP  = { "||" }
 NOT_OP = { "!" }

--- a/icn-ccl/tests/control_flow.rs
+++ b/icn-ccl/tests/control_flow.rs
@@ -117,3 +117,24 @@ fn compile_governance_conditions() {
     let (wasm, _meta) = compile_ccl_source_to_wasm(src).expect("compile");
     assert!(wasm.starts_with(b"\0asm"));
 }
+
+#[test]
+fn compile_comparison_operators() {
+    let src = r#"
+        fn compare(a: Integer, b: Integer) -> Integer {
+            if a < b {
+                return 1;
+            }
+            if a <= b {
+                return 1;
+            }
+            return 0;
+        }
+
+        fn run() -> Integer {
+            return compare(1, 2);
+        }
+    "#;
+    let (wasm, _meta) = compile_ccl_source_to_wasm(src).expect("compile");
+    assert!(wasm.starts_with(b"\0asm"));
+}


### PR DESCRIPTION
## Summary
- reorder comparison operator rules so multi-char tokens match first
- add a test covering `<` and `<=`

## Testing
- `cargo test -p icn-ccl --test control_flow -- --test-threads=1`
- `cargo test -p icn-ccl --test integration_tests -- --test-threads=1` *(fails: method `unwrap` not found)*
- `cargo test -p icn-ccl --test wasm_executor_integration -- --test-threads=1` *(fails: trait bound not satisfied)*
- `cargo test -p icn-ccl -- --test-threads=1` *(fails: method `unwrap` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca9831c2c832482b54e5ecdc2a83a