### PR TITLE
Add async overview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ More detailed information can be found in the `README.md` file within each crate
 * [Complete Feature Overview](docs/ICN_FEATURE_OVERVIEW.md) – comprehensive feature breakdown
 * [Context & Philosophy](CONTEXT.md) – core principles and architectural vision
 * [Development Workflow](docs/ONBOARDING.md) – getting started guide
+* [Async Overview](docs/async-guide.md) – networking and storage use async/await
 * [Multi-Node Setup](MULTI_NODE_GUIDE.md) – federation deployment guide
 
 ### **Governance & Economics**

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -5,6 +5,7 @@ It allows users and administrators to manage nodes, interact with the network, a
 The CLI aims for usability, discoverability, and scriptability.
 
 See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+This binary runs on Tokio; see [async-guide](../docs/async-guide.md) for details.
 
 ## Purpose
 

--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -3,6 +3,7 @@
 This crate implements or defines interfaces for content-addressed Directed Acyclic Graph (DAG) storage and manipulation, crucial for the InterCooperative Network (ICN) data model.
 
 See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+Async storage details are covered in [async-guide](../docs/async-guide.md).
 
 ## Purpose
 

--- a/crates/icn-governance/README.md
+++ b/crates/icn-governance/README.md
@@ -3,6 +3,7 @@
 This crate defines the mechanisms for network governance within the InterCooperative Network (ICN).
 
 See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+Async federation helpers are described in [async-guide](../docs/async-guide.md).
 
 ## Purpose
 

--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -4,6 +4,7 @@ This crate manages peer-to-peer (P2P) networking aspects for the InterCooperativ
 It defines the core networking abstractions, message types, and service interfaces. A lightweight stub service is available for tests, while production builds enable a libp2p-based implementation via the `libp2p` feature.
 
 See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+For a summary of async networking and storage patterns see [async-guide](../docs/async-guide.md).
 
 ## Purpose
 

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -5,6 +5,7 @@ It integrates various core components to operate a functional ICN node, handling
 lifecycle, configuration, service hosting, and persistence.
 
 See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+Async runtime considerations are documented in [async-guide](../docs/async-guide.md).
 
 ## Purpose
 

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -3,6 +3,7 @@
 This crate provides the execution environment for InterCooperative Network (ICN) logic, possibly including WebAssembly (WASM) runtimes and host interaction capabilities.
 
 See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+For the overall async model see [async-guide](../docs/async-guide.md).
 
 ## Purpose
 

--- a/docs/async-guide.md
+++ b/docs/async-guide.md
@@ -1,0 +1,18 @@
+# Async Network and Storage Overview
+
+Most operations that involve I/O in `icn-core` use Rust's `async`/`await` model. This applies to networking, the HTTP API, and all persistent storage layers. A Tokio runtime is used by the binaries and tests.
+
+## Async Storage Interfaces
+
+All storage traits expose asynchronous methods. The `icn-dag` crate defines `AsyncStorageService` and provides `TokioFileDagStore` when compiled with the `async` feature. `icn-runtime` and `icn-node` depend on these traits for DAG persistence and mana ledgers.
+
+## Crates with Async APIs
+
+* **`icn-network`** – peer discovery, messaging, and libp2p services built on Tokio.
+* **`icn-api`** – HTTP client utilities implemented with `reqwest` and async handlers.
+* **`icn-dag`** – asynchronous storage backends via the `async` feature (`TokioFileDagStore`).
+* **`icn-runtime`** – runtime context and host calls that operate on async storage and network traits.
+* **`icn-governance`** – `request_federation_sync` helper uses async network operations.
+* **`icn-cli`** and **`icn-node`** – binaries execute within a Tokio runtime and interact with async APIs.
+
+Some older synchronous helpers remain for file-based storage (`FileDagStore`) or simple test utilities, but new code should prefer the async interfaces.


### PR DESCRIPTION
## Summary
- document async/await usage across the workspace
- link the async guide from root README and crate READMEs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not compile icn-runtime)*
- `cargo test --workspace --no-run` *(failed: could not compile icn-node)*

------
https://chatgpt.com/codex/tasks/task_e_686cd0b4e3dc8324b48af3b515257444