### PR TITLE
[runtime] add get_reputation host

### DIFF
--- a/crates/icn-runtime/src/abi.rs
+++ b/crates/icn-runtime/src/abi.rs
@@ -27,6 +27,10 @@ pub const ABI_HOST_GET_PENDING_MESH_JOBS: u32 = 22;
 /// Anchors an execution receipt to the DAG and updates reputation.
 pub const ABI_HOST_ANCHOR_RECEIPT: u32 = 23;
 
+/// ABI Index for `host_get_reputation`.
+/// Retrieves the reputation score for the given DID.
+pub const ABI_HOST_GET_REPUTATION: u32 = 24;
+
 // --- Governance ABI Functions (RFC 0010) ---
 // Indices reserved for governance operations defined in RFC 0010.
 

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -535,6 +535,17 @@ impl JobExecutor for WasmExecutor {
             })
             .map_err(|e| CommonError::InternalError(e.to_string()))?;
 
+        let ctx_clone = self.ctx.clone();
+        linker
+            .func_wrap("icn", "host_get_reputation", move || -> i64 {
+                let handle = tokio::runtime::Handle::current();
+                let did = ctx_clone.current_identity.to_string();
+                handle
+                    .block_on(async { host_get_reputation(&ctx_clone, &did).await })
+                    .unwrap_or(0) as i64
+            })
+            .map_err(|e| CommonError::InternalError(e.to_string()))?;
+
         linker
             .func_wrap(
                 "icn",

--- a/icn-ccl/demo_ccl.rs
+++ b/icn-ccl/demo_ccl.rs
@@ -67,6 +67,19 @@ fn main() {
         println!("⚠️  Example file not found at {}", example_path.display());
     }
 
+    // Example usage of the runtime's host_get_reputation function to calculate
+    // a discounted mana cost. This is illustrative only and not executed.
+    //
+    // ```rust
+    // use icn_runtime::{host_get_reputation, context::RuntimeContext};
+    // use icn_economics::price_by_reputation;
+    //
+    // async fn calculate_mana_cost(ctx: &RuntimeContext, base: u64) -> u64 {
+    //     let rep = host_get_reputation(ctx, &ctx.current_identity.to_string()).await.unwrap();
+    //     price_by_reputation(base, rep)
+    // }
+    // ```
+
     println!("\n🎉 CCL Demo Complete!");
     println!("🔗 CCL enables:");
     println!("   • Governance as Code");


### PR DESCRIPTION
## Summary
- expose ABI_HOST_GET_REPUTATION constant
- implement host_get_reputation and wasm wrapper
- extend RuntimeContext with get_reputation
- register host_get_reputation in Executor
- test WASM import for get_reputation
- show example usage in `demo_ccl.rs`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build took too long)*
- `cargo test --all-features --workspace` *(failed: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_686cc1d688a48324a04fc43700adc13f