### PR TITLE
Enable async feature in tests

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -51,6 +51,6 @@ once_cell = "1"
 assert_cmd = "2.0"
 predicates = "3.1"
 axum = { version = "0.7", features = ["json"] }
-icn-node = { path = "../crates/icn-node" }
-icn-runtime = { path = "../crates/icn-runtime" }
+icn-node = { path = "../crates/icn-node", features = ["with-libp2p"] }
+icn-runtime = { path = "../crates/icn-runtime", features = ["async"] }
 icn-governance = { path = "../crates/icn-governance" }


### PR DESCRIPTION
## Summary
- enable `async` feature for `icn-runtime` in integration tests
- build `icn-node` with libp2p feature for async operations

## Testing
- `cargo test --manifest-path tests/Cargo.toml --workspace --all-features --no-run` *(fails: current package believes it's in a workspace when it's not)*


------
https://chatgpt.com/codex/tasks/task_e_686cd129d1848324b8acdeeaf3055513