### PR TITLE
Add Criterion benchmarks for mesh and runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run CLI-node integration tests
         run: cargo test --all-features -p icn-integration-tests --test cli_node
 
+      - name: Run benchmarks
+        run: cargo bench --workspace --all-features
+
       - name: Start devnet (nightly only)
         if: matrix.rust == 'nightly'
         run: |

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -548,9 +548,9 @@ mod tests {
     use super::*;
     use icn_common::DagLink; // For test setup
     use icn_dag::TokioFileDagStore; // Async file-based store for tests
-    use tempfile::tempdir;
     use icn_governance::GovernanceModule; // For governance tests
     use icn_protocol::{DagBlockRequestMessage, GossipMessage, MessagePayload, ProtocolMessage};
+    use tempfile::tempdir;
 
     // Helper to create a default in-memory store for tests
     fn new_test_storage() -> Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> {
@@ -935,10 +935,9 @@ mod tests {
         use tempfile::tempdir;
 
         let dir = tempdir().unwrap();
-        let store: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> =
-            Arc::new(tokio::sync::Mutex::new(
-                TokioFileDagStore::new(dir.into_path()).unwrap(),
-            ));
+        let store: Arc<tokio::sync::Mutex<dyn AsyncStorageService<DagBlock> + Send>> = Arc::new(
+            tokio::sync::Mutex::new(TokioFileDagStore::new(dir.into_path()).unwrap()),
+        );
         let data = b"query block".to_vec();
         let ts = 0u64;
         let author = Did::new("key", "tester");

--- a/crates/icn-common/src/retry.rs
+++ b/crates/icn-common/src/retry.rs
@@ -31,9 +31,7 @@ where
                     error!("Operation failed after {attempts} attempts: {error:?}");
                     return Err(error);
                 }
-                warn!(
-                    "Operation failed (attempt {attempts}), retrying in {delay:?}: {error:?}"
-                );
+                warn!("Operation failed (attempt {attempts}), retrying in {delay:?}: {error:?}");
                 tokio::time::sleep(delay).await;
                 delay = std::cmp::min(delay * 2, max_delay);
                 let jitter =

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -722,7 +722,7 @@ mod tests {
             scope: None,
         };
         assert!(store.put(&modified_block1).is_ok());
-        
+
         // Original block should still be retrievable by its CID
         match store.get(&block1.cid) {
             Ok(Some(retrieved_block)) => {
@@ -731,7 +731,7 @@ mod tests {
             }
             _ => panic!("Failed to get original block1"),
         }
-        
+
         // Modified block should be retrievable by its CID
         match store.get(&modified_cid) {
             Ok(Some(retrieved_block)) => {
@@ -790,7 +790,7 @@ mod tests {
             scope: None,
         };
         store.put(&mod_block).await.unwrap();
-        
+
         // Original block should still be retrievable
         match store.get(&block1.cid).await {
             Ok(Some(retrieved)) => {
@@ -799,7 +799,7 @@ mod tests {
             }
             _ => panic!("Failed to get original block1"),
         }
-        
+
         // Modified block should be retrievable by its CID
         match store.get(&mod_cid).await {
             Ok(Some(retrieved)) => {

--- a/crates/icn-dag/src/rocksdb_store.rs
+++ b/crates/icn-dag/src/rocksdb_store.rs
@@ -74,9 +74,8 @@ impl StorageService<DagBlock> for RocksDagStore {
         use rocksdb::IteratorMode;
         let mut blocks = Vec::new();
         for item in self.db.iterator(IteratorMode::Start) {
-            let (_key, val) = item.map_err(|e| {
-                CommonError::DatabaseError(format!("Iteration error: {}", e))
-            })?;
+            let (_key, val) =
+                item.map_err(|e| CommonError::DatabaseError(format!("Iteration error: {}", e)))?;
             let block: DagBlock = bincode::deserialize(&val).map_err(|e| {
                 CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
             })?;

--- a/crates/icn-dag/src/sled_store.rs
+++ b/crates/icn-dag/src/sled_store.rs
@@ -95,9 +95,8 @@ impl StorageService<DagBlock> for SledDagStore {
         let tree = self.tree()?;
         let mut blocks = Vec::new();
         for item in tree.iter() {
-            let (_, val) = item.map_err(|e| {
-                CommonError::DatabaseError(format!("Iteration error: {}", e))
-            })?;
+            let (_, val) =
+                item.map_err(|e| CommonError::DatabaseError(format!("Iteration error: {}", e)))?;
             let block: DagBlock = bincode::deserialize(&val).map_err(|e| {
                 CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
             })?;

--- a/crates/icn-dag/src/sqlite_store.rs
+++ b/crates/icn-dag/src/sqlite_store.rs
@@ -101,15 +101,17 @@ impl StorageService<DagBlock> for SqliteDagStore {
     }
 
     fn list_blocks(&self) -> Result<Vec<DagBlock>, CommonError> {
-        let mut stmt = self.conn.prepare("SELECT data FROM blocks").map_err(|e| {
-            CommonError::DatabaseError(format!("Prepare failed: {}", e))
-        })?;
-        let rows = stmt.query_map([], |row| row.get::<_, Vec<u8>>(0)).map_err(|e| {
-            CommonError::DatabaseError(format!("Query failed: {}", e))
-        })?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT data FROM blocks")
+            .map_err(|e| CommonError::DatabaseError(format!("Prepare failed: {}", e)))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, Vec<u8>>(0))
+            .map_err(|e| CommonError::DatabaseError(format!("Query failed: {}", e)))?;
         let mut blocks = Vec::new();
         for row_result in rows {
-            let data = row_result.map_err(|e| CommonError::DatabaseError(format!("Row error: {}", e)))?;
+            let data =
+                row_result.map_err(|e| CommonError::DatabaseError(format!("Row error: {}", e)))?;
             let block: DagBlock = serde_json::from_slice(&data).map_err(|e| {
                 CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
             })?;

--- a/crates/icn-governance/tests/voting.rs
+++ b/crates/icn-governance/tests/voting.rs
@@ -204,7 +204,10 @@ fn close_before_deadline_errors() {
         VoteOption::Yes,
     )
     .unwrap();
-    assert_eq!(gov.close_voting_period(&pid).unwrap(), ProposalStatus::Accepted);
+    assert_eq!(
+        gov.close_voting_period(&pid).unwrap(),
+        ProposalStatus::Accepted
+    );
 }
 
 #[test]

--- a/crates/icn-mesh/Cargo.toml
+++ b/crates/icn-mesh/Cargo.toml
@@ -14,3 +14,6 @@ icn-economics = { path = "../icn-economics" }
 once_cell = "1.21"
 prometheus-client = "0.22"
 log = "0.4"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async"] }

--- a/crates/icn-mesh/benches/select_executor.rs
+++ b/crates/icn-mesh/benches/select_executor.rs
@@ -1,0 +1,89 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use icn_common::{Cid, Did};
+use icn_economics::ManaLedger;
+use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+use icn_mesh::{select_executor, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy};
+use icn_reputation::InMemoryReputationStore;
+use std::str::FromStr;
+
+// Simple in-memory ledger for benchmarks
+struct BenchLedger {
+    inner: std::collections::HashMap<Did, u64>,
+}
+impl BenchLedger {
+    fn new() -> Self {
+        Self {
+            inner: std::collections::HashMap::new(),
+        }
+    }
+}
+impl ManaLedger for BenchLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        *self.inner.get(did).unwrap_or(&0)
+    }
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        self.inner.insert(did.clone(), amount);
+        Ok(())
+    }
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let bal = self
+            .inner
+            .get_mut(did)
+            .ok_or_else(|| icn_common::CommonError::DatabaseError("account".into()))?;
+        if *bal < amount {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= amount;
+        Ok(())
+    }
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let bal = self.inner.entry(did.clone()).or_insert(0);
+        *bal += amount;
+        Ok(())
+    }
+}
+
+fn bench_select_executor(c: &mut Criterion) {
+    let job_id = JobId(Cid::new_v1_sha256(0x55, b"benchjob"));
+    let spec = JobSpec::default();
+    let policy = SelectionPolicy::default();
+    let mut group = c.benchmark_group("select_executor");
+
+    for &num_bids in &[10usize, 100, 1000] {
+        group.bench_with_input(BenchmarkId::from_parameter(num_bids), &num_bids, |b, &n| {
+            // Prepare bids, ledger and reputation store
+            let rep_store = InMemoryReputationStore::new();
+            let ledger = BenchLedger::new();
+            let mut bids = Vec::with_capacity(n);
+            for i in 0..n {
+                let (_sk, vk) = generate_ed25519_keypair();
+                let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+                rep_store.set_score(did.clone(), i as u64);
+                ledger.set_balance(&did, 100).unwrap();
+                bids.push(MeshJobBid {
+                    job_id: job_id.clone(),
+                    executor_did: did,
+                    price_mana: (i % 10) as u64,
+                    resources: Resources {
+                        cpu_cores: 1,
+                        memory_mb: 512,
+                    },
+                    signature: SignatureBytes(Vec::new()),
+                });
+            }
+            b.iter_batched(
+                || bids.clone(),
+                |bids_vec| {
+                    black_box(select_executor(
+                        &job_id, &spec, bids_vec, &policy, &rep_store, &ledger,
+                    ));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_select_executor);
+criterion_main!(benches);

--- a/crates/icn-network/tests/libp2p.rs
+++ b/crates/icn-network/tests/libp2p.rs
@@ -63,11 +63,13 @@ mod libp2p_tests {
             .send_message(
                 &PeerId(node_a.local_peer_id().to_string()),
                 ProtocolMessage::new(
-                    MessagePayload::FederationSyncRequest(icn_protocol::FederationSyncRequestMessage {
-                        federation_id: "test".to_string(),
-                        since_timestamp: None,
-                        sync_types: vec![],
-                    }),
+                    MessagePayload::FederationSyncRequest(
+                        icn_protocol::FederationSyncRequestMessage {
+                            federation_id: "test".to_string(),
+                            since_timestamp: None,
+                            sync_types: vec![],
+                        },
+                    ),
                     Did::default(),
                     None,
                 ),

--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -665,7 +665,10 @@ mod libp2p_mesh_integration {
             Did::new("key", "node_a"),
             None,
         );
-        node_a.service.broadcast_message(job_announcement_msg).await?;
+        node_a
+            .service
+            .broadcast_message(job_announcement_msg)
+            .await?;
         info!("📢 [PIPELINE-REFACTORED] Job announced: {}", job_id);
 
         // Node B receives job announcement
@@ -802,18 +805,19 @@ mod libp2p_mesh_integration {
         info!("📤 [PIPELINE-REFACTORED] Receipt submitted");
 
         // Node A receives and verifies receipt
-        let verified_receipt = wait_for_message(&mut node_a.receiver, 10, |msg| match &msg.payload {
-            MessagePayload::MeshReceiptSubmission(sub) => {
-                let receipt = &sub.receipt;
-                if receipt.job_id == job_id.0 {
-                    Some(receipt.clone())
-                } else {
-                    None
+        let verified_receipt =
+            wait_for_message(&mut node_a.receiver, 10, |msg| match &msg.payload {
+                MessagePayload::MeshReceiptSubmission(sub) => {
+                    let receipt = &sub.receipt;
+                    if receipt.job_id == job_id.0 {
+                        Some(receipt.clone())
+                    } else {
+                        None
+                    }
                 }
-            }
-            _ => None,
-        })
-        .await?;
+                _ => None,
+            })
+            .await?;
         info!("✅ [PIPELINE-REFACTORED] Receipt received and verified");
 
         // Verify receipt signature format
@@ -885,7 +889,10 @@ mod libp2p_mesh_integration {
             Did::new("key", "node_a"),
             None,
         );
-        node_a.service.broadcast_message(job_announcement_msg).await?;
+        node_a
+            .service
+            .broadcast_message(job_announcement_msg)
+            .await?;
 
         // Verify reception
         let received_job = wait_for_message(&mut node_b.receiver, 5, |msg| match &msg.payload {

--- a/crates/icn-node/src/main.rs
+++ b/crates/icn-node/src/main.rs
@@ -3,4 +3,4 @@ use icn_node::node::run_node;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     run_node().await
-} 
+}

--- a/crates/icn-node/tests/governance_membership.rs
+++ b/crates/icn-node/tests/governance_membership.rs
@@ -137,7 +137,8 @@ async fn add_and_remove_member_via_http() {
 async fn governance_membership_required_for_vote() {
     let router = {
         let (_router, _ctx) =
-            app_router_with_options(None, None, None, None, None, None, None, None, None, None).await;
+            app_router_with_options(None, None, None, None, None, None, None, None, None, None)
+                .await;
         _router
     };
 }

--- a/crates/icn-protocol/src/lib.rs
+++ b/crates/icn-protocol/src/lib.rs
@@ -7,7 +7,7 @@
 //! This is the single source of truth for all network protocol messages,
 //! including mesh computing, governance, DAG operations, and federation management.
 
-use icn_common::{Cid, Did, DagBlock, CommonError, NodeInfo};
+use icn_common::{Cid, CommonError, DagBlock, Did, NodeInfo};
 use icn_identity::{ExecutionReceipt, SignatureBytes};
 use serde::{Deserialize, Serialize};
 
@@ -45,7 +45,7 @@ pub enum MessagePayload {
     MeshJobAssignment(MeshJobAssignmentMessage),
     /// Submit execution receipt with results
     MeshReceiptSubmission(MeshReceiptSubmissionMessage),
-    
+
     // === DAG and Storage Messages ===
     /// Announce availability of a new DAG block
     DagBlockAnnouncement(DagBlockAnnouncementMessage),
@@ -53,7 +53,7 @@ pub enum MessagePayload {
     DagBlockRequest(DagBlockRequestMessage),
     /// Response with requested DAG block data
     DagBlockResponse(DagBlockResponseMessage),
-    
+
     // === Governance Messages ===
     /// Announce a new governance proposal
     GovernanceProposalAnnouncement(GovernanceProposalMessage),
@@ -61,7 +61,7 @@ pub enum MessagePayload {
     GovernanceVoteAnnouncement(GovernanceVoteMessage),
     /// Request governance state synchronization
     GovernanceStateSyncRequest(GovernanceStateSyncRequestMessage),
-    
+
     // === Federation Management ===
     /// Request to join a federation
     FederationJoinRequest(FederationJoinRequestMessage),
@@ -69,7 +69,7 @@ pub enum MessagePayload {
     FederationJoinResponse(FederationJoinResponseMessage),
     /// Request federation state synchronization
     FederationSyncRequest(FederationSyncRequestMessage),
-    
+
     // === Network Management ===
     /// Generic gossip message for flexible communication
     GossipMessage(GossipMessage),
@@ -247,7 +247,10 @@ pub struct GovernanceProposalMessage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProposalType {
     /// Change a system parameter
-    ParameterChange { parameter: String, new_value: String },
+    ParameterChange {
+        parameter: String,
+        new_value: String,
+    },
     /// Add a new member to governance
     MembershipInvitation { new_member: Did },
     /// Remove a member from governance
@@ -469,7 +472,7 @@ impl MessagePayload {
     pub fn message_type(&self) -> &'static str {
         match self {
             MessagePayload::MeshJobAnnouncement(_) => "MeshJobAnnouncement",
-            MessagePayload::MeshBidSubmission(_) => "MeshBidSubmission", 
+            MessagePayload::MeshBidSubmission(_) => "MeshBidSubmission",
             MessagePayload::MeshJobAssignment(_) => "MeshJobAssignment",
             MessagePayload::MeshReceiptSubmission(_) => "MeshReceiptSubmission",
             MessagePayload::DagBlockAnnouncement(_) => "DagBlockAnnouncement",
@@ -585,7 +588,9 @@ mod tests {
             creator_did: Did::from_str("did:key:creator").unwrap(),
             max_cost_mana: 100,
             job_spec: JobSpec {
-                kind: JobKind::Echo { payload: "test".to_string() },
+                kind: JobKind::Echo {
+                    payload: "test".to_string(),
+                },
                 inputs: vec![],
                 outputs: vec!["result".to_string()],
                 required_resources: ResourceRequirements::default(),

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -50,6 +50,7 @@ serial_test = { version = "3", features = ["async"] }
 # Logging for integration tests
 env_logger = "0.11"
 # temp-dir = "0.1"
+criterion = { version = "0.5", features = ["async"] }
 
 [features]
 default = []

--- a/crates/icn-runtime/benches/job_manager.rs
+++ b/crates/icn-runtime/benches/job_manager.rs
@@ -1,0 +1,83 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use icn_common::{Cid, Did};
+use icn_identity::{
+    did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt, SignatureBytes,
+    SigningKey,
+};
+use icn_mesh::{ActualMeshJob, JobId, JobSpec, JobState, MeshJobBid, Resources};
+use icn_runtime::context::{LocalMeshSubmitReceiptMessage, RuntimeContext, StubMeshNetworkService};
+use std::str::FromStr;
+use tokio::runtime::Runtime;
+use tokio::time::{sleep, Duration};
+
+async fn queue_and_process_job() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:bench:node", 100).unwrap();
+    ctx.default_receipt_wait_ms = 50;
+
+    let stub = ctx
+        .mesh_network_service
+        .as_any()
+        .downcast_ref::<StubMeshNetworkService>()
+        .expect("stub service");
+
+    let (exec_sk, exec_vk) = generate_ed25519_keypair();
+    let exec_did = Did::from_str(&did_key_from_verifying_key(&exec_vk)).unwrap();
+
+    let job_id = JobId(Cid::new_v1_sha256(0x55, b"benchjob"));
+
+    let unsigned_bid = MeshJobBid {
+        job_id: job_id.clone(),
+        executor_did: exec_did.clone(),
+        price_mana: 10,
+        resources: Resources::default(),
+        signature: SignatureBytes(Vec::new()),
+    };
+    let signed_bid = unsigned_bid.clone().sign(&exec_sk).unwrap();
+    stub.stage_bid(job_id.clone(), signed_bid).await;
+
+    let receipt = ExecutionReceipt {
+        job_id: job_id.clone().into(),
+        executor_did: exec_did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"result"),
+        cpu_ms: 1,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    }
+    .sign_with_key(&exec_sk)
+    .unwrap();
+    stub.stage_receipt(LocalMeshSubmitReceiptMessage { receipt })
+        .await;
+
+    let ctx_clone = ctx.clone();
+    ctx_clone.spawn_mesh_job_manager().await;
+
+    let job = ActualMeshJob {
+        id: job_id.clone(),
+        manifest_cid: Cid::new_v1_sha256(0x55, b"manifest"),
+        spec: JobSpec::default(),
+        creator_did: ctx.current_identity.clone(),
+        cost_mana: 10,
+        max_execution_wait_ms: Some(50),
+        signature: SignatureBytes(Vec::new()),
+    };
+    ctx.internal_queue_mesh_job(job).await.unwrap();
+
+    for _ in 0..20 {
+        if let Some(state) = ctx.job_states.get(&job_id).map(|s| s.value().clone()) {
+            if matches!(state, JobState::Completed { .. }) {
+                break;
+            }
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+}
+
+fn bench_job_manager(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    c.bench_function("queue_and_process_job", |b| {
+        b.to_async(&rt).iter(|| queue_and_process_job());
+    });
+}
+
+criterion_group!(benches, bench_job_manager);
+criterion_main!(benches);

--- a/crates/icn-runtime/tests/integrity_checker.rs
+++ b/crates/icn-runtime/tests/integrity_checker.rs
@@ -1,5 +1,5 @@
-use icn_runtime::context::RuntimeContext;
 use icn_common::{compute_merkle_cid, DagBlock, Did};
+use icn_runtime::context::RuntimeContext;
 
 fn create_block(id: &str) -> DagBlock {
     let data = format!("data {id}").into_bytes();

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -422,7 +422,11 @@ async fn test_wasm_executor_runs_proposal_flow() {
     };
 
     let signer = std::sync::Arc::new(icn_runtime::context::StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer, icn_runtime::executor::WasmExecutorConfig::default());
+    let exec = WasmExecutor::new(
+        ctx.clone(),
+        signer,
+        icn_runtime::executor::WasmExecutorConfig::default(),
+    );
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
     let expected_cid = Cid::new_v1_sha256(0x55, &3i64.to_le_bytes());
@@ -480,7 +484,11 @@ async fn test_wasm_executor_runs_voting_logic() {
     };
 
     let signer = std::sync::Arc::new(icn_runtime::context::StubSigner::new_with_keys(sk, vk));
-    let exec = WasmExecutor::new(ctx.clone(), signer, icn_runtime::executor::WasmExecutorConfig::default());
+    let exec = WasmExecutor::new(
+        ctx.clone(),
+        signer,
+        icn_runtime::executor::WasmExecutorConfig::default(),
+    );
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
     let expected_cid = Cid::new_v1_sha256(0x55, &6i64.to_le_bytes());

--- a/icn-ccl/tests/operator_precedence.rs
+++ b/icn-ccl/tests/operator_precedence.rs
@@ -1,6 +1,7 @@
 use icn_ccl::{
     ast::{
-        AstNode, ExpressionNode, StatementNode, PolicyStatementNode, BinaryOperator, UnaryOperator, ParameterNode, TypeAnnotationNode, BlockNode,
+        AstNode, BinaryOperator, BlockNode, ExpressionNode, ParameterNode, PolicyStatementNode,
+        StatementNode, TypeAnnotationNode, UnaryOperator,
     },
     parser::parse_ccl_source,
 };
@@ -10,7 +11,9 @@ fn arithmetic_mixed_precedence() {
     let src = "fn run() -> Integer { return 1 + 2 * 3 - 4 / 2; }";
     let ast = parse_ccl_source(src).expect("parse");
     if let AstNode::Policy(items) = ast {
-        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) = &items[0] {
+        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) =
+            &items[0]
+        {
             if let StatementNode::Return(expr) = &body.statements[0] {
                 let expected = ExpressionNode::BinaryOp {
                     left: Box::new(ExpressionNode::BinaryOp {
@@ -46,7 +49,9 @@ fn nested_gte_comparisons() {
     let src = "fn run(a: Integer, b: Integer, c: Integer) -> Bool { return a >= b >= c; }";
     let ast = parse_ccl_source(src).expect("parse");
     if let AstNode::Policy(items) = ast {
-        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) = &items[0] {
+        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) =
+            &items[0]
+        {
             if let StatementNode::Return(expr) = &body.statements[0] {
                 let expected = ExpressionNode::BinaryOp {
                     left: Box::new(ExpressionNode::BinaryOp {
@@ -58,17 +63,26 @@ fn nested_gte_comparisons() {
                     right: Box::new(ExpressionNode::Identifier("c".into())),
                 };
                 assert_eq!(expr, &expected);
-            } else { panic!("expected return") }
-        } else { panic!("unexpected ast") }
-    } else { panic!("unexpected root") }
+            } else {
+                panic!("expected return")
+            }
+        } else {
+            panic!("unexpected ast")
+        }
+    } else {
+        panic!("unexpected root")
+    }
 }
 
 #[test]
 fn unary_logic_combination() {
-    let src = "fn run(x: Bool, y: Integer, z: Integer) -> Bool { return !x || -y * 2 > 3 && z != 0; }";
+    let src =
+        "fn run(x: Bool, y: Integer, z: Integer) -> Bool { return !x || -y * 2 > 3 && z != 0; }";
     let ast = parse_ccl_source(src).expect("parse");
     if let AstNode::Policy(items) = ast {
-        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) = &items[0] {
+        if let PolicyStatementNode::FunctionDef(AstNode::FunctionDefinition { body, .. }) =
+            &items[0]
+        {
             if let StatementNode::Return(expr) = &body.statements[0] {
                 let expected = ExpressionNode::BinaryOp {
                     left: Box::new(ExpressionNode::UnaryOp {
@@ -98,7 +112,13 @@ fn unary_logic_combination() {
                     }),
                 };
                 assert_eq!(expr, &expected);
-            } else { panic!("expected return") }
-        } else { panic!("unexpected ast") }
-    } else { panic!("unexpected root") }
+            } else {
+                panic!("expected return")
+            }
+        } else {
+            panic!("unexpected ast")
+        }
+    } else {
+        panic!("unexpected root")
+    }
 }

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ validate:
 
 # Run benchmarks for all crates
 bench:
-    cargo bench --all-features --workspace
+    cargo bench --workspace --all-features
 
 # Run federation health checks
 health-check:


### PR DESCRIPTION
## Summary
- benchmark `select_executor` in icn-mesh with varying bid counts
- benchmark runtime job manager with stubbed network
- add Criterion dev dependency to icn-mesh and icn-runtime
- run `cargo bench` from justfile and CI

## Testing
- `cargo fmt --all`
- `cargo test --workspace --all-features --exclude icn-integration-tests --no-run` *(fails: compilation heavy)*

------
https://chatgpt.com/codex/tasks/task_e_686cd700d3cc83249805ab0d46ccca4b