### PR TITLE
[mesh] refine bid scoring

### DIFF
--- a/crates/icn-mesh/Cargo.toml
+++ b/crates/icn-mesh/Cargo.toml
@@ -13,3 +13,4 @@ icn-reputation = { path = "../icn-reputation" }
 icn-economics = { path = "../icn-economics" }
 once_cell = "1.21"
 prometheus-client = "0.22"
+log = "0.4"


### PR DESCRIPTION
## Summary
- log executor selection via `log::debug!`
- avoid duplicate balance checks when scoring bids
- add `available_mana` parameter to `score_bid`
- adjust tests for new API

## Testing
- `cargo fmt --all -- --check` *(fails: diff output)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails to compile icn-runtime)*
- `cargo test --all-features --workspace` *(fails to compile icn-runtime)*
- `cargo test -p icn-ccl` *(fails to compile)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ccfe7fd5c8324bc0865052d323f18