### PR TITLE
[mesh] add job process time metric

### DIFF
--- a/crates/icn-mesh/src/metrics.rs
+++ b/crates/icn-mesh/src/metrics.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
 
 /// Counts calls to `select_executor`.
 pub static SELECT_EXECUTOR_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
@@ -9,3 +9,6 @@ pub static SCHEDULE_MESH_JOB_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
 
 /// Tracks the number of jobs currently waiting in the runtime queue.
 pub static PENDING_JOBS_GAUGE: Lazy<Gauge<i64>> = Lazy::new(Gauge::default);
+
+/// Records the time from job assignment to receipt processing in seconds.
+pub static JOB_PROCESS_TIME: Lazy<Histogram> = Lazy::new(Histogram::default);

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1269,12 +1269,14 @@ async fn metrics_handler() -> impl IntoResponse {
     use icn_dag::metrics::{DAG_GET_CALLS, DAG_PUT_CALLS};
     use icn_economics::metrics::{CREDIT_MANA_CALLS, GET_BALANCE_CALLS, SPEND_MANA_CALLS};
     use icn_governance::metrics::{CAST_VOTE_CALLS, EXECUTE_PROPOSAL_CALLS, SUBMIT_PROPOSAL_CALLS};
-    use icn_mesh::metrics::{PENDING_JOBS_GAUGE, SCHEDULE_MESH_JOB_CALLS, SELECT_EXECUTOR_CALLS};
+    use icn_mesh::metrics::{
+        JOB_PROCESS_TIME, PENDING_JOBS_GAUGE, SCHEDULE_MESH_JOB_CALLS, SELECT_EXECUTOR_CALLS,
+    };
     use icn_runtime::metrics::{
         HOST_ACCOUNT_GET_MANA_CALLS, HOST_ACCOUNT_SPEND_MANA_CALLS,
         HOST_GET_PENDING_MESH_JOBS_CALLS, HOST_SUBMIT_MESH_JOB_CALLS,
     };
-    use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
+    use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
 
     let mut registry = Registry::default();
 
@@ -1353,6 +1355,11 @@ async fn metrics_handler() -> impl IntoResponse {
         "mesh_pending_jobs",
         "Current number of pending mesh jobs",
         PENDING_JOBS_GAUGE.clone(),
+    );
+    registry.register(
+        "mesh_job_process_time_seconds",
+        "Time from job assignment to receipt",
+        JOB_PROCESS_TIME.clone(),
     );
 
     // Add system metrics


### PR DESCRIPTION
## Summary
- add a JOB_PROCESS_TIME histogram metric in icn-mesh
- measure job elapsed time in wait_for_and_process_receipt
- expose the metric via icn-node metrics handler

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` *(fails: build took too long)*
- `cargo test --all-features --workspace` *(fails: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_686cd0c2e9108324814554b47ac6ca31