### PR TITLE
Switch icn-api to async dag storage

### DIFF
--- a/crates/icn-api/Cargo.toml
+++ b/crates/icn-api/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [dependencies]
 icn-common = { path = "../icn-common" }
-icn-dag = { path = "../icn-dag" }
+icn-dag = { path = "../icn-dag", features = ["async"] }
 icn-network = { path = "../icn-network" }
 icn-protocol = { path = "../icn-protocol" }
 icn-governance = { path = "../icn-governance", features = ["serde"] }


### PR DESCRIPTION
## Summary
- update icn-api to depend on async dag storage
- adjust API functions and tests to use `AsyncStorageService`
- use `TokioFileDagStore` in tests

## Testing
- `cargo test -p icn-api`

------
https://chatgpt.com/codex/tasks/task_e_686cd12b7f3c8324bab1192270fb483b