### PR TITLE
[node] use async dag store

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -9,9 +9,9 @@ license.workspace = true
 icn-common = { path = "../icn-common" }
 icn-api = { path = "../icn-api", default-features = false, features = ["types-only"] }
 icn-network = { path = "../icn-network", default-features = false }
-icn-dag = { path = "../icn-dag" }
+icn-dag = { path = "../icn-dag", features = ["async"] }
 icn-governance = { path = "../icn-governance", features = ["serde"] }
-icn-runtime = { path = "../icn-runtime", features = ["cli"] }
+icn-runtime = { path = "../icn-runtime", features = ["cli", "async"] }
 icn-identity = { path = "../icn-identity" }
 icn-mesh = { path = "../icn-mesh" }
 icn-reputation = { path = "../icn-reputation" }

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -514,8 +514,10 @@ impl JobExecutor for WasmExecutor {
         // Configure timeout and resource limits
         let timeout_duration =
             Duration::from_secs(self.config.security_limits.max_execution_time_secs);
-        let mut limiter = ICNResourceLimiter::new(self.config.max_memory, timeout_duration);
-        store.limiter(|_| &mut limiter);
+        let limiter: &'static mut ICNResourceLimiter = Box::leak(Box::new(
+            ICNResourceLimiter::new(self.config.max_memory, timeout_duration),
+        ));
+        store.limiter(move |_| limiter as &mut dyn ResourceLimiter);
 
         store
             .set_fuel(self.config.fuel)


### PR DESCRIPTION
## Summary
- enable async DAG store dependencies
- expose Tokio DAG store in config
- fix resource limiter lifetime for runtime executor

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-runtime`)*
- `cargo test -p icn-ccl` *(fails to build)*


------
https://chatgpt.com/codex/tasks/task_e_686cd4c746b08324a2e9693c682b654a