### PR TITLE
[docs] add async overview notes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,7 +44,14 @@
 ### Storage & Execution
 - **Runtime-Based Execution**: The `icn-runtime` crate hosts WASM contracts and orchestrates mesh jobs through a host ABI. Deterministic execution ensures verifiable receipts.
 - **DAG Ground Truth**: `icn-dag` anchors execution receipts and stores state in a content-addressed DAG, providing tamper-evident history.
-- **Cryptographic Auditability**: Every significant action emits signed execution receipts stored in the DAG for complete transparency.
+ - **Cryptographic Auditability**: Every significant action emits signed execution receipts stored in the DAG for complete transparency.
+
+### Async I/O Model
+ - **Tokio Runtime**: All networking and persistence layers run on Tokio and expose `async` functions.
+ - **Async Storage Interfaces**: The `icn-dag` crate's `AsyncStorageService` is the canonical trait for persistence backends.
+ - **Async Crates**: `icn-api`, `icn-cli`, `icn-dag`, `icn-network`, `icn-runtime`, `icn-governance`, and `icn-node` provide async APIs.
+ - **Remaining Sync Code**: Only `icn-dag` retains `StorageService` for legacy synchronous environments.
+ - See [docs/ASYNC_OVERVIEW.md](docs/ASYNC_OVERVIEW.md) for more detail.
 
 ## Crate Responsibilities
 

--- a/docs/ASYNC_OVERVIEW.md
+++ b/docs/ASYNC_OVERVIEW.md
@@ -1,11 +1,12 @@
 # Async APIs and Concurrency in ICN Core
 
-The ICN Core workspace favors asynchronous code for any operation that touches the network or storage. All crates that perform I/O expose async interfaces so callers can compose them using `async`/`await` and Tokio.
+The ICN Core workspace favors asynchronous code for any operation that touches the network or persistent storage. Tokio is the default runtime and every crate that performs I/O exposes `async` functions so callers can compose them with `async`/`await`.
 
 ## Key Points
 
 - **Network and storage interactions are async.** Services in `icn-network`, the HTTP APIs in `icn-api`, and the CLI HTTP client all use async functions.
 - **Storage interfaces are async.** `icn-dag` defines `AsyncStorageService` and async backends such as `TokioFileDagStore`. The older `StorageService` trait remains for limited synchronous environments.
+- **Tokio runtime.** All nodes and services run on the Tokio runtime for cooperative scheduling.
 - **Crates with async APIs:**
   - `icn-api` – async RPC helpers and network calls
   - `icn-cli` – async HTTP requests

--- a/icn-ccl/README.md
+++ b/icn-ccl/README.md
@@ -3,6 +3,7 @@
 This crate provides the compiler for the Cooperative Contract Language (CCL) used in the InterCooperative Network (ICN). It translates CCL source into WebAssembly (WASM) modules and produces metadata describing the contract.
 
 See [CONTEXT.md](../CONTEXT.md) for ICN Core design philosophy and crate roles.
+See [docs/ASYNC_OVERVIEW.md](../docs/ASYNC_OVERVIEW.md) for async API guidelines.
 
 ## Purpose
 


### PR DESCRIPTION
## Summary
- clarify that network and storage ops use Tokio async runtime
- list async crates and remaining sync code in CONTEXT
- link async overview from icn-ccl crate readme

## Testing
- `cargo fmt --all -- --check` *(fails: Diff in icn-api/src/lib.rs)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-mesh`)*
- `cargo test --all-features --workspace` *(interrupted)*
- `cargo test -p icn-ccl` *(fails: could not compile `icn-mesh`)*
- `just test-ccl-contracts` *(fails: command not found)*
- `just test-covm-execution` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd55ac83c8324a7a12273444d89cd