### PR TITLE
Use MPSC channel for pending mesh jobs

### DIFF
--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -178,8 +178,7 @@ async fn wasm_executor_host_submit_mesh_job_json() {
     let expected_cid = Cid::new_v1_sha256(0x55, &(40i64).to_le_bytes());
     assert_eq!(receipt.result_cid, expected_cid);
     assert_eq!(ctx.get_mana(&ctx.current_identity).await.unwrap(), 40);
-    let pending = ctx.pending_mesh_jobs.lock().await;
-    assert_eq!(pending.len(), 1);
+    assert_eq!(icn_mesh::metrics::PENDING_JOBS_GAUGE.get(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/icn-runtime/tests/wasm_host_api.rs
+++ b/crates/icn-runtime/tests/wasm_host_api.rs
@@ -120,9 +120,7 @@ async fn wasm_host_api_functions() {
     assert_eq!(mana_after, 35);
 
     // Build and anchor receipt
-    let pending = ctx.pending_mesh_jobs.lock().await;
-    let job_id = pending[0].id.clone();
-    drop(pending);
+    let job_id = JobId::from_str(&_job_id_str).unwrap();
 
     let (_sk, vk) = generate_ed25519_keypair();
     let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();


### PR DESCRIPTION
## Summary
- refactor runtime queue to use a bounded `mpsc` channel
- push jobs into the channel instead of a locked VecDeque
- process jobs using `recv()` in the manager loop
- snapshot pending jobs by draining and requeueing
- update tests for new queue mechanics

## Testing
- `cargo test --all-features --workspace` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686cd0c0eac083249676ea2fdf7fda0c