### PR TITLE
[tests] remove dead_code allow

### DIFF
--- a/tests/integration/federation.rs
+++ b/tests/integration/federation.rs
@@ -273,7 +273,6 @@ async fn test_federation_complete_workflow() {
 }
 
 // Helper function for manual testing
-#[allow(dead_code)]
 pub async fn wait_for_federation_ready() -> Result<(), Box<dyn std::error::Error>> {
     println!("⏳ Waiting for federation to be ready...");
     


### PR DESCRIPTION
## Summary
- remove `#[allow(dead_code)]` from `wait_for_federation_ready`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timed out)*
- `cargo test --all-features --workspace` *(failed: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686cd19f3ed083249e303af5c76dee95