### PR TITLE
Add benchmarks for mesh and runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
         if: matrix.rust == 'nightly'
         run: cargo build --release --all-features --workspace
 
+      - name: Run benchmarks
+        run: cargo bench --workspace --all-features
+
   libp2p_tests:
     name: Libp2p Feature Tests
     needs: test_and_lint

--- a/crates/icn-mesh/Cargo.toml
+++ b/crates/icn-mesh/Cargo.toml
@@ -13,3 +13,6 @@ icn-reputation = { path = "../icn-reputation" }
 icn-economics = { path = "../icn-economics" }
 once_cell = "1.21"
 prometheus-client = "0.22"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async"] }

--- a/crates/icn-mesh/benches/select_executor.rs
+++ b/crates/icn-mesh/benches/select_executor.rs
@@ -1,0 +1,67 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use icn_common::{Cid, Did};
+use icn_economics::ManaLedger;
+use icn_identity::SignatureBytes;
+use icn_mesh::{select_executor, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy};
+use icn_reputation::InMemoryReputationStore;
+
+struct BenchLedger {
+    balance: u64,
+}
+
+impl ManaLedger for BenchLedger {
+    fn get_balance(&self, _did: &Did) -> u64 {
+        self.balance
+    }
+
+    fn set_balance(&self, _did: &Did, _amount: u64) -> Result<(), icn_common::CommonError> {
+        Ok(())
+    }
+
+    fn spend(&self, _did: &Did, _amount: u64) -> Result<(), icn_common::CommonError> {
+        Ok(())
+    }
+
+    fn credit(&self, _did: &Did, _amount: u64) -> Result<(), icn_common::CommonError> {
+        Ok(())
+    }
+}
+
+fn dummy_job_id() -> JobId {
+    JobId(Cid::new_v1_sha256(0x55, b"select_executor_bench"))
+}
+
+fn create_bids(job_id: &JobId, count: usize) -> Vec<MeshJobBid> {
+    (0..count)
+        .map(|i| MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: Did::new("bench", &format!("exec{i}")),
+            price_mana: ((i % 10) + 1) as u64,
+            resources: Resources {
+                cpu_cores: 1,
+                memory_mb: 512,
+            },
+            signature: SignatureBytes(Vec::new()),
+        })
+        .collect()
+}
+
+fn bench_select_executor(c: &mut Criterion) {
+    let rep_store = InMemoryReputationStore::new();
+    let ledger = BenchLedger { balance: 100 };
+    let job_id = dummy_job_id();
+    let spec = JobSpec::default();
+    let policy = SelectionPolicy::default();
+
+    for &count in &[10usize, 100, 1000] {
+        let bids = create_bids(&job_id, count);
+        c.bench_function(&format!("select_executor_{count}"), |b| {
+            b.iter(|| {
+                select_executor(&job_id, &spec, bids.clone(), &policy, &rep_store, &ledger);
+            });
+        });
+    }
+}
+
+criterion_group!(mesh_benches, bench_select_executor);
+criterion_main!(mesh_benches);

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -48,6 +48,8 @@ tempfile = "3"
 serial_test = { version = "3", features = ["async"] }
 # Logging for integration tests
 env_logger = "0.11"
+# Benchmarking
+criterion = { version = "0.5", features = ["async"] }
 # temp-dir = "0.1"
 
 [features]

--- a/crates/icn-runtime/benches/job_manager.rs
+++ b/crates/icn-runtime/benches/job_manager.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use icn_common::{Cid, Did};
+use icn_identity::SignatureBytes;
+use icn_mesh::{
+    select_executor, ActualMeshJob, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy,
+};
+use icn_runtime::context::{
+    JobAssignmentNotice, LocalMeshSubmitReceiptMessage, RuntimeContext, StubDagStore,
+    StubMeshNetworkService, StubSigner,
+};
+use tokio::runtime::Runtime;
+use tokio::sync::Mutex as TokioMutex;
+
+async fn queue_and_process_job() {
+    let network = Arc::new(StubMeshNetworkService::new());
+    let dag_store = Arc::new(TokioMutex::new(StubDagStore::new()));
+    let ctx = RuntimeContext::new(
+        Did::new("bench", "submitter"),
+        network.clone(),
+        Arc::new(StubSigner::new()),
+        Arc::new(icn_identity::KeyDidResolver),
+        dag_store,
+    );
+    ctx.mana_ledger
+        .set_balance(&ctx.current_identity, 100)
+        .expect("set balance");
+
+    let job = ActualMeshJob {
+        id: JobId(Cid::new_v1_sha256(0x55, b"bench_job")),
+        manifest_cid: Cid::new_v1_sha256(0x55, b"manifest"),
+        spec: JobSpec::default(),
+        creator_did: ctx.current_identity.clone(),
+        cost_mana: 10,
+        max_execution_wait_ms: None,
+        signature: SignatureBytes(Vec::new()),
+    };
+
+    let exec_did = Did::new("bench", "exec1");
+    let bid = MeshJobBid {
+        job_id: job.id.clone(),
+        executor_did: exec_did.clone(),
+        price_mana: 5,
+        resources: Resources::default(),
+        signature: SignatureBytes(Vec::new()),
+    };
+    network.stage_bid(job.id.clone(), bid).await;
+
+    let receipt = icn_identity::ExecutionReceipt {
+        job_id: job.id.clone().into(),
+        executor_did: exec_did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"result"),
+        cpu_ms: 10,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    };
+    network
+        .stage_receipt(LocalMeshSubmitReceiptMessage { receipt })
+        .await;
+
+    ctx.internal_queue_mesh_job(job.clone())
+        .await
+        .expect("queue job");
+
+    ctx.mesh_network_service
+        .announce_job(&job)
+        .await
+        .expect("announce");
+    let bids = ctx
+        .mesh_network_service
+        .collect_bids_for_job(&job.id, Duration::from_millis(10))
+        .await
+        .expect("collect");
+    let policy = SelectionPolicy::default();
+    let exec = select_executor(
+        &job.id,
+        &job.spec,
+        bids,
+        &policy,
+        ctx.reputation_store.as_ref(),
+        &ctx.mana_ledger,
+    )
+    .expect("selected executor");
+    ctx.mesh_network_service
+        .notify_executor_of_assignment(&JobAssignmentNotice {
+            job_id: job.id.clone(),
+            executor_did: exec.clone(),
+        })
+        .await
+        .expect("notify");
+    let _ = ctx
+        .mesh_network_service
+        .try_receive_receipt(&job.id, &exec, Duration::from_millis(10))
+        .await
+        .expect("receipt");
+}
+
+fn bench_job_manager(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    c.bench_function("queue_and_process_job", |b| {
+        b.to_async(&rt).iter(|| queue_and_process_job());
+    });
+}
+
+criterion_group!(runtime_benches, bench_job_manager);
+criterion_main!(runtime_benches);

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ validate:
 
 # Run benchmarks for all crates
 bench:
-    cargo bench --all-features --workspace
+    cargo bench --workspace --all-features
 
 # Run federation health checks
 health-check:


### PR DESCRIPTION
## Summary
- benchmark `select_executor` with varying bid counts
- benchmark job queuing and processing flow using stubs
- enable `criterion` for `icn-mesh` and `icn-runtime`
- run `cargo bench` via justfile and CI workflow

## Testing
- `cargo check -p icn-mesh --all-features --benches`
- `cargo check -p icn-runtime --all-features --benches`


------
https://chatgpt.com/codex/tasks/task_e_686cd0c1e2d08324ac9072af8b5d37ac