### PR TITLE
Add job process time histogram

### DIFF
--- a/crates/icn-mesh/src/metrics.rs
+++ b/crates/icn-mesh/src/metrics.rs
@@ -1,5 +1,9 @@
 use once_cell::sync::Lazy;
-use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
+use prometheus_client::metrics::{
+    counter::Counter,
+    gauge::Gauge,
+    histogram::{exponential_buckets, Histogram},
+};
 
 /// Counts calls to `select_executor`.
 pub static SELECT_EXECUTOR_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
@@ -9,3 +13,9 @@ pub static SCHEDULE_MESH_JOB_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
 
 /// Tracks the number of jobs currently waiting in the runtime queue.
 pub static PENDING_JOBS_GAUGE: Lazy<Gauge<i64>> = Lazy::new(Gauge::default);
+
+/// Measures the time from job assignment to receipt processing in seconds.
+pub static JOB_PROCESS_TIME: Lazy<Histogram> = Lazy::new(|| {
+    // Start at 0.5 seconds, doubling up to ~8 minutes
+    Histogram::new(exponential_buckets(0.5, 2.0, 15))
+});

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1269,12 +1269,21 @@ async fn metrics_handler() -> impl IntoResponse {
     use icn_dag::metrics::{DAG_GET_CALLS, DAG_PUT_CALLS};
     use icn_economics::metrics::{CREDIT_MANA_CALLS, GET_BALANCE_CALLS, SPEND_MANA_CALLS};
     use icn_governance::metrics::{CAST_VOTE_CALLS, EXECUTE_PROPOSAL_CALLS, SUBMIT_PROPOSAL_CALLS};
-    use icn_mesh::metrics::{PENDING_JOBS_GAUGE, SCHEDULE_MESH_JOB_CALLS, SELECT_EXECUTOR_CALLS};
+    use icn_mesh::metrics::{
+        JOB_PROCESS_TIME,
+        PENDING_JOBS_GAUGE,
+        SCHEDULE_MESH_JOB_CALLS,
+        SELECT_EXECUTOR_CALLS,
+    };
     use icn_runtime::metrics::{
         HOST_ACCOUNT_GET_MANA_CALLS, HOST_ACCOUNT_SPEND_MANA_CALLS,
         HOST_GET_PENDING_MESH_JOBS_CALLS, HOST_SUBMIT_MESH_JOB_CALLS,
     };
-    use prometheus_client::metrics::{counter::Counter, gauge::Gauge};
+    use prometheus_client::metrics::{
+        counter::Counter,
+        gauge::Gauge,
+        histogram::Histogram,
+    };
 
     let mut registry = Registry::default();
 
@@ -1353,6 +1362,11 @@ async fn metrics_handler() -> impl IntoResponse {
         "mesh_pending_jobs",
         "Current number of pending mesh jobs",
         PENDING_JOBS_GAUGE.clone(),
+    );
+    registry.register(
+        "mesh_job_process_time_seconds",
+        "Time from assignment to receipt",
+        JOB_PROCESS_TIME.clone(),
     );
 
     // Add system metrics

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1053,6 +1053,7 @@ impl RuntimeContext {
         job: ActualMeshJob,
         assigned_executor_did: Did,
     ) -> Result<(), HostAbiError> {
+        let start_time = StdInstant::now();
         log::info!(
             "[JobManagerDetail] Waiting for receipt for job {:?} from executor {:?}",
             job.id, assigned_executor_did
@@ -1069,6 +1070,8 @@ impl RuntimeContext {
             .await
         {
             Ok(Some(receipt)) => {
+                icn_mesh::metrics::JOB_PROCESS_TIME
+                    .observe(start_time.elapsed().as_secs_f64());
                 log::info!(
                     "[JobManagerDetail] Received receipt for job {:?}: {:?}",
                     job.id, receipt


### PR DESCRIPTION
## Summary
- add `JOB_PROCESS_TIME` histogram to mesh metrics
- record assignment-to-receipt time in `RuntimeContext`
- expose metric via node metrics endpoint

## Testing
- `cargo test --all-features --workspace` *(fails: build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686ccff5533083249d6eaa204fbf6ebb