### PR TITLE
Switch runtime job state map to DashMap

### DIFF
--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -32,6 +32,7 @@ wasmparser = "0.121"
 bincode = "1.3"
 once_cell = "1.21"
 prometheus-client = "0.22"
+dashmap = "5"
 clap = { version = "4.0", features = ["derive"], optional = true }
 icn-ccl = { path = "../../icn-ccl" }
 sha2 = "0.10"

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1,8 +1,6 @@
 //! Defines the `RuntimeContext`, `HostEnvironment`, and related types for the ICN runtime.
 
-use icn_common::{
-    Cid, CommonError, DagBlock, Did,
-};
+use icn_common::{Cid, CommonError, DagBlock, Did};
 use icn_identity::{ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes};
 use icn_mesh::{ActualMeshJob, JobId, JobState, MeshJobBid, Resources};
 
@@ -14,6 +12,7 @@ use icn_network::{NetworkService, PeerId, StubNetworkService};
 use icn_protocol::GossipMessage;
 use icn_protocol::{MessagePayload, ProtocolMessage};
 
+use dashmap::DashMap;
 #[cfg(not(any(
     feature = "persist-sled",
     feature = "persist-sqlite",
@@ -34,13 +33,13 @@ use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
+#[cfg(not(feature = "async"))]
+use std::sync::Mutex as SyncMutex;
 use std::time::{Duration as StdDuration, Instant as StdInstant};
 #[cfg(test)]
 use tempfile;
 #[cfg(feature = "async")]
 use tokio::sync::Mutex as TokioMutex;
-#[cfg(not(feature = "async"))]
-use std::sync::Mutex as SyncMutex;
 
 use async_trait::async_trait;
 
@@ -74,7 +73,7 @@ use icn_dag::rocksdb_store::RocksDagStore;
 #[cfg(feature = "async")]
 use icn_dag::{AsyncStorageService as DagStorageService, TokioFileDagStore};
 #[cfg(not(feature = "async"))]
-use icn_dag::{StorageService as DagStorageService, FileDagStore};
+use icn_dag::{FileDagStore, StorageService as DagStorageService};
 
 #[cfg(feature = "async")]
 type DagStoreMutex<T> = TokioMutex<T>;
@@ -437,7 +436,8 @@ impl MeshNetworkService for DefaultMeshNetworkService {
     ) -> Result<Vec<MeshJobBid>, HostAbiError> {
         log::debug!(
             "[DefaultMeshNetworkService] Collecting bids for job {:?} for {:?}",
-            job_id, duration
+            job_id,
+            duration
         );
         let mut bids = Vec::new();
         let mut receiver = self.inner.subscribe().await.map_err(|e| {
@@ -656,7 +656,7 @@ pub struct RuntimeContext {
     pub current_identity: Did,
     pub mana_ledger: SimpleManaLedger,
     pub pending_mesh_jobs: Arc<DagStoreMutex<VecDeque<ActualMeshJob>>>,
-    pub job_states: Arc<DagStoreMutex<HashMap<JobId, JobState>>>,
+    pub job_states: Arc<DashMap<JobId, JobState>>,
     pub governance_module: Arc<DagStoreMutex<GovernanceModule>>,
     pub mesh_network_service: Arc<dyn MeshNetworkService>, // Uses local MeshNetworkService trait
     pub signer: Arc<dyn Signer>,
@@ -760,7 +760,7 @@ impl RuntimeContext {
         policy_enforcer: Option<Arc<dyn ScopedPolicyEnforcer>>,
         time_provider: Arc<dyn icn_common::TimeProvider>,
     ) -> Arc<Self> {
-        let job_states = Arc::new(TokioMutex::new(HashMap::new()));
+        let job_states = Arc::new(DashMap::new());
         let pending_mesh_jobs = Arc::new(TokioMutex::new(VecDeque::new()));
 
         #[cfg(feature = "persist-sled")]
@@ -853,9 +853,9 @@ impl RuntimeContext {
         policy_enforcer: Option<Arc<dyn ScopedPolicyEnforcer>>,
     ) -> Result<Arc<Self>, CommonError> {
         #[cfg(feature = "persist-rocksdb")]
-        let dag_store = Arc::new(DagStoreMutex::new(icn_dag::rocksdb_store::RocksDagStore::new(
-            dag_path.clone(),
-        )?)) as Arc<DagStoreMutex<dyn DagStorageService<DagBlock> + Send>>;
+        let dag_store = Arc::new(DagStoreMutex::new(
+            icn_dag::rocksdb_store::RocksDagStore::new(dag_path.clone())?,
+        )) as Arc<DagStoreMutex<dyn DagStorageService<DagBlock> + Send>>;
 
         #[cfg(all(not(feature = "persist-rocksdb"), feature = "persist-sled"))]
         let dag_store = Arc::new(DagStoreMutex::new(icn_dag::sled_store::SledDagStore::new(
@@ -876,9 +876,9 @@ impl RuntimeContext {
             }
             #[cfg(not(feature = "async"))]
             {
-                Arc::new(DagStoreMutex::new(icn_dag::sqlite_store::SqliteDagStore::new(
-                    dag_path.clone(),
-                )?)) as Arc<DagStoreMutex<dyn DagStorageService<DagBlock> + Send>>
+                Arc::new(DagStoreMutex::new(
+                    icn_dag::sqlite_store::SqliteDagStore::new(dag_path.clone())?,
+                )) as Arc<DagStoreMutex<dyn DagStorageService<DagBlock> + Send>>
             }
         };
 
@@ -1023,8 +1023,7 @@ impl RuntimeContext {
         let mut queue = self.pending_mesh_jobs.lock().await;
         queue.push_back(job.clone());
         icn_mesh::metrics::PENDING_JOBS_GAUGE.inc();
-        let mut states = self.job_states.lock().await;
-        states.insert(job.id.clone(), JobState::Pending);
+        self.job_states.insert(job.id.clone(), JobState::Pending);
         log::info!(
             "[RuntimeContext] Queued mesh job: id={:?}, state=Pending",
             job.id
@@ -1055,7 +1054,8 @@ impl RuntimeContext {
     ) -> Result<(), HostAbiError> {
         log::info!(
             "[JobManagerDetail] Waiting for receipt for job {:?} from executor {:?}",
-            job.id, assigned_executor_did
+            job.id,
+            assigned_executor_did
         );
         // Determine how long to wait for the execution receipt.
         let timeout_ms = job
@@ -1071,7 +1071,8 @@ impl RuntimeContext {
             Ok(Some(receipt)) => {
                 log::info!(
                     "[JobManagerDetail] Received receipt for job {:?}: {:?}",
-                    job.id, receipt
+                    job.id,
+                    receipt
                 );
 
                 // Resolve executor verifying key and verify the receipt.
@@ -1091,7 +1092,8 @@ impl RuntimeContext {
                     Err(e) => {
                         log::error!(
                             "[JobManagerDetail] Failed to resolve DID {:?}: {}",
-                            receipt.executor_did, e
+                            receipt.executor_did,
+                            e
                         );
                         return Err(HostAbiError::Common(e));
                     }
@@ -1101,10 +1103,10 @@ impl RuntimeContext {
                     Ok(receipt_cid) => {
                         log::info!(
                             "[JobManagerDetail] Receipt for job {:?} anchored successfully: {:?}",
-                            job.id, receipt_cid
+                            job.id,
+                            receipt_cid
                         );
-                        let mut job_states_guard = self.job_states.lock().await;
-                        job_states_guard.insert(
+                        self.job_states.insert(
                             job.id.clone(),
                             JobState::Completed {
                                 receipt: receipt.clone(),
@@ -1121,8 +1123,7 @@ impl RuntimeContext {
                     }
                     Err(e) => {
                         log::error!("[JobManagerDetail] Failed to anchor receipt for job {:?}: {}. Marking as Failed (AnchorFailed).", job.id, e);
-                        let mut job_states_guard = self.job_states.lock().await;
-                        job_states_guard.insert(
+                        self.job_states.insert(
                             job.id.clone(),
                             JobState::Failed {
                                 reason: format!("Failed to anchor receipt: {}", e),
@@ -1131,7 +1132,8 @@ impl RuntimeContext {
                         if let Err(err) = self.credit_mana(&job.creator_did, job.cost_mana).await {
                             log::error!(
                                 "[JobManagerDetail] Failed to refund mana to {:?}: {}",
-                                job.creator_did, err
+                                job.creator_did,
+                                err
                             );
                         }
                         Err(HostAbiError::DagOperationFailed(format!(
@@ -1143,8 +1145,7 @@ impl RuntimeContext {
             }
             Ok(None) => {
                 log::warn!("[JobManagerDetail] No receipt received for job {:?} within timeout. Marking as Failed (NoReceipt).", job.id);
-                let mut job_states_guard = self.job_states.lock().await;
-                job_states_guard.insert(
+                self.job_states.insert(
                     job.id.clone(),
                     JobState::Failed {
                         reason: "No receipt received within timeout".to_string(),
@@ -1153,7 +1154,8 @@ impl RuntimeContext {
                 if let Err(err) = self.credit_mana(&job.creator_did, job.cost_mana).await {
                     log::error!(
                         "[JobManagerDetail] Failed to refund mana to {:?}: {}",
-                        job.creator_did, err
+                        job.creator_did,
+                        err
                     );
                 }
                 Err(HostAbiError::NetworkError(
@@ -1162,8 +1164,7 @@ impl RuntimeContext {
             }
             Err(e) => {
                 log::error!("[JobManagerDetail] Error while trying to receive receipt for job {:?}: {}. Marking as Failed (ReceiptError).", job.id, e);
-                let mut job_states_guard = self.job_states.lock().await;
-                job_states_guard.insert(
+                self.job_states.insert(
                     job.id.clone(),
                     JobState::Failed {
                         reason: format!("Error receiving receipt: {}", e),
@@ -1172,7 +1173,8 @@ impl RuntimeContext {
                 if let Err(err) = self.credit_mana(&job.creator_did, job.cost_mana).await {
                     log::error!(
                         "[JobManagerDetail] Failed to refund mana to {:?}: {}",
-                        job.creator_did, err
+                        job.creator_did,
+                        err
                     );
                 }
                 Err(e)
@@ -1208,13 +1210,15 @@ impl RuntimeContext {
                     let current_job_id = job.id.clone(); // Clone for use in logs and map keys
 
                     // Get current state from the central job_states map
-                    let job_states_guard = self_clone.job_states.lock().await;
-                    let current_job_state = job_states_guard.get(&current_job_id).cloned();
-                    drop(job_states_guard); // Release lock quickly
+                    let current_job_state = self_clone
+                        .job_states
+                        .get(&current_job_id)
+                        .map(|s| s.clone());
 
                     log::info!(
                         "[JobManagerLoop] Processing job: {:?}, current state from map: {:?}",
-                        current_job_id, current_job_state
+                        current_job_id,
+                        current_job_state
                     );
 
                     match current_job_state {
@@ -1227,7 +1231,8 @@ impl RuntimeContext {
                             {
                                 log::error!(
                                     "[JobManagerLoop] Failed to announce job {:?}: {}. Re-queuing.",
-                                    current_job_id, e
+                                    current_job_id,
+                                    e
                                 );
                                 jobs_to_requeue.push_back(job); // Re-queue the ActualMeshJob
                                 continue;
@@ -1254,21 +1259,20 @@ impl RuntimeContext {
 
                             if bids.is_empty() {
                                 log::warn!("[JobManagerLoop] No bids received for job {:?}. Marking as Failed (NoBids).", current_job_id);
-                                let mut job_states_guard = self_clone.job_states.lock().await;
-                                job_states_guard.insert(
+                                self_clone.job_states.insert(
                                     current_job_id.clone(),
                                     JobState::Failed {
                                         reason: "No bids received".to_string(),
                                     },
                                 );
-                                drop(job_states_guard);
                                 if let Err(e) = self_clone
                                     .credit_mana(&job.creator_did, job.cost_mana)
                                     .await
                                 {
                                     log::error!(
                                         "[JobManagerLoop] Failed to refund mana to {:?}: {}",
-                                        job.creator_did, e
+                                        job.creator_did,
+                                        e
                                     );
                                 }
                                 continue;
@@ -1290,9 +1294,9 @@ impl RuntimeContext {
                                 };
                                 log::info!("[JobManagerLoop] Job {:?} assigned to executor {:?}. Notifying...", current_job_id, selected_exec);
 
-                                let mut job_states_guard = self_clone.job_states.lock().await;
-                                job_states_guard.insert(current_job_id.clone(), new_state);
-                                drop(job_states_guard);
+                                self_clone
+                                    .job_states
+                                    .insert(current_job_id.clone(), new_state);
 
                                 let notice = JobAssignmentNotice {
                                     job_id: current_job_id.clone(),
@@ -1305,10 +1309,9 @@ impl RuntimeContext {
                                     .await
                                 {
                                     log::error!("[JobManagerLoop] Failed to notify executor for job {:?}: {}. Reverting to Pending.", current_job_id, e);
-                                    let mut job_states_guard = self_clone.job_states.lock().await;
-                                    job_states_guard
+                                    self_clone
+                                        .job_states
                                         .insert(current_job_id.clone(), JobState::Pending); // Revert state in map
-                                    drop(job_states_guard);
                                     jobs_to_requeue.push_back(job); // Re-queue the ActualMeshJob
                                     continue;
                                 }
@@ -1326,21 +1329,20 @@ impl RuntimeContext {
                                 });
                             } else {
                                 log::warn!("[JobManagerLoop] No valid bid selected for job {:?}. Marking as Failed.", current_job_id);
-                                let mut job_states_guard = self_clone.job_states.lock().await;
-                                job_states_guard.insert(
+                                self_clone.job_states.insert(
                                     current_job_id.clone(),
                                     JobState::Failed {
                                         reason: "No valid bid selected".to_string(),
                                     },
                                 );
-                                drop(job_states_guard);
                                 if let Err(e) = self_clone
                                     .credit_mana(&job.creator_did, job.cost_mana)
                                     .await
                                 {
                                     log::error!(
                                         "[JobManagerLoop] Failed to refund mana to {:?}: {}",
-                                        job.creator_did, e
+                                        job.creator_did,
+                                        e
                                     );
                                 }
                                 continue;
@@ -1452,7 +1454,8 @@ impl RuntimeContext {
     pub async fn spend_mana(&self, account: &Did, amount: u64) -> Result<(), HostAbiError> {
         log::debug!(
             "[RuntimeContext] spend_mana called for account: {:?} amount: {}",
-            account, amount
+            account,
+            amount
         );
         if account != &self.current_identity {
             return Err(HostAbiError::InvalidParameters(
@@ -1466,7 +1469,8 @@ impl RuntimeContext {
     pub async fn credit_mana(&self, account: &Did, amount: u64) -> Result<(), HostAbiError> {
         log::debug!(
             "[RuntimeContext] credit_mana called for account: {:?} amount: {}",
-            account, amount
+            account,
+            amount
         );
         icn_economics::credit_mana(self.mana_ledger.clone(), account, amount)
             .map_err(|e| HostAbiError::InternalError(format!("{e:?}")))
@@ -1480,7 +1484,8 @@ impl RuntimeContext {
     ) -> Result<Cid, HostAbiError> {
         log::info!(
             "[CONTEXT] Attempting to anchor receipt for job {:?} from executor {:?}",
-            receipt.job_id, receipt.executor_did
+            receipt.job_id,
+            receipt.executor_did
         );
 
         // Resolve the executor's verifying key via the provided DidResolver.
@@ -1552,8 +1557,7 @@ impl RuntimeContext {
         );
 
         {
-            let mut job_states_guard = self.job_states.lock().await;
-            job_states_guard.insert(
+            self.job_states.insert(
                 JobId::from(receipt.job_id.clone()),
                 JobState::Completed {
                     receipt: receipt.clone(),
@@ -1877,14 +1881,17 @@ impl RuntimeContext {
     }
 
     #[cfg(feature = "async")]
-    pub async fn host_anchor_receipt(&self, receipt: &IdentityExecutionReceipt) -> Result<(), HostAbiError> {
+    pub async fn host_anchor_receipt(
+        &self,
+        receipt: &IdentityExecutionReceipt,
+    ) -> Result<(), HostAbiError> {
         let receipt_data = serde_json::to_vec(receipt)
             .map_err(|e| HostAbiError::Common(CommonError::SerializationError(e.to_string())))?;
-        
+
         // Convert from icn_identity::SignatureBytes to icn_common::SignatureBytes
         let common_sig = icn_common::SignatureBytes(receipt.sig.0.clone());
         let signature_opt = Some(common_sig);
-        
+
         let block = DagBlock {
             cid: icn_common::compute_merkle_cid(
                 0x55, // DAG-CBOR codec
@@ -1902,7 +1909,7 @@ impl RuntimeContext {
             signature: signature_opt,
             scope: None,
         };
-        
+
         let result = {
             #[cfg(feature = "async")]
             {
@@ -1919,20 +1926,25 @@ impl RuntimeContext {
         let cid = block.cid.clone();
         log::info!(
             "Anchored receipt for job {} from executor {} to DAG as {}",
-            receipt.job_id, receipt.executor_did, cid
+            receipt.job_id,
+            receipt.executor_did,
+            cid
         );
         Ok(())
     }
 
     #[cfg(not(feature = "async"))]
-    pub fn host_anchor_receipt(&self, receipt: &IdentityExecutionReceipt) -> Result<(), HostAbiError> {
+    pub fn host_anchor_receipt(
+        &self,
+        receipt: &IdentityExecutionReceipt,
+    ) -> Result<(), HostAbiError> {
         let receipt_data = serde_json::to_vec(receipt)
             .map_err(|e| HostAbiError::Common(CommonError::SerializationError(e.to_string())))?;
-        
+
         // Convert from icn_identity::SignatureBytes to icn_common::SignatureBytes
         let common_sig = icn_common::SignatureBytes(receipt.sig.0.clone());
         let signature_opt = Some(common_sig);
-        
+
         let block = DagBlock {
             cid: icn_common::compute_merkle_cid(
                 0x55, // DAG-CBOR codec
@@ -1950,7 +1962,7 @@ impl RuntimeContext {
             signature: signature_opt,
             scope: None,
         };
-        
+
         let result = {
             #[cfg(feature = "async")]
             {
@@ -1977,7 +1989,7 @@ impl RuntimeContext {
         mesh_network_service: Arc<StubMeshNetworkService>,
         dag_store: Arc<TokioMutex<StubDagStore>>,
     ) -> Arc<Self> {
-        let job_states = Arc::new(TokioMutex::new(HashMap::new()));
+        let job_states = Arc::new(DashMap::new());
         let pending_mesh_jobs = Arc::new(TokioMutex::new(VecDeque::new()));
         let temp_dir = tempfile::tempdir().expect("temp dir for mana ledger");
         let mana_ledger_path = temp_dir.path().join("mana.sled");
@@ -2496,7 +2508,8 @@ impl MeshNetworkService for StubMeshNetworkService {
     ) -> Result<(), HostAbiError> {
         log::debug!(
             "[StubMeshNetworkService] Broadcast assignment for job {:?} to executor {:?}",
-            notice.job_id, notice.executor_did
+            notice.job_id,
+            notice.executor_did
         );
         Ok(())
     }

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -154,8 +154,8 @@ mod runtime_host_abi_tests {
         for attempt in 1..=20 {
             sleep(Duration::from_millis(500)).await;
 
-            let job_states = submitter_node.job_states.lock().await;
-            if let Some(job_state) = job_states.get(&submitted_job_id) {
+            if let Some(job_state) = submitter_node.job_states.get(&submitted_job_id) {
+                let job_state = job_state.value();
                 match job_state {
                     icn_mesh::JobState::Assigned { executor } => {
                         info!(
@@ -198,8 +198,8 @@ mod runtime_host_abi_tests {
         for attempt in 1..=30 {
             sleep(Duration::from_millis(1000)).await;
 
-            let job_states = submitter_node.job_states.lock().await;
-            if let Some(job_state) = job_states.get(&submitted_job_id) {
+            if let Some(job_state) = submitter_node.job_states.get(&submitted_job_id) {
+                let job_state = job_state.value();
                 match job_state {
                     icn_mesh::JobState::Completed { receipt } => {
                         info!("🎉 [RUNTIME-INTEGRATION] Job completed! Receipt job_id: {} (attempt {})", receipt.job_id, attempt);
@@ -297,10 +297,11 @@ mod runtime_host_abi_tests {
         info!("✅ [HOST-ABI-TEST] Job submitted successfully: {}", job_id);
 
         // Verify job appears in pending state
-        let job_states = runtime_ctx.job_states.lock().await;
-        let job_state = job_states
+        let job_state_entry = runtime_ctx
+            .job_states
             .get(&job_id)
             .ok_or_else(|| anyhow::anyhow!("Job not found in runtime state"))?;
+        let job_state = job_state_entry.value();
 
         match job_state {
             icn_mesh::JobState::Pending => {

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -59,13 +59,17 @@ async fn assert_job_state(
     tokio::task::yield_now().await;
     sleep(Duration::from_millis(100)).await; // Increased delay slightly for job manager processing
 
-    let states = ctx.job_states.lock().await;
-    let job_state = states.get(job_id).unwrap_or_else(|| {
+    let job_state_entry = ctx.job_states.get(job_id).unwrap_or_else(|| {
         panic!(
             "Job ID {:?} not found in states map. States: {:?}",
-            job_id, states
+            job_id,
+            ctx.job_states
+                .iter()
+                .map(|e| (*e.key(), e.value().clone()))
+                .collect::<Vec<_>>()
         )
     });
+    let job_state = job_state_entry.value().clone();
 
     match (job_state, &expected_state_variant) {
         (JobState::Pending, JobStateVariant::Pending) => {}
@@ -521,8 +525,8 @@ async fn test_job_manager_refunds_on_no_valid_bid() {
     let mana_after = ctx.get_mana(&submitter_did).await.unwrap();
     assert_eq!(mana_after, 50);
 
-    let states = ctx.job_states.lock().await;
-    let state = states.get(&job_id).expect("job state");
+    let state = ctx.job_states.get(&job_id).expect("job state");
+    let state = state.value();
     match state {
         JobState::Failed { .. } => {}
         other => panic!("Unexpected state {:?}", other),
@@ -624,8 +628,7 @@ async fn assign_job_to_executor_directly(
         "Test util: Directly assigning job {:?} to executor {:?}",
         job_id, assigned_executor_did
     );
-    let mut states = job_manager_ctx.job_states.lock().await;
-    states.insert(
+    job_manager_ctx.job_states.insert(
         JobId(job_id),
         JobState::Assigned {
             executor: assigned_executor_did.clone(),

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -284,10 +284,13 @@ async fn submit_compiled_ccl_runs_via_executor() {
     let job_json = serde_json::to_string(&job).unwrap();
     let job_id = host_submit_mesh_job(&ctx, &job_json).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    let states = ctx.job_states.lock().await;
-    if let Some(icn_mesh::JobState::Completed { receipt }) = states.get(&job_id) {
-        let expected = Cid::new_v1_sha256(0x55, &9i64.to_le_bytes());
-        assert_eq!(receipt.result_cid, expected);
+    if let Some(state) = ctx.job_states.get(&job_id) {
+        if let icn_mesh::JobState::Completed { receipt } = state.value() {
+            let expected = Cid::new_v1_sha256(0x55, &9i64.to_le_bytes());
+            assert_eq!(receipt.result_cid, expected);
+        } else {
+            panic!("job not completed");
+        }
     } else {
         panic!("job not completed");
     }
@@ -327,10 +330,13 @@ async fn queued_compiled_ccl_executes() {
     };
     ctx.internal_queue_mesh_job(job.clone()).await.unwrap();
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    let states = ctx.job_states.lock().await;
-    if let Some(icn_mesh::JobState::Completed { receipt }) = states.get(&job.id) {
-        let expected = Cid::new_v1_sha256(0x55, &4i64.to_le_bytes());
-        assert_eq!(receipt.result_cid, expected);
+    if let Some(state) = ctx.job_states.get(&job.id) {
+        if let icn_mesh::JobState::Completed { receipt } = state.value() {
+            let expected = Cid::new_v1_sha256(0x55, &4i64.to_le_bytes());
+            assert_eq!(receipt.result_cid, expected);
+        } else {
+            panic!("job not completed");
+        }
     } else {
         panic!("job not completed");
     }

--- a/tests/integration/job_pipeline.rs
+++ b/tests/integration/job_pipeline.rs
@@ -63,8 +63,10 @@ mod job_pipeline {
         let job_id = host_submit_mesh_job(&node_a, &job_json).await?;
 
         {
-            let states = node_a.job_states.lock().await;
-            assert!(matches!(states.get(&job_id), Some(icn_mesh::JobState::Pending)));
+            assert!(matches!(
+                node_a.job_states.get(&job_id).map(|e| e.value().clone()),
+                Some(icn_mesh::JobState::Pending)
+            ));
         }
 
         mesh_a.announce_job(&job).await?;
@@ -132,8 +134,7 @@ mod job_pipeline {
         service_a.broadcast_message(msg).await?;
 
         {
-            let mut states = node_a.job_states.lock().await;
-            states.insert(
+            node_a.job_states.insert(
                 job_id.clone(),
                 icn_mesh::JobState::Assigned {
                     executor: node_b.current_identity.clone(),
@@ -187,8 +188,7 @@ mod job_pipeline {
         let cid = host_anchor_receipt(&node_a, &receipt_json, &ReputationUpdater::new()).await?;
 
         {
-            let states = node_a.job_states.lock().await;
-            match states.get(&job_id) {
+            match node_a.job_states.get(&job_id).map(|e| e.value().clone()) {
                 Some(icn_mesh::JobState::Completed { .. }) => {}
                 other => panic!("Job not completed: {:?}", other),
             }

--- a/tests/integration/libp2p_job_pipeline.rs
+++ b/tests/integration/libp2p_job_pipeline.rs
@@ -251,8 +251,10 @@ mod libp2p_job_pipeline {
         let job_id = host_submit_mesh_job(&node_a, &job_json).await?;
 
         {
-            let states = node_a.job_states.lock().await;
-            assert!(matches!(states.get(&job_id), Some(JobState::Pending)));
+            assert!(matches!(
+                node_a.job_states.get(&job_id).map(|e| e.value().clone()),
+                Some(JobState::Pending)
+            ));
         }
 
         mesh_a.announce_job(&job).await?;
@@ -320,8 +322,7 @@ mod libp2p_job_pipeline {
         service_a.broadcast_message(msg).await?;
 
         {
-            let mut states = node_a.job_states.lock().await;
-            states.insert(
+            node_a.job_states.insert(
                 job_id.clone(),
                 JobState::Assigned {
                     executor: node_b.current_identity.clone(),
@@ -376,8 +377,7 @@ mod libp2p_job_pipeline {
         let cid = host_anchor_receipt(&node_a, &receipt_json, &ReputationUpdater::new()).await?;
 
         {
-            let states = node_a.job_states.lock().await;
-            match states.get(&job_id) {
+            match node_a.job_states.get(&job_id).map(|e| e.value().clone()) {
                 Some(JobState::Completed { .. }) => {}
                 other => panic!("Job not completed: {:?}", other),
             }


### PR DESCRIPTION
## Summary
- use `DashMap` for `job_states` in runtime context
- add `dashmap` dependency
- update node job listing to use concurrent map
- adapt tests for new API

## Testing
- `cargo check -p icn-runtime --all-features` *(fails: could not finish in time)*

------
https://chatgpt.com/codex/tasks/task_e_686cd0c13a8083249476b8805da430a4