### PR TITLE
Add basic benchmarks for mesh and runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
         if: matrix.rust == 'nightly'
         run: cargo build --release --all-features --workspace
 
+      - name: Run benchmarks
+        run: cargo bench --workspace --all-features
+
   libp2p_tests:
     name: Libp2p Feature Tests
     needs: test_and_lint

--- a/crates/icn-mesh/Cargo.toml
+++ b/crates/icn-mesh/Cargo.toml
@@ -13,3 +13,6 @@ icn-reputation = { path = "../icn-reputation" }
 icn-economics = { path = "../icn-economics" }
 once_cell = "1.21"
 prometheus-client = "0.22"
+
+[dev-dependencies]
+criterion = "0.5"

--- a/crates/icn-mesh/benches/select_executor.rs
+++ b/crates/icn-mesh/benches/select_executor.rs
@@ -1,0 +1,91 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use icn_common::{Cid, Did};
+use icn_economics::ManaLedger;
+use icn_identity::SignatureBytes;
+use icn_mesh::{select_executor, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy};
+use icn_reputation::InMemoryReputationStore;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Mutex;
+
+struct BenchLedger {
+    balances: Mutex<HashMap<Did, u64>>,
+}
+
+impl BenchLedger {
+    fn new() -> Self {
+        Self {
+            balances: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl ManaLedger for BenchLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        *self.balances.lock().unwrap().get(did).unwrap_or(&0)
+    }
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        self.balances.lock().unwrap().insert(did.clone(), amount);
+        Ok(())
+    }
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let bal = map
+            .get_mut(did)
+            .ok_or_else(|| icn_common::CommonError::DatabaseError("account".into()))?;
+        if *bal < amount {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= amount;
+        Ok(())
+    }
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let entry = map.entry(did.clone()).or_insert(0);
+        *entry += amount;
+        Ok(())
+    }
+}
+
+fn bench_select_executor(c: &mut Criterion) {
+    let mut group = c.benchmark_group("select_executor");
+    for &num_bids in &[10usize, 100, 1000] {
+        group.bench_with_input(BenchmarkId::from_parameter(num_bids), &num_bids, |b, &n| {
+            let job_id = JobId(Cid::new_v1_sha256(0x55, b"bench_job"));
+            let job_spec = JobSpec::default();
+            let policy = SelectionPolicy::default();
+            let rep_store = InMemoryReputationStore::new();
+            let ledger = BenchLedger::new();
+            let mut bids = Vec::with_capacity(n);
+            for i in 0..n {
+                let did = Did::from_str(&format!("did:icn:test:{i}")).unwrap();
+                rep_store.set_score(did.clone(), (i % 10) as u64);
+                ledger.set_balance(&did, 100).unwrap();
+                bids.push(MeshJobBid {
+                    job_id: job_id.clone(),
+                    executor_did: did,
+                    price_mana: (i % 50 + 1) as u64,
+                    resources: Resources {
+                        cpu_cores: 2,
+                        memory_mb: 1024,
+                    },
+                    signature: SignatureBytes(vec![]),
+                });
+            }
+            b.iter(|| {
+                let _ = select_executor(
+                    &job_id,
+                    &job_spec,
+                    bids.clone(),
+                    &policy,
+                    &rep_store,
+                    &ledger,
+                );
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_select_executor);
+criterion_main!(benches);

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -48,6 +48,7 @@ tempfile = "3"
 serial_test = { version = "3", features = ["async"] }
 # Logging for integration tests
 env_logger = "0.11"
+criterion = { version = "0.5", features = ["async"] }
 # temp-dir = "0.1"
 
 [features]

--- a/crates/icn-runtime/benches/job_manager.rs
+++ b/crates/icn-runtime/benches/job_manager.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use icn_common::{Cid, Did};
+use icn_identity::SignatureBytes;
+use icn_mesh::{ActualMeshJob, JobId, JobSpec, MeshJobBid, Resources};
+use icn_runtime::context::{
+    LocalMeshSubmitReceiptMessage, RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner,
+};
+use icn_runtime::host_submit_mesh_job;
+use tokio::runtime::Runtime;
+use tokio::sync::Mutex as TokioMutex;
+
+fn create_context() -> Arc<RuntimeContext> {
+    let network: Arc<StubMeshNetworkService> = Arc::new(StubMeshNetworkService::new());
+    let dag = Arc::new(TokioMutex::new(StubDagStore::new()));
+    let did = Did::new("key", "bench_submitter");
+    let ctx = RuntimeContext::new(
+        did.clone(),
+        network.clone(),
+        Arc::new(StubSigner::new()),
+        Arc::new(icn_identity::KeyDidResolver),
+        dag,
+    );
+    ctx.mana_ledger.set_balance(&did, 100).expect("set balance");
+    ctx
+}
+
+async fn run_once() {
+    let ctx = create_context();
+    let network = ctx
+        .mesh_network_service
+        .clone()
+        .downcast_arc::<StubMeshNetworkService>()
+        .expect("stub network");
+    ctx.spawn_mesh_job_manager().await;
+
+    let manifest_cid = Cid::new_v1_sha256(0x55, b"manifest");
+    let job = ActualMeshJob {
+        id: JobId(Cid::new_v1_sha256(0x55, b"job")),
+        manifest_cid: manifest_cid.clone(),
+        spec: JobSpec::default(),
+        creator_did: ctx.current_identity.clone(),
+        cost_mana: 10,
+        max_execution_wait_ms: Some(1000),
+        signature: SignatureBytes(vec![]),
+    };
+    let job_json = serde_json::to_string(&job).unwrap();
+
+    let job_id = host_submit_mesh_job(&ctx, &job_json).await.unwrap();
+
+    let exec_did = Did::new("key", "bench_exec");
+    ctx.mana_ledger
+        .set_balance(&exec_did, 100)
+        .expect("set balance");
+
+    let bid = MeshJobBid {
+        job_id: job_id.clone(),
+        executor_did: exec_did.clone(),
+        price_mana: 5,
+        resources: Resources::default(),
+        signature: SignatureBytes(vec![]),
+    };
+    network.stage_bid(job_id.clone(), bid).await;
+
+    let receipt = icn_identity::ExecutionReceipt {
+        job_id: job_id.clone().into(),
+        executor_did: exec_did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"result"),
+        cpu_ms: 1,
+        success: true,
+        sig: SignatureBytes(vec![]),
+    };
+    network
+        .stage_receipt(LocalMeshSubmitReceiptMessage { receipt })
+        .await;
+
+    for _ in 0..200 {
+        {
+            let states = ctx.job_states.lock().await;
+            if matches!(
+                states.get(&job_id),
+                Some(icn_mesh::JobState::Completed { .. })
+            ) {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+fn bench_job_manager(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    c.bench_function("queue_and_process", |b| {
+        b.iter_custom(|iters| {
+            rt.block_on(async {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    let start = Instant::now();
+                    run_once().await;
+                    total += start.elapsed();
+                }
+                total
+            })
+        });
+    });
+}
+
+criterion_group!(benches, bench_job_manager);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ validate:
 
 # Run benchmarks for all crates
 bench:
-    cargo bench --all-features --workspace
+    cargo bench --workspace --all-features
 
 # Run federation health checks
 health-check:


### PR DESCRIPTION
## Summary
- benchmark select_executor with varying bids
- benchmark job manager queuing/processing
- enable Criterion in mesh/runtime crates
- run benchmarks in `just bench` and CI workflow

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p icn-mesh`
- `cargo test -p icn-runtime --lib --features async` *(fails: could not compile `icn-runtime`)*


------
https://chatgpt.com/codex/tasks/task_e_686ccff282bc8324893f87c07b257d64