### PR TITLE
Switch pending_mesh_jobs to channel

### DIFF
--- a/crates/icn-mesh/src/metrics.rs
+++ b/crates/icn-mesh/src/metrics.rs
@@ -1,5 +1,9 @@
 use once_cell::sync::Lazy;
-use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
+use prometheus_client::metrics::{
+    counter::Counter,
+    gauge::Gauge,
+    histogram::{exponential_buckets, Histogram},
+};
 
 /// Counts calls to `select_executor`.
 pub static SELECT_EXECUTOR_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
@@ -11,4 +15,5 @@ pub static SCHEDULE_MESH_JOB_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
 pub static PENDING_JOBS_GAUGE: Lazy<Gauge<i64>> = Lazy::new(Gauge::default);
 
 /// Records the time from job assignment to receipt processing in seconds.
-pub static JOB_PROCESS_TIME: Lazy<Histogram> = Lazy::new(Histogram::default);
+pub static JOB_PROCESS_TIME: Lazy<Histogram> =
+    Lazy::new(|| Histogram::new(exponential_buckets(1.0, 2.0, 10)));

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -178,7 +178,7 @@ async fn wasm_executor_host_submit_mesh_job_json() {
     let expected_cid = Cid::new_v1_sha256(0x55, &(40i64).to_le_bytes());
     assert_eq!(receipt.result_cid, expected_cid);
     assert_eq!(ctx.get_mana(&ctx.current_identity).await.unwrap(), 40);
-    let pending = ctx.pending_mesh_jobs.lock().await;
+    let pending = icn_runtime::host_get_pending_mesh_jobs(&ctx).await.unwrap();
     assert_eq!(pending.len(), 1);
 }
 

--- a/crates/icn-runtime/tests/wasm_host_api.rs
+++ b/crates/icn-runtime/tests/wasm_host_api.rs
@@ -120,9 +120,8 @@ async fn wasm_host_api_functions() {
     assert_eq!(mana_after, 35);
 
     // Build and anchor receipt
-    let pending = ctx.pending_mesh_jobs.lock().await;
+    let pending = icn_runtime::host_get_pending_mesh_jobs(&ctx).await.unwrap();
     let job_id = pending[0].id.clone();
-    drop(pending);
 
     let (_sk, vk) = generate_ed25519_keypair();
     let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();


### PR DESCRIPTION
## Summary
- track mesh job queue with `mpsc` channel
- push jobs into the channel instead of VecDeque
- consume jobs with `recv` loop in job manager
- update pending job gauge handling
- adjust tests for new API

## Testing
- `cargo test -p icn-runtime --no-run` *(fails: lifetime may not live long enough)*

------
https://chatgpt.com/codex/tasks/task_e_686cd53c8e2483248955c233b973455e