### PR TITLE
Add benchmarking harnesses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run CLI-node integration tests
         run: cargo test --all-features -p icn-integration-tests --test cli_node
 
+      - name: Run benchmarks
+        run: cargo bench --workspace --all-features
+
       - name: Start devnet (nightly only)
         if: matrix.rust == 'nightly'
         run: |

--- a/crates/icn-mesh/Cargo.toml
+++ b/crates/icn-mesh/Cargo.toml
@@ -14,3 +14,6 @@ icn-economics = { path = "../icn-economics" }
 once_cell = "1.21"
 prometheus-client = "0.22"
 log = "0.4"
+
+[dev-dependencies]
+criterion = "0.5"

--- a/crates/icn-mesh/benches/select_executor.rs
+++ b/crates/icn-mesh/benches/select_executor.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, black_box};
+use icn_common::{Cid, Did, CommonError};
+use icn_economics::ManaLedger;
+use icn_mesh::{select_executor, MeshJobBid, JobId, JobSpec, SelectionPolicy, Resources};
+use icn_reputation::{InMemoryReputationStore, ReputationStore};
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct BenchLedger {
+    balances: Mutex<HashMap<Did, u64>>, 
+}
+
+impl BenchLedger {
+    fn set_balance(&self, did: &Did, amount: u64) {
+        self.balances.lock().unwrap().insert(did.clone(), amount);
+    }
+}
+
+impl ManaLedger for BenchLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        *self.balances.lock().unwrap().get(did).unwrap_or(&0)
+    }
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        self.balances.lock().unwrap().insert(did.clone(), amount);
+        Ok(())
+    }
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let bal = map.get_mut(did).ok_or_else(|| CommonError::DatabaseError("account".into()))?;
+        if *bal < amount {
+            return Err(CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= amount;
+        Ok(())
+    }
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let entry = map.entry(did.clone()).or_insert(0);
+        *entry += amount;
+        Ok(())
+    }
+    fn credit_all(&self, amount: u64) -> Result<(), CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        for val in map.values_mut() { *val += amount; }
+        Ok(())
+    }
+    fn all_accounts(&self) -> Vec<Did> {
+        self.balances.lock().unwrap().keys().cloned().collect()
+    }
+}
+
+fn build_bids(job_id: &JobId, count: usize) -> (Vec<MeshJobBid>, BenchLedger, InMemoryReputationStore) {
+    let ledger = BenchLedger::default();
+    let rep = InMemoryReputationStore::new();
+    let mut bids = Vec::with_capacity(count);
+    for i in 0..count {
+        let did = Did::new("icn", &format!("exec{i}"));
+        ledger.set_balance(&did, 1000);
+        rep.set_score(did.clone(), 1);
+        let bid = MeshJobBid {
+            job_id: job_id.clone(),
+            executor_did: did,
+            price_mana: (i % 10 + 1) as u64,
+            resources: Resources { cpu_cores: 1, memory_mb: 512 },
+            signature: icn_identity::SignatureBytes(Vec::new()),
+        };
+        bids.push(bid);
+    }
+    (bids, ledger, rep)
+}
+
+fn bench_select_executor(c: &mut Criterion) {
+    let policy = SelectionPolicy::default();
+    let job_id = JobId(Cid::new_v1_sha256(0x55, b"bench_job"));
+    let spec = JobSpec::default();
+
+    let mut group = c.benchmark_group("select_executor");
+    for &count in &[1usize, 10, 100, 1000] {
+        let (bids, ledger, rep) = build_bids(&job_id, count);
+        group.bench_with_input(BenchmarkId::from_parameter(count), &bids, |b, bids| {
+            b.iter(|| {
+                let result = select_executor(black_box(&job_id), &spec, bids.clone(), &policy, &rep, &ledger);
+                black_box(result);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_select_executor);
+criterion_main!(benches);
+

--- a/crates/icn-mesh/src/metrics.rs
+++ b/crates/icn-mesh/src/metrics.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
+use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::{Histogram, exponential_buckets}};
 
 /// Counts calls to `select_executor`.
 pub static SELECT_EXECUTOR_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
@@ -11,4 +11,4 @@ pub static SCHEDULE_MESH_JOB_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
 pub static PENDING_JOBS_GAUGE: Lazy<Gauge<i64>> = Lazy::new(Gauge::default);
 
 /// Records the time from job assignment to receipt processing in seconds.
-pub static JOB_PROCESS_TIME: Lazy<Histogram> = Lazy::new(Histogram::default);
+pub static JOB_PROCESS_TIME: Lazy<Histogram> = Lazy::new(|| Histogram::new(exponential_buckets(0.1, 2.0, 10)));

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -49,6 +49,8 @@ tempfile = "3"
 serial_test = { version = "3", features = ["async"] }
 # Logging for integration tests
 env_logger = "0.11"
+# Benchmarking
+criterion = { version = "0.5", features = ["async"] }
 # temp-dir = "0.1"
 
 [features]

--- a/crates/icn-runtime/benches/job_manager.rs
+++ b/crates/icn-runtime/benches/job_manager.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+use std::sync::Arc;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use icn_common::Cid;
+use icn_identity::{SignatureBytes, generate_ed25519_keypair, did_key_from_verifying_key};
+use icn_mesh::{ActualMeshJob, JobId, JobSpec, Resources, MeshJobBid};
+use icn_runtime::context::{RuntimeContext, StubMeshNetworkService, LocalMeshSubmitReceiptMessage};
+use icn_runtime::context::JobState;
+use tokio::runtime::Runtime;
+
+async fn queue_and_process() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:bench_submitter", 100).unwrap();
+    let network = ctx
+        .mesh_network_service
+        .clone()
+        .downcast_arc::<StubMeshNetworkService>()
+        .expect("stub net");
+    let (_sk, vk) = generate_ed25519_keypair();
+    let exec_did = did_key_from_verifying_key(&vk);
+    let exec_ctx = RuntimeContext::new_with_stubs_and_mana(&exec_did, 50).unwrap();
+
+    let job = ActualMeshJob {
+        id: JobId(Cid::new_v1_sha256(0x55, b"bench_job")),
+        manifest_cid: Cid::new_v1_sha256(0x55, b"manifest"),
+        spec: JobSpec { kind: icn_mesh::JobKind::Echo { payload: "hi".into() }, ..Default::default() },
+        creator_did: ctx.current_identity.clone(),
+        cost_mana: 5,
+        max_execution_wait_ms: None,
+        signature: SignatureBytes(Vec::new()),
+    };
+
+    let bid = MeshJobBid {
+        job_id: job.id.clone(),
+        executor_did: exec_ctx.current_identity.clone(),
+        price_mana: 1,
+        resources: Resources { cpu_cores: 1, memory_mb: 512 },
+        signature: SignatureBytes(Vec::new()),
+    };
+    network.stage_bid(job.id.clone(), bid).await;
+
+    // prepare receipt signed by executor
+    let receipt = icn_identity::ExecutionReceipt {
+        job_id: job.id.clone().into(),
+        executor_did: exec_ctx.current_identity.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"result"),
+        cpu_ms: 1,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    };
+    let mut msg = Vec::new();
+    msg.extend_from_slice(receipt.job_id.to_string().as_bytes());
+    msg.extend_from_slice(exec_ctx.current_identity.to_string().as_bytes());
+    msg.extend_from_slice(receipt.result_cid.to_string().as_bytes());
+    msg.extend_from_slice(&receipt.cpu_ms.to_le_bytes());
+    msg.push(receipt.success as u8);
+    let sig = exec_ctx.signer.sign(&msg).unwrap();
+    let mut signed_receipt = receipt.clone();
+    signed_receipt.sig = SignatureBytes(sig);
+    network
+        .stage_receipt(LocalMeshSubmitReceiptMessage { receipt: signed_receipt })
+        .await;
+
+    ctx.internal_queue_mesh_job(job.clone()).await.unwrap();
+    ctx.clone()
+        .wait_for_and_process_receipt(job, exec_ctx.current_identity.clone())
+        .await
+        .unwrap();
+
+    assert!(matches!(ctx.job_states.get(&JobId(Cid::new_v1_sha256(0x55, b"bench_job"))).map(|s| s.value().clone()), Some(JobState::Completed { .. })));
+}
+
+fn bench_job_manager(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    c.bench_function("queue_and_process_job", |b| {
+        b.to_async(&rt).iter(|| async {
+            queue_and_process().await;
+        });
+    });
+}
+
+criterion_group!(benches, bench_job_manager);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ validate:
 
 # Run benchmarks for all crates
 bench:
-    cargo bench --all-features --workspace
+    cargo bench --workspace --all-features
 
 # Run federation health checks
 health-check:


### PR DESCRIPTION
## Summary
- add Criterion benchmarks for `select_executor` and Runtime job processing
- enable Criterion in the mesh and runtime crates
- run `cargo bench --workspace --all-features` via justfile and CI
- fix compile error in mesh metrics histogram setup

## Testing
- `cargo bench --workspace --all-features --no-run` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_686cd6068cdc83249239610d4895a6d6