### PR TITLE
[node] enable async runtime features

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -9,9 +9,9 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-api = { path = "../icn-api", default-features = false, features = ["types-only"] }
 icn-network = { path = "../icn-network", default-features = false }
-icn-dag = { path = "../icn-dag" }
+icn-dag = { path = "../icn-dag", features = ["async"] }
 icn-governance = { path = "../icn-governance", features = ["serde"] }
-icn-runtime = { path = "../icn-runtime", features = ["cli"] }
+icn-runtime = { path = "../icn-runtime", features = ["cli", "async"] }
 icn-identity = { path = "../icn-identity" }
 icn-mesh = { path = "../icn-mesh" }
 icn-reputation = { path = "../icn-reputation" }


### PR DESCRIPTION
## Summary
- enable async features for `icn-runtime` and `icn-dag` in icn-node

## Testing
- `cargo check -p icn-node` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_686cd12f9fa483248ac09d95fbb08bb4