### PR TITLE
[docs] clarify TokioFileDagStore usage

### DIFF
--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -26,7 +26,8 @@ The API style prioritizes:
 
 ## Async Feature
 
-Enable the `async` feature to use asynchronous storage via `TokioFileDagStore`:
+Enable the `async` feature to use asynchronous storage via `TokioFileDagStore`.
+`TokioFileDagStore` requires your application to run on the Tokio runtime:
 
 ```toml
 [dependencies]

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -111,7 +111,8 @@ implement a custom repair strategy if desired.
 ## DAG Storage
 
 `RuntimeContext` selects a storage backend for receipts and other DAG data. When
-compiled with the `async` feature, use `TokioFileDagStore`:
+compiled with the `async` feature, use `TokioFileDagStore` (requires the Tokio
+runtime):
 
 ```rust
 use icn_runtime::context::{RuntimeContext, StubMeshNetworkService, StubSigner};


### PR DESCRIPTION
## Summary
- document Tokio runtime requirement for TokioFileDagStore
- mention Tokio runtime requirement in runtime README

## Testing
- `cargo fmt --all -- --check`
- *(failure: `cargo clippy --all-targets --all-features -- -D warnings`)*
- *(failure: `cargo test --all-features --workspace`)*

------
https://chatgpt.com/codex/tasks/task_e_686cd129fd28832490b205d112828116