### PR TITLE
Propagate signer errors in runtime

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -446,7 +446,7 @@ pub async fn app_router_with_options(
     let node_did = Did::from_str(&node_did_string).expect("Failed to create test node DID");
     info!("Test/Embedded Node DID: {}", node_did);
 
-    let signer = Arc::new(RuntimeStubSigner::new_with_keys(sk, pk));
+    let signer = Arc::new(RuntimeStubSigner::new_with_keys(sk, pk).expect("stub signer"));
     let cfg = NodeConfig {
         storage_backend: storage_backend.unwrap_or(StorageBackendType::Memory),
         storage_path: storage_path
@@ -904,7 +904,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         info!("Using local libp2p networking (P2P disabled)");
-        let signer = Arc::new(Ed25519Signer::new_with_keys(node_sk, node_pk));
+        let signer = Arc::new(Ed25519Signer::new_with_keys(node_sk, node_pk)?);
         let dag_store_for_rt = match config.init_dag_store() {
             Ok(store) => store,
             Err(e) => {
@@ -2563,7 +2563,9 @@ mod tests {
         let (sk, vk) = generate_ed25519_keypair();
         let exec_did = did_key_from_verifying_key(&vk);
         let exec_did = Did::from_str(&exec_did).unwrap();
-        let signer = std::sync::Arc::new(icn_runtime::context::StubSigner::new_with_keys(sk, vk));
+        let signer = std::sync::Arc::new(
+            icn_runtime::context::StubSigner::new_with_keys(sk, vk).expect("stub signer"),
+        );
         let executor = WasmExecutor::new(
             ctx.clone(),
             signer,

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -617,7 +617,7 @@ mod tests {
         RuntimeContext::new(
             test_did,
             Arc::new(StubMeshNetworkService::new()),
-            Arc::new(StubSigner::new()),
+            Arc::new(StubSigner::new().expect("create stub signer")),
             Arc::new(icn_identity::KeyDidResolver),
             Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         )

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -551,7 +551,7 @@ fn new_mesh_test_context_with_two_executors() -> (
     let submitter_ctx = RuntimeContext::new(
         submitter_did.clone(),
         network_service.clone(),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         dag_store.clone(),
     );
@@ -563,7 +563,7 @@ fn new_mesh_test_context_with_two_executors() -> (
     let executor1_ctx = RuntimeContext::new(
         executor1_did.clone(),
         network_service.clone(),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         dag_store.clone(),
     );
@@ -575,7 +575,7 @@ fn new_mesh_test_context_with_two_executors() -> (
     let executor2_ctx = RuntimeContext::new(
         executor2_did.clone(),
         network_service.clone(),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         dag_store.clone(),
     );

--- a/crates/icn-runtime/tests/policy.rs
+++ b/crates/icn-runtime/tests/policy.rs
@@ -17,7 +17,7 @@ async fn anchor_receipt_denied_by_policy() {
     let ctx = RuntimeContext::new_with_ledger_path(
         did.clone(),
         Arc::new(StubMeshNetworkService::new()),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         Arc::new(TokioMutex::new(StubDagStore::new())),
         PathBuf::from("./mana_ledger.sled"),

--- a/crates/icn-runtime/tests/reputation.rs
+++ b/crates/icn-runtime/tests/reputation.rs
@@ -19,7 +19,7 @@ async fn anchor_receipt_updates_reputation() {
     let ctx = RuntimeContext::new_with_ledger_path(
         did.clone(),
         Arc::new(StubMeshNetworkService::new()),
-        Arc::new(StubSigner::new_with_keys(sk.clone(), vk)),
+        Arc::new(StubSigner::new_with_keys(sk.clone(), vk).unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         Arc::new(tokio::sync::Mutex::new(StubDagStore::new())),
         std::path::PathBuf::from("./mana_ledger.sled"),

--- a/crates/icn-runtime/tests/time_provider.rs
+++ b/crates/icn-runtime/tests/time_provider.rs
@@ -15,7 +15,7 @@ async fn anchor_receipt_uses_time_provider() {
     let ctx = RuntimeContext::new_with_ledger_path_and_time(
         did.clone(),
         Arc::new(StubMeshNetworkService::new()),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         Arc::new(TokioMutex::new(StubDagStore::new())),
         std::path::PathBuf::from("./mana_ledger.sled"),

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -54,7 +54,7 @@ async fn wasm_executor_runs_wasm() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
@@ -97,7 +97,7 @@ async fn wasm_executor_runs_compiled_ccl_contract() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let receipt = exec.execute_job(&job).await.unwrap();
     assert_eq!(receipt.executor_did, node_did);
@@ -171,7 +171,7 @@ async fn wasm_executor_host_submit_mesh_job_json() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let receipt = exec.execute_job(&job).await.unwrap();
 
@@ -238,7 +238,7 @@ async fn wasm_executor_host_anchor_receipt_json() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(node_sk, node_vk));
+    let signer = Arc::new(StubSigner::new_with_keys(node_sk, node_vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let _ = exec.execute_job(&job).await.unwrap();
 
@@ -367,7 +367,7 @@ async fn compiled_example_contract_file_runs() {
         max_execution_wait_ms: None,
         signature: SignatureBytes(vec![]),
     };
-    let signer = std::sync::Arc::new(StubSigner::new());
+    let signer = std::sync::Arc::new(StubSigner::new().unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let receipt = exec.execute_job(&job).await.unwrap();
     let expected = Cid::new_v1_sha256(0x55, &11i64.to_le_bytes());
@@ -401,7 +401,7 @@ async fn wasm_executor_enforces_memory_limit() {
         max_execution_wait_ms: None,
         signature: SignatureBytes(vec![]),
     };
-    let signer = Arc::new(StubSigner::new());
+    let signer = Arc::new(StubSigner::new().unwrap());
     let config = WasmExecutorConfig {
         max_memory: 64 * 1024,
         fuel: 10_000,
@@ -437,7 +437,7 @@ async fn wasm_executor_enforces_fuel_limit() {
         max_execution_wait_ms: None,
         signature: SignatureBytes(vec![]),
     };
-    let signer = Arc::new(StubSigner::new());
+    let signer = Arc::new(StubSigner::new().unwrap());
     let config = WasmExecutorConfig {
         max_memory: 256 * 1024,
         fuel: 100,

--- a/icn-ccl/tests/wasm_executor_integration.rs
+++ b/icn-ccl/tests/wasm_executor_integration.rs
@@ -17,7 +17,7 @@ fn ctx_with_temp_store(did: &str, mana: u64) -> Arc<RuntimeContext> {
     let ctx = RuntimeContext::new_with_ledger_path(
         icn_common::Did::from_str(did).unwrap(),
         Arc::new(StubMeshNetworkService::new()),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         dag_store,
         temp.path().join("mana"),
@@ -68,7 +68,7 @@ async fn wasm_executor_runs_compiled_ccl() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
@@ -119,7 +119,7 @@ async fn wasm_executor_runs_compiled_addition() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
@@ -170,7 +170,7 @@ async fn wasm_executor_fails_without_run() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
@@ -218,7 +218,7 @@ async fn compile_and_execute_simple_contract() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = thread::spawn(move || {
@@ -271,7 +271,7 @@ async fn wasm_executor_runs_compiled_file() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = std::thread::spawn(move || {
@@ -321,7 +321,7 @@ async fn wasm_executor_runs_while_loop() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = std::thread::spawn(move || {
@@ -376,7 +376,7 @@ async fn contract_queries_reputation() {
         signature: SignatureBytes(vec![]),
     };
 
-    let signer = Arc::new(StubSigner::new_with_keys(sk, vk));
+    let signer = Arc::new(StubSigner::new_with_keys(sk, vk).unwrap());
     let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
     let job_clone = job.clone();
     let handle = std::thread::spawn(move || {

--- a/icn-runtime/tests/ledger_persistence.rs
+++ b/icn-runtime/tests/ledger_persistence.rs
@@ -13,7 +13,7 @@ async fn mana_persists_across_contexts() {
     let ctx1 = RuntimeContext::new_with_ledger_path(
         did.clone(),
         Arc::new(StubMeshNetworkService::new()),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(TokioMutex::new(StubDagStore::new())),
         ledger_path.clone(),
         temp_dir.path().join("rep.sled"),
@@ -24,7 +24,7 @@ async fn mana_persists_across_contexts() {
     let ctx2 = RuntimeContext::new_with_ledger_path(
         did.clone(),
         Arc::new(StubMeshNetworkService::new()),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(TokioMutex::new(StubDagStore::new())),
         ledger_path,
         temp_dir.path().join("rep.sled"),

--- a/icn-runtime/tests/wasm_executor.rs
+++ b/icn-runtime/tests/wasm_executor.rs
@@ -13,7 +13,7 @@ async fn compiled_policy_executes_via_host_abi() {
     let ctx = RuntimeContext::new_with_mana_ledger(
         Did::new("key", "tester"),
         Arc::new(StubMeshNetworkService::new()),
-        Arc::new(StubSigner::new()),
+        Arc::new(StubSigner::new().unwrap()),
         Arc::new(icn_identity::KeyDidResolver),
         dag_store.clone(),
         icn_runtime::context::SimpleManaLedger::default(),

--- a/tests/integration/persistence.rs
+++ b/tests/integration/persistence.rs
@@ -40,7 +40,7 @@ mod persistence_rocksdb {
         RuntimeContext::new_with_paths(
             id,
             mesh,
-            Arc::new(StubSigner::new()),
+            Arc::new(StubSigner::new().unwrap()),
             Arc::new(icn_identity::KeyDidResolver),
             dag,
             mana,

--- a/tests/integration/reputation_persistence.rs
+++ b/tests/integration/reputation_persistence.rs
@@ -78,7 +78,7 @@ mod reputation_persistence {
         RuntimeContext::new_with_paths(
             id,
             mesh,
-            Arc::new(StubSigner::new()),
+            Arc::new(StubSigner::new().unwrap()),
             Arc::new(icn_identity::KeyDidResolver),
             dag,
             mana,


### PR DESCRIPTION
## Summary
- return `Result` from StubSigner and Ed25519Signer constructors
- propagate DID parsing errors through `did()`
- handle Mutex lock failures without panics
- use `?` instead of `unwrap` for temp dirs and ledger setup
- adjust runtime, node, and tests for new APIs

## Testing
- `cargo test -p icn-runtime --features async --lib --no-run`

------
https://chatgpt.com/codex/tasks/task_e_686cd08dcd2c8324ab62eae486f50b83