### PR TITLE
Fix metrics histogram init

### DIFF
--- a/crates/icn-mesh/src/metrics.rs
+++ b/crates/icn-mesh/src/metrics.rs
@@ -1,5 +1,9 @@
 use once_cell::sync::Lazy;
-use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
+use prometheus_client::metrics::{
+    counter::Counter,
+    gauge::Gauge,
+    histogram::{exponential_buckets, Histogram},
+};
 
 /// Counts calls to `select_executor`.
 pub static SELECT_EXECUTOR_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
@@ -11,4 +15,6 @@ pub static SCHEDULE_MESH_JOB_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
 pub static PENDING_JOBS_GAUGE: Lazy<Gauge<i64>> = Lazy::new(Gauge::default);
 
 /// Records the time from job assignment to receipt processing in seconds.
-pub static JOB_PROCESS_TIME: Lazy<Histogram> = Lazy::new(Histogram::default);
+pub static JOB_PROCESS_TIME: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::new(exponential_buckets(0.005, 2.0, 20))
+});


### PR DESCRIPTION
## Summary
- fix prometheus histogram init

## Testing
- `cargo test -p icn-runtime --no-run --features async` *(fails: method not found errors in executor.rs)*

------
https://chatgpt.com/codex/tasks/task_e_686cd6d8ca3c83248213e8f728c0fe28