### PR TITLE
Switch icn-node to async DAG storage

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -11,17 +11,16 @@
 
 // Depending on icn_common crate
 use icn_common::{
-    compute_merkle_cid, retry_with_backoff, CircuitBreaker, CircuitBreakerError,
-    SystemTimeProvider, Cid, CommonError, DagBlock, Did, NodeInfo, NodeStatus,
-    ICN_CORE_VERSION,
+    compute_merkle_cid, retry_with_backoff, Cid, CircuitBreaker, CircuitBreakerError, CommonError,
+    DagBlock, Did, NodeInfo, NodeStatus, SystemTimeProvider, ICN_CORE_VERSION,
 };
 // Remove direct use of icn_dag::put_block and icn_dag::get_block which use global store
 // use icn_dag::{put_block as dag_put_block, get_block as dag_get_block};
-use icn_dag::StorageService; // Import the trait
+use icn_dag::AsyncStorageService; // Import the async trait
 use once_cell::sync::Lazy;
 use std::sync::{Arc, Mutex}; // To accept the storage service
 use tokio::sync::Mutex as AsyncMutex;
-                             // Added imports for network functionality
+// Added imports for network functionality
 use icn_network::{NetworkService, PeerId, StubNetworkService};
 
 use icn_protocol::ProtocolMessage;
@@ -83,7 +82,7 @@ pub fn submit_transaction(tx_json: String) -> Result<String, CommonError> {
 ///
 /// Returns the [`DagBlock`] if found, or `Ok(None)` if the block does not exist.
 pub async fn query_data(
-    storage: Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>>,
+    storage: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>>,
     cid_json: String,
 ) -> Result<Option<DagBlock>, CommonError> {
     let cid: Cid = serde_json::from_str(&cid_json).map_err(|e| {
@@ -94,7 +93,7 @@ pub async fn query_data(
     })?;
 
     let store_guard = storage.lock().await;
-    store_guard.get(&cid).map_err(|e| match e {
+    store_guard.get(&cid).await.map_err(|e| match e {
         CommonError::StorageError(msg) => {
             CommonError::StorageError(format!("API: Failed to query DagBlock: {}", msg))
         }
@@ -135,7 +134,7 @@ pub fn get_node_status(is_simulated_online: bool) -> Result<NodeStatus, CommonEr
 /// Submits a DagBlock to the provided DAG store.
 /// Returns the CID of the stored block upon success.
 pub async fn submit_dag_block(
-    storage: Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>>,
+    storage: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>>,
     block_data_json: String,
     policy_enforcer: Option<Arc<dyn ScopedPolicyEnforcer>>,
     actor: Did,
@@ -170,7 +169,7 @@ pub async fn submit_dag_block(
 
     let mut store = storage.lock().await;
 
-    store.put(&block).map_err(|e| match e {
+    store.put(&block).await.map_err(|e| match e {
         CommonError::StorageError(msg) => {
             CommonError::StorageError(format!("API: Failed to store DagBlock: {}", msg))
         }
@@ -193,7 +192,7 @@ pub async fn submit_dag_block(
 /// Retrieves a DagBlock from the provided DAG store by its CID.
 /// The result is an Option<DagBlock> to indicate if the block was found.
 pub async fn retrieve_dag_block(
-    storage: Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>>,
+    storage: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>>,
     cid_json: String,
 ) -> Result<Option<DagBlock>, CommonError> {
     let cid: Cid = serde_json::from_str(&cid_json).map_err(|e| {
@@ -205,7 +204,7 @@ pub async fn retrieve_dag_block(
 
     let store = storage.lock().await;
 
-    store.get(&cid).map_err(|e| match e {
+    store.get(&cid).await.map_err(|e| match e {
         CommonError::StorageError(msg) => {
             CommonError::StorageError(format!("API: Failed to retrieve DagBlock: {}", msg))
         }
@@ -466,9 +465,9 @@ pub async fn http_get_local_peer_id(api_url: &str) -> Result<String, CommonError
             .call(|| async {
                 retry_with_backoff(
                     || async {
-                        reqwest::get(&url)
-                            .await
-                            .map_err(|e| CommonError::ApiError(format!("Failed to send request: {}", e)))
+                        reqwest::get(&url).await.map_err(|e| {
+                            CommonError::ApiError(format!("Failed to send request: {}", e))
+                        })
                     },
                     3,
                     Duration::from_millis(100),
@@ -514,9 +513,9 @@ pub async fn http_get_peer_list(api_url: &str) -> Result<Vec<String>, CommonErro
             .call(|| async {
                 retry_with_backoff(
                     || async {
-                        reqwest::get(&url)
-                            .await
-                            .map_err(|e| CommonError::ApiError(format!("Failed to send request: {}", e)))
+                        reqwest::get(&url).await.map_err(|e| {
+                            CommonError::ApiError(format!("Failed to send request: {}", e))
+                        })
                     },
                     3,
                     Duration::from_millis(100),
@@ -553,7 +552,7 @@ mod tests {
     use icn_protocol::{DagBlockRequestMessage, GossipMessage, MessagePayload, ProtocolMessage};
 
     // Helper to create a default in-memory store for tests
-    fn new_test_storage() -> Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>> {
+    fn new_test_storage() -> Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> {
         Arc::new(tokio::sync::Mutex::new(InMemoryDagStore::new()))
     }
 
@@ -930,7 +929,7 @@ mod tests {
     async fn test_query_data() {
         use icn_dag::InMemoryDagStore;
 
-        let store: Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>> =
+        let store: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> =
             Arc::new(tokio::sync::Mutex::new(InMemoryDagStore::new()));
         let data = b"query block".to_vec();
         let ts = 0u64;
@@ -958,20 +957,20 @@ mod tests {
 
     struct DenyAllStore;
 
-    impl StorageService<DagBlock> for DenyAllStore {
-        fn put(&mut self, _block: &DagBlock) -> Result<(), CommonError> {
+    impl AsyncStorageService<DagBlock> for DenyAllStore {
+        async fn put(&mut self, _block: &DagBlock) -> Result<(), CommonError> {
             Err(CommonError::PolicyDenied("put blocked".to_string()))
         }
 
-        fn get(&self, _cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
+        async fn get(&self, _cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
             Err(CommonError::PolicyDenied("get blocked".to_string()))
         }
 
-        fn delete(&mut self, _cid: &Cid) -> Result<(), CommonError> {
+        async fn delete(&mut self, _cid: &Cid) -> Result<(), CommonError> {
             Err(CommonError::PolicyDenied("delete blocked".to_string()))
         }
 
-        fn contains(&self, _cid: &Cid) -> Result<bool, CommonError> {
+        async fn contains(&self, _cid: &Cid) -> Result<bool, CommonError> {
             Err(CommonError::PolicyDenied("contains blocked".to_string()))
         }
 
@@ -986,7 +985,7 @@ mod tests {
 
     #[tokio::test]
     async fn policy_error_propagates_on_put() {
-        let store: Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>> =
+        let store: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> =
             Arc::new(tokio::sync::Mutex::new(DenyAllStore));
 
         let data = b"block".to_vec();
@@ -1012,7 +1011,7 @@ mod tests {
 
     #[tokio::test]
     async fn policy_error_propagates_on_get() {
-        let store: Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>> =
+        let store: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> =
             Arc::new(tokio::sync::Mutex::new(DenyAllStore));
 
         let cid = Cid::new_v1_sha256(0x71, b"a");
@@ -1025,7 +1024,7 @@ mod tests {
 
     #[tokio::test]
     async fn policy_error_propagates_on_query() {
-        let store: Arc<tokio::sync::Mutex<dyn StorageService<DagBlock> + Send>> =
+        let store: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> =
             Arc::new(tokio::sync::Mutex::new(DenyAllStore));
 
         let cid = Cid::new_v1_sha256(0x71, b"a");

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -154,6 +154,38 @@ impl StorageService<DagBlock> for InMemoryDagStore {
     }
 }
 
+#[cfg(feature = "async")]
+#[async_trait::async_trait]
+impl AsyncStorageService<DagBlock> for InMemoryDagStore {
+    async fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
+        StorageService::put(self, block)
+    }
+
+    async fn get(&self, cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
+        StorageService::get(self, cid)
+    }
+
+    async fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        StorageService::delete(self, cid)
+    }
+
+    async fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
+        StorageService::contains(self, cid)
+    }
+
+    async fn list_blocks(&self) -> Result<Vec<DagBlock>, CommonError> {
+        StorageService::list_blocks(self)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
 // --- File-based DAG Store (Placeholder) ---
 
 /// Simple file-based [`StorageService`] storing one JSON file per block.

--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -9,9 +9,9 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-api = { path = "../icn-api", default-features = false, features = ["types-only"] }
 icn-network = { path = "../icn-network", default-features = false }
-icn-dag = { path = "../icn-dag" }
+icn-dag = { path = "../icn-dag", features = ["async"] }
 icn-governance = { path = "../icn-governance", features = ["serde"] }
-icn-runtime = { path = "../icn-runtime", features = ["cli"] }
+icn-runtime = { path = "../icn-runtime", features = ["cli", "async"] }
 icn-identity = { path = "../icn-identity" }
 icn-mesh = { path = "../icn-mesh" }
 icn-reputation = { path = "../icn-reputation" }

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -13,7 +13,7 @@ use icn_dag::rocksdb_store::RocksDagStore;
 use icn_dag::sled_store::SledDagStore;
 #[cfg(feature = "persist-sqlite")]
 use icn_dag::sqlite_store::SqliteDagStore;
-use icn_dag::{FileDagStore, InMemoryDagStore, StorageService};
+use icn_dag::{AsyncStorageService, InMemoryDagStore, TokioFileDagStore};
 
 /// Storage backends supported by the node.
 #[derive(clap::ValueEnum, Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -527,13 +527,13 @@ impl NodeConfig {
     /// Initialize a DAG store based on this configuration.
     pub fn init_dag_store(
         &self,
-    ) -> Result<Arc<TokioMutex<dyn StorageService<DagBlock> + Send>>, CommonError> {
-        let store: Arc<TokioMutex<dyn StorageService<DagBlock> + Send>> = match self.storage_backend
+    ) -> Result<Arc<TokioMutex<dyn AsyncStorageService<DagBlock> + Send>>, CommonError> {
+        let store: Arc<TokioMutex<dyn AsyncStorageService<DagBlock> + Send>> = match self.storage_backend
         {
             StorageBackendType::Memory => {
                 Arc::new(TokioMutex::new(InMemoryDagStore::new())) as Arc<_>
             }
-            StorageBackendType::File => Arc::new(TokioMutex::new(FileDagStore::new(
+            StorageBackendType::File => Arc::new(TokioMutex::new(TokioFileDagStore::new(
                 self.storage_path.clone(),
             )?)) as Arc<_>,
             StorageBackendType::Sqlite => {

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1421,7 +1421,7 @@ async fn dag_put_handler(
         scope: None,
     };
     let mut store = state.runtime_context.dag_store.lock().await;
-    match store.put(&dag_block) {
+    match store.put(&dag_block).await {
         Ok(()) => (StatusCode::CREATED, Json(dag_block.cid)).into_response(),
         Err(e) => map_rust_error_to_json_response(
             format!("DAG put error: {}", e),
@@ -1447,7 +1447,7 @@ async fn dag_get_handler(
         }
     };
     let store = state.runtime_context.dag_store.lock().await;
-    match store.get(&cid_to_get) {
+    match store.get(&cid_to_get).await {
         Ok(Some(block)) => (StatusCode::OK, Json(block.data)).into_response(),
         Ok(None) => map_rust_error_to_json_response("Block not found", StatusCode::NOT_FOUND)
             .into_response(),


### PR DESCRIPTION
## Summary
- switch `icn-node` to use `AsyncStorageService`
- use `TokioFileDagStore` for file backend
- expose async trait in `icn-api`
- implement async trait for `InMemoryDagStore`

## Testing
- `cargo check -p icn-node`
- `cargo test -p icn-node --no-run`


------
https://chatgpt.com/codex/tasks/task_e_686cd12e76bc8324a6c3d28f48400b50