### PR TITLE
[governance] add vote delegation

### DIFF
--- a/crates/icn-api/src/governance_trait.rs
+++ b/crates/icn-api/src/governance_trait.rs
@@ -12,6 +12,17 @@ pub struct CastVoteRequest {
     pub vote_option: String, // e.g., "Yes", "No", "Abstain" - will map to VoteOption enum
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DelegateRequest {
+    pub from_did: String,
+    pub to_did: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RevokeDelegationRequest {
+    pub from_did: String,
+}
+
 // Define ProposalInputType and SubmitProposalRequest as per Step 2
 #[derive(Serialize, Deserialize, Debug, Clone)] // Added Clone
 #[serde(tag = "type", content = "data")]

--- a/crates/icn-governance/tests/delegation.rs
+++ b/crates/icn-governance/tests/delegation.rs
@@ -1,0 +1,55 @@
+use icn_common::Did;
+use icn_governance::{GovernanceModule, ProposalStatus, ProposalType, VoteOption};
+use std::str::FromStr;
+
+#[test]
+fn delegation_affects_tally() {
+    let mut gov = GovernanceModule::new();
+    let alice = Did::from_str("did:example:alice").unwrap();
+    let bob = Did::from_str("did:example:bob").unwrap();
+    let carol = Did::from_str("did:example:carol").unwrap();
+    gov.add_member(alice.clone());
+    gov.add_member(bob.clone());
+    gov.add_member(carol.clone());
+    gov.set_quorum(2);
+    gov.set_threshold(0.6);
+
+    let pid = gov
+        .submit_proposal(
+            alice.clone(),
+            ProposalType::GenericText("delegate".into()),
+            "desc".into(),
+            60,
+            None,
+            None,
+        )
+        .unwrap();
+    gov.open_voting(&pid).unwrap();
+
+    gov.delegate_vote(alice.clone(), bob.clone()).unwrap();
+    gov.cast_vote(bob.clone(), &pid, VoteOption::Yes).unwrap();
+    gov.cast_vote(carol.clone(), &pid, VoteOption::No).unwrap();
+
+    let status = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
+
+    // revoke and try again
+    let pid2 = gov
+        .submit_proposal(
+            alice.clone(),
+            ProposalType::GenericText("delegate2".into()),
+            "desc".into(),
+            60,
+            None,
+            None,
+        )
+        .unwrap();
+    gov.open_voting(&pid2).unwrap();
+    gov.delegate_vote(alice.clone(), bob.clone()).unwrap();
+    gov.revoke_delegation(alice.clone());
+    gov.cast_vote(bob.clone(), &pid2, VoteOption::Yes).unwrap();
+    gov.cast_vote(carol.clone(), &pid2, VoteOption::No).unwrap();
+
+    let status2 = gov.close_voting_period(&pid2).unwrap();
+    assert_eq!(status2, ProposalStatus::Rejected);
+}

--- a/crates/icn-node/tests/governance_delegation.rs
+++ b/crates/icn-node/tests/governance_delegation.rs
@@ -1,0 +1,166 @@
+use icn_api::governance_trait::{
+    CastVoteRequest, DelegateRequest, ProposalInputType, RevokeDelegationRequest,
+    SubmitProposalRequest,
+};
+use icn_common::Did;
+use icn_governance::{ProposalId, ProposalStatus, VoteOption};
+use icn_node::app_router_with_options;
+use reqwest::Client;
+use std::str::FromStr;
+use tokio::task;
+
+#[tokio::test]
+async fn delegate_and_revoke_flow() {
+    let (router, ctx) =
+        app_router_with_options(None, None, None, None, None, None, None, None, None, None).await;
+    let node_did = ctx.current_identity.clone();
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.add_member(node_did.clone());
+        gov.add_member(Did::from_str("did:example:bob").unwrap());
+        gov.add_member(Did::from_str("did:example:carol").unwrap());
+        gov.set_quorum(2);
+        gov.set_threshold(0.6);
+    }
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let client = Client::new();
+    let submit_req = SubmitProposalRequest {
+        proposer_did: node_did.to_string(),
+        proposal: ProposalInputType::GenericText { text: "hi".into() },
+        description: "test".into(),
+        duration_secs: 60,
+        quorum: None,
+        threshold: None,
+    };
+    let resp = client
+        .post(format!("http://{addr}/governance/submit"))
+        .json(&submit_req)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let pid: String = resp.json().await.unwrap();
+    let pid_struct = ProposalId(pid.clone());
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.open_voting(&pid_struct).unwrap();
+    }
+
+    let dreq = DelegateRequest {
+        from_did: "did:example:bob".into(),
+        to_did: node_did.to_string(),
+    };
+    let dresp = client
+        .post(format!("http://{addr}/governance/delegate"))
+        .json(&dreq)
+        .send()
+        .await
+        .unwrap();
+    assert!(dresp.status().is_success());
+
+    let vote_req = CastVoteRequest {
+        voter_did: node_did.to_string(),
+        proposal_id: pid.clone(),
+        vote_option: "yes".into(),
+    };
+    let vresp = client
+        .post(format!("http://{addr}/governance/vote"))
+        .json(&vote_req)
+        .send()
+        .await
+        .unwrap();
+    assert!(vresp.status().is_success());
+
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.cast_vote(
+            Did::from_str("did:example:carol").unwrap(),
+            &pid_struct,
+            VoteOption::No,
+        )
+        .unwrap();
+    }
+
+    let close = client
+        .post(format!("http://{addr}/governance/close"))
+        .json(&serde_json::json!({"proposal_id": pid.clone()}))
+        .send()
+        .await
+        .unwrap();
+    assert!(close.status().is_success());
+    {
+        let gov = ctx.governance_module.lock().await;
+        let prop = gov.get_proposal(&pid_struct).unwrap().unwrap();
+        assert_eq!(prop.status, ProposalStatus::Executed);
+    }
+
+    // revoke delegation for second proposal
+    let submit_req2 = SubmitProposalRequest {
+        proposer_did: node_did.to_string(),
+        proposal: ProposalInputType::GenericText { text: "bye".into() },
+        description: "test2".into(),
+        duration_secs: 60,
+        quorum: None,
+        threshold: None,
+    };
+    let resp2 = client
+        .post(format!("http://{addr}/governance/submit"))
+        .json(&submit_req2)
+        .send()
+        .await
+        .unwrap();
+    let pid2: String = resp2.json().await.unwrap();
+    let pid2_struct = ProposalId(pid2.clone());
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.open_voting(&pid2_struct).unwrap();
+    }
+    let rreq = RevokeDelegationRequest {
+        from_did: "did:example:bob".into(),
+    };
+    client
+        .post(format!("http://{addr}/governance/revoke"))
+        .json(&rreq)
+        .send()
+        .await
+        .unwrap();
+    let vote_req2 = CastVoteRequest {
+        voter_did: node_did.to_string(),
+        proposal_id: pid2.clone(),
+        vote_option: "yes".into(),
+    };
+    client
+        .post(format!("http://{addr}/governance/vote"))
+        .json(&vote_req2)
+        .send()
+        .await
+        .unwrap();
+    {
+        let mut gov = ctx.governance_module.lock().await;
+        gov.cast_vote(
+            Did::from_str("did:example:carol").unwrap(),
+            &pid2_struct,
+            VoteOption::No,
+        )
+        .unwrap();
+    }
+    let close2 = client
+        .post(format!("http://{addr}/governance/close"))
+        .json(&serde_json::json!({"proposal_id": pid2.clone()}))
+        .send()
+        .await
+        .unwrap();
+    assert!(close2.status().is_success());
+    {
+        let gov = ctx.governance_module.lock().await;
+        let prop = gov.get_proposal(&pid2_struct).unwrap().unwrap();
+        assert_eq!(prop.status, ProposalStatus::Rejected);
+    }
+
+    server.abort();
+}

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -1757,6 +1757,23 @@ impl RuntimeContext {
         }
     }
 
+    pub async fn delegate_vote(&self, from_did: &str, to_did: &str) -> Result<(), HostAbiError> {
+        let from = Did::from_str(from_did)
+            .map_err(|e| HostAbiError::InvalidParameters(format!("Invalid DID: {}", e)))?;
+        let to = Did::from_str(to_did)
+            .map_err(|e| HostAbiError::InvalidParameters(format!("Invalid DID: {}", e)))?;
+        let mut gov = self.governance_module.lock().await;
+        gov.delegate_vote(from, to).map_err(HostAbiError::Common)
+    }
+
+    pub async fn revoke_delegation(&self, from_did: &str) -> Result<(), HostAbiError> {
+        let from = Did::from_str(from_did)
+            .map_err(|e| HostAbiError::InvalidParameters(format!("Invalid DID: {}", e)))?;
+        let mut gov = self.governance_module.lock().await;
+        gov.revoke_delegation(from);
+        Ok(())
+    }
+
     /// Inserts a proposal received from the network into the local GovernanceModule.
     pub async fn ingest_external_proposal(
         &self,

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -589,6 +589,23 @@ pub async fn host_execute_governance_proposal(
     ctx.execute_governance_proposal(proposal_id).await
 }
 
+/// Delegate voting power from one DID to another.
+pub async fn host_delegate_vote(
+    ctx: &RuntimeContext,
+    from_did: &str,
+    to_did: &str,
+) -> Result<(), HostAbiError> {
+    ctx.delegate_vote(from_did, to_did).await
+}
+
+/// Revoke any vote delegation for the given DID.
+pub async fn host_revoke_delegation(
+    ctx: &RuntimeContext,
+    from_did: &str,
+) -> Result<(), HostAbiError> {
+    ctx.revoke_delegation(from_did).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- support vote delegation in `GovernanceModule`
- expose `/governance/delegate` and `/governance/revoke` endpoints
- add runtime helpers for delegation
- test delegation logic and HTTP flows

## Testing
- `cargo clippy -p icn-governance -p icn-runtime -p icn-node -p icn-api --all-targets --all-features -- -D warnings` *(failed: process terminated)*
- `cargo test --all-features --workspace` *(failed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686d729d5d1c8324924b59b4b847c2ca