### PR TITLE
[ccl] recursive unary ops

### DIFF
--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -43,7 +43,7 @@ equality = { comparison ~ ((EQ_OP | NEQ_OP) ~ comparison)* }
 comparison = { addition ~ ((LTE_OP | LT_OP | GTE_OP | GT_OP) ~ addition)* }
 addition = { multiplication ~ ((ADD_OP | SUB_OP) ~ multiplication)* }
 multiplication = { unary ~ ((MUL_OP | DIV_OP) ~ unary)* }
-unary = { (NOT_OP | NEG_OP)? ~ primary }
+unary = { (NOT_OP | SUB_OP) ~ unary | primary }
 primary = { atom ~ ("[" ~ expression ~ "]")* }
 atom = { integer_literal | boolean_literal | string_literal | function_call | identifier | array_literal | "(" ~ expression ~ ")" }
 array_literal = { "[" ~ expression ~ ("," ~ expression)* ~ "]" }
@@ -62,7 +62,6 @@ GT_OP  = { ">" }
 AND_OP = { "&&" }
 OR_OP  = { "||" }
 NOT_OP = { "!" }
-NEG_OP = { "-" }
 
 // Example: Actions (specific to policy rules)
 action = { ALLOW | DENY | CHARGE ~ expression }

--- a/icn-ccl/src/optimizer.rs
+++ b/icn-ccl/src/optimizer.rs
@@ -1,7 +1,7 @@
 // icn-ccl/src/optimizer.rs
 use crate::ast::{
     ActionNode, AstNode, BinaryOperator, BlockNode, ExpressionNode, PolicyStatementNode,
-    StatementNode,
+    StatementNode, UnaryOperator,
 };
 use crate::error::CclError;
 
@@ -158,6 +158,21 @@ impl Optimizer {
                 name,
                 arguments: arguments.into_iter().map(|a| self.fold_expr(a)).collect(),
             },
+            ExpressionNode::UnaryOp { operator, operand } => {
+                let folded_operand = self.fold_expr(*operand);
+                match (&operator, &folded_operand) {
+                    (UnaryOperator::Neg, ExpressionNode::IntegerLiteral(i)) => {
+                        ExpressionNode::IntegerLiteral(-i)
+                    }
+                    (UnaryOperator::Not, ExpressionNode::BooleanLiteral(b)) => {
+                        ExpressionNode::BooleanLiteral(!b)
+                    }
+                    _ => ExpressionNode::UnaryOp {
+                        operator,
+                        operand: Box::new(folded_operand),
+                    },
+                }
+            }
             e => e,
         }
     }


### PR DESCRIPTION
## Summary
- support repeated unary operators in grammar and parser
- fold unary operators in optimizer for constants

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p icn-ccl` *(fails: compile_array_literals, compile_governance_contract)*

------
https://chatgpt.com/codex/tasks/task_e_686cb91782b08324848462ba66747600