### PR TITLE
Switch job states to DashMap

### DIFF
--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -36,6 +36,7 @@ clap = { version = "4.0", features = ["derive"], optional = true }
 icn-ccl = { path = "../../icn-ccl" }
 sha2 = "0.10"
 anyhow = "1.0"
+dashmap = "5"
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -154,8 +154,11 @@ mod runtime_host_abi_tests {
         for attempt in 1..=20 {
             sleep(Duration::from_millis(500)).await;
 
-            let job_states = submitter_node.job_states.lock().await;
-            if let Some(job_state) = job_states.get(&submitted_job_id) {
+            if let Some(job_state) = submitter_node
+                .job_states
+                .get(&submitted_job_id)
+                .map(|s| s.value().clone())
+            {
                 match job_state {
                     icn_mesh::JobState::Assigned { executor } => {
                         info!(
@@ -198,8 +201,11 @@ mod runtime_host_abi_tests {
         for attempt in 1..=30 {
             sleep(Duration::from_millis(1000)).await;
 
-            let job_states = submitter_node.job_states.lock().await;
-            if let Some(job_state) = job_states.get(&submitted_job_id) {
+            if let Some(job_state) = submitter_node
+                .job_states
+                .get(&submitted_job_id)
+                .map(|s| s.value().clone())
+            {
                 match job_state {
                     icn_mesh::JobState::Completed { receipt } => {
                         info!("🎉 [RUNTIME-INTEGRATION] Job completed! Receipt job_id: {} (attempt {})", receipt.job_id, attempt);
@@ -297,9 +303,10 @@ mod runtime_host_abi_tests {
         info!("✅ [HOST-ABI-TEST] Job submitted successfully: {}", job_id);
 
         // Verify job appears in pending state
-        let job_states = runtime_ctx.job_states.lock().await;
-        let job_state = job_states
+        let job_state = runtime_ctx
+            .job_states
             .get(&job_id)
+            .map(|s| s.value().clone())
             .ok_or_else(|| anyhow::anyhow!("Job not found in runtime state"))?;
 
         match job_state {

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -59,13 +59,20 @@ async fn assert_job_state(
     tokio::task::yield_now().await;
     sleep(Duration::from_millis(100)).await; // Increased delay slightly for job manager processing
 
-    let states = ctx.job_states.lock().await;
-    let job_state = states.get(job_id).unwrap_or_else(|| {
-        panic!(
-            "Job ID {:?} not found in states map. States: {:?}",
-            job_id, states
-        )
-    });
+    let job_state = ctx
+        .job_states
+        .get(job_id)
+        .map(|s| s.value().clone())
+        .unwrap_or_else(|| {
+            panic!(
+                "Job ID {:?} not found in states map. States: {:?}",
+                job_id,
+                ctx.job_states
+                    .iter()
+                    .map(|kv| (*kv.key(), kv.value().clone()))
+                    .collect::<Vec<_>>()
+            )
+        });
 
     match (job_state, &expected_state_variant) {
         (JobState::Pending, JobStateVariant::Pending) => {}
@@ -521,8 +528,11 @@ async fn test_job_manager_refunds_on_no_valid_bid() {
     let mana_after = ctx.get_mana(&submitter_did).await.unwrap();
     assert_eq!(mana_after, 50);
 
-    let states = ctx.job_states.lock().await;
-    let state = states.get(&job_id).expect("job state");
+    let state = ctx
+        .job_states
+        .get(&job_id)
+        .map(|s| s.value().clone())
+        .expect("job state");
     match state {
         JobState::Failed { .. } => {}
         other => panic!("Unexpected state {:?}", other),
@@ -624,8 +634,7 @@ async fn assign_job_to_executor_directly(
         "Test util: Directly assigning job {:?} to executor {:?}",
         job_id, assigned_executor_did
     );
-    let mut states = job_manager_ctx.job_states.lock().await;
-    states.insert(
+    job_manager_ctx.job_states.insert(
         JobId(job_id),
         JobState::Assigned {
             executor: assigned_executor_did.clone(),

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -284,8 +284,9 @@ async fn submit_compiled_ccl_runs_via_executor() {
     let job_json = serde_json::to_string(&job).unwrap();
     let job_id = host_submit_mesh_job(&ctx, &job_json).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    let states = ctx.job_states.lock().await;
-    if let Some(icn_mesh::JobState::Completed { receipt }) = states.get(&job_id) {
+    if let Some(icn_mesh::JobState::Completed { receipt }) =
+        ctx.job_states.get(&job_id).map(|s| s.value().clone())
+    {
         let expected = Cid::new_v1_sha256(0x55, &9i64.to_le_bytes());
         assert_eq!(receipt.result_cid, expected);
     } else {
@@ -327,8 +328,9 @@ async fn queued_compiled_ccl_executes() {
     };
     ctx.internal_queue_mesh_job(job.clone()).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    let states = ctx.job_states.lock().await;
-    if let Some(icn_mesh::JobState::Completed { receipt }) = states.get(&job.id) {
+    if let Some(icn_mesh::JobState::Completed { receipt }) =
+        ctx.job_states.get(&job.id).map(|s| s.value().clone())
+    {
         let expected = Cid::new_v1_sha256(0x55, &4i64.to_le_bytes());
         assert_eq!(receipt.result_cid, expected);
     } else {

--- a/icn-runtime/tests/wasm_executor.rs
+++ b/icn-runtime/tests/wasm_executor.rs
@@ -60,8 +60,11 @@ async fn compiled_policy_executes_via_host_abi() {
     let job_id = host_submit_mesh_job(&ctx, &job_json).await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    let states = ctx.job_states.lock().await;
-    if let Some(icn_mesh::JobState::Completed { receipt }) = states.get(&job_id) {
+    if let Some(icn_mesh::JobState::Completed { receipt }) = ctx
+        .job_states
+        .get(&job_id)
+        .map(|s| s.value().clone())
+    {
         let expected = Cid::new_v1_sha256(0x55, &2i64.to_le_bytes());
         assert_eq!(receipt.result_cid, expected);
     } else {

--- a/tests/integration/job_pipeline.rs
+++ b/tests/integration/job_pipeline.rs
@@ -63,8 +63,13 @@ mod job_pipeline {
         let job_id = host_submit_mesh_job(&node_a, &job_json).await?;
 
         {
-            let states = node_a.job_states.lock().await;
-            assert!(matches!(states.get(&job_id), Some(icn_mesh::JobState::Pending)));
+            assert!(matches!(
+                node_a
+                    .job_states
+                    .get(&job_id)
+                    .map(|s| s.value().clone()),
+                Some(icn_mesh::JobState::Pending)
+            ));
         }
 
         mesh_a.announce_job(&job).await?;
@@ -132,8 +137,7 @@ mod job_pipeline {
         service_a.broadcast_message(msg).await?;
 
         {
-            let mut states = node_a.job_states.lock().await;
-            states.insert(
+            node_a.job_states.insert(
                 job_id.clone(),
                 icn_mesh::JobState::Assigned {
                     executor: node_b.current_identity.clone(),
@@ -187,8 +191,7 @@ mod job_pipeline {
         let cid = host_anchor_receipt(&node_a, &receipt_json, &ReputationUpdater::new()).await?;
 
         {
-            let states = node_a.job_states.lock().await;
-            match states.get(&job_id) {
+            match node_a.job_states.get(&job_id).map(|s| s.value().clone()) {
                 Some(icn_mesh::JobState::Completed { .. }) => {}
                 other => panic!("Job not completed: {:?}", other),
             }


### PR DESCRIPTION
## Summary
- add `dashmap` to runtime crate dependencies
- replace `job_states` HashMap with `DashMap`
- update job state updates to call `DashMap` API
- adjust tests to use new `DashMap` accessors

## Testing
- `cargo test -p icn-runtime --no-run` *(fails: trait bounds and methods missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ccfece7908324a84dbcb6f3ce9ec9