### PR TITLE
Add async API overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It provides the foundational crates for building ICN nodes, CLI tools, and other
 For full architecture, philosophy, and comprehensive feature overview, see:
 - [CONTEXT.md](CONTEXT.md) - Core philosophy and architectural principles
 - [docs/ICN_FEATURE_OVERVIEW.md](docs/ICN_FEATURE_OVERVIEW.md) - Complete feature set (current and planned)
+- [docs/ASYNC_OVERVIEW.md](docs/ASYNC_OVERVIEW.md) - Async APIs and concurrency model
 
 ## Overview
 
@@ -281,6 +282,7 @@ More detailed information can be found in the `README.md` file within each crate
 * [Complete Feature Overview](docs/ICN_FEATURE_OVERVIEW.md) – comprehensive feature breakdown
 * [Context & Philosophy](CONTEXT.md) – core principles and architectural vision
 * [Development Workflow](docs/ONBOARDING.md) – getting started guide
+* [Async Overview](docs/ASYNC_OVERVIEW.md) – networking and storage concurrency
 * [Multi-Node Setup](MULTI_NODE_GUIDE.md) – federation deployment guide
 
 ### **Governance & Economics**

--- a/crates/icn-api/README.md
+++ b/crates/icn-api/README.md
@@ -2,7 +2,8 @@
 
 This crate provides the primary API endpoints for interacting with InterCooperative Network (ICN) nodes.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -4,7 +4,8 @@ This crate provides a command-line interface (CLI) for interacting with the Inte
 It allows users and administrators to manage nodes, interact with the network, and perform administrative tasks.
 The CLI aims for usability, discoverability, and scriptability.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-common/README.md
+++ b/crates/icn-common/README.md
@@ -2,7 +2,8 @@
 
 This crate provides common data structures, types, utilities, and error definitions shared across multiple InterCooperative Network (ICN) core crates.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -2,7 +2,8 @@
 
 This crate implements or defines interfaces for content-addressed Directed Acyclic Graph (DAG) storage and manipulation, crucial for the InterCooperative Network (ICN) data model.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-economics/README.md
+++ b/crates/icn-economics/README.md
@@ -2,7 +2,8 @@
 
 This crate handles the economic protocols of the InterCooperative Network (ICN).
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-governance/README.md
+++ b/crates/icn-governance/README.md
@@ -2,7 +2,8 @@
 
 This crate defines the mechanisms for network governance within the InterCooperative Network (ICN).
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-identity/README.md
+++ b/crates/icn-identity/README.md
@@ -2,7 +2,8 @@
 
 This crate manages decentralized identities (DIDs), verifiable credentials (VCs), and cryptographic operations for users and nodes within the InterCooperative Network (ICN).
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-mesh/README.md
+++ b/crates/icn-mesh/README.md
@@ -2,7 +2,8 @@
 
 This crate focuses on job orchestration, scheduling, and execution within the InterCooperative Network (ICN) mesh network.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -3,7 +3,8 @@
 This crate manages peer-to-peer (P2P) networking aspects for the InterCooperative Network (ICN).
 It defines the core networking abstractions, message types, and service interfaces. A lightweight stub service is available for tests, while production builds enable a libp2p-based implementation via the `libp2p` feature.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -4,7 +4,8 @@ This crate provides the main binary for running a long-lived InterCooperative Ne
 It integrates various core components to operate a functional ICN node, handling initialization,
 lifecycle, configuration, service hosting, and persistence.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-protocol/README.md
+++ b/crates/icn-protocol/README.md
@@ -2,7 +2,8 @@
 
 This crate defines core message formats, communication protocols, and potentially helpers for a domain-specific language like CCL (Cooperative Contract Language) within the InterCooperative Network (ICN).
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/crates/icn-reputation/README.md
+++ b/crates/icn-reputation/README.md
@@ -4,4 +4,5 @@ This crate provides reputation tracking utilities for the InterCooperative Netwo
 It defines the `ReputationStore` trait used by the mesh scheduling logic and a simple
 in-memory implementation useful for testing.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -2,7 +2,8 @@
 
 This crate provides the execution environment for InterCooperative Network (ICN) logic, possibly including WebAssembly (WASM) runtimes and host interaction capabilities.
 
-See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 

--- a/docs/ASYNC_OVERVIEW.md
+++ b/docs/ASYNC_OVERVIEW.md
@@ -1,0 +1,20 @@
+# Async APIs and Concurrency in ICN Core
+
+The ICN Core workspace favors asynchronous code for any operation that touches the network or storage. All crates that perform I/O expose async interfaces so callers can compose them using `async`/`await` and Tokio.
+
+## Key Points
+
+- **Network and storage interactions are async.** Services in `icn-network`, the HTTP APIs in `icn-api`, and the CLI HTTP client all use async functions.
+- **Storage interfaces are async.** `icn-dag` defines `AsyncStorageService` and async backends such as `TokioFileDagStore`. The older `StorageService` trait remains for limited synchronous environments.
+- **Crates with async APIs:**
+  - `icn-api` – async RPC helpers and network calls
+  - `icn-cli` – async HTTP requests
+  - `icn-dag` – async storage trait and backends when built with the `async` feature
+  - `icn-network` – async peer‑to‑peer networking service
+  - `icn-runtime` – async runtime context interacting with storage and networking
+  - `icn-governance` – async federation sync helpers
+  - `icn-node` – daemon uses Tokio for its main loop
+- **Remaining sync code:**
+  - `icn-dag` provides synchronous storage (`StorageService` and `FileDagStore`) when the `async` feature is disabled. Most other crates rely exclusively on async traits.
+
+When adding new network or persistence features, prefer async traits and functions so that nodes remain responsive and can integrate with the Tokio runtime.


### PR DESCRIPTION
## Summary
- add docs/ASYNC_OVERVIEW.md describing async operations
- link to async overview from root README
- reference async overview from each crate README

## Testing
- `cargo fmt --all -- --check`
- `cargo test --workspace` *(fails: mismatched types in icn-node)*

------
https://chatgpt.com/codex/tasks/task_e_686ccfda80d883249c5eced5df98bb04