### PR TITLE
Add vote tally output to close endpoint

### DIFF
--- a/crates/icn-api/src/governance_trait.rs
+++ b/crates/icn-api/src/governance_trait.rs
@@ -52,3 +52,11 @@ pub trait GovernanceApi {
     fn get_proposal(&self, id: ProposalId) -> Result<Option<Proposal>, CommonError>;
     fn list_proposals(&self) -> Result<Vec<Proposal>, CommonError>;
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CloseProposalResponse {
+    pub status: String,
+    pub yes: usize,
+    pub no: usize,
+    pub abstain: usize,
+}

--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -564,8 +564,12 @@ async fn handle_gov_tally(
     proposal_id: &str,
 ) -> Result<(), anyhow::Error> {
     let req = serde_json::json!({ "proposal_id": proposal_id });
-    let status: String = post_request(&cli.api_url, client, "/governance/close", &req).await?;
-    println!("Tally result: {}", status);
+    let result: icn_api::governance_trait::CloseProposalResponse =
+        post_request(&cli.api_url, client, "/governance/close", &req).await?;
+    println!(
+        "Tally result: yes={} no={} abstain={} status={}",
+        result.yes, result.no, result.abstain, result.status
+    );
     Ok(())
 }
 

--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -847,7 +847,7 @@ impl GovernanceModule {
     pub fn close_voting_period(
         &mut self,
         proposal_id: &ProposalId,
-    ) -> Result<ProposalStatus, CommonError> {
+    ) -> Result<(ProposalStatus, (usize, usize, usize)), CommonError> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -866,7 +866,7 @@ impl GovernanceModule {
                 })?;
                 // Allow early closing of the voting period
                 if proposal.status != ProposalStatus::VotingOpen {
-                    return Ok(proposal.status.clone());
+                    return Ok((proposal.status.clone(), (0, 0, 0)));
                 }
                 let (yes, no, abstain) = {
                     let mut yes = 0;
@@ -894,7 +894,7 @@ impl GovernanceModule {
                 } else {
                     proposal.status = ProposalStatus::Rejected;
                 }
-                Ok(proposal.status.clone())
+                Ok((proposal.status.clone(), (yes, no, abstain)))
             }
             #[cfg(feature = "persist-sled")]
             Backend::Sled {
@@ -931,7 +931,7 @@ impl GovernanceModule {
                     })?;
                 // Allow early closing of the voting period
                 if proposal.status != ProposalStatus::VotingOpen {
-                    return Ok(proposal.status.clone());
+                    return Ok((proposal.status.clone(), (0, 0, 0)));
                 }
                 let (yes, no, abstain) = {
                     let mut yes = 0;
@@ -977,7 +977,7 @@ impl GovernanceModule {
                         proposal_id.0, e
                     ))
                 })?;
-                Ok(proposal.status)
+                Ok((proposal.status, (yes, no, abstain)))
             }
         }
     }

--- a/crates/icn-governance/tests/callback.rs
+++ b/crates/icn-governance/tests/callback.rs
@@ -42,10 +42,8 @@ fn callback_runs_on_execute() {
         VoteOption::Yes,
     )
     .unwrap();
-    assert_eq!(
-        gov.close_voting_period(&pid).unwrap(),
-        ProposalStatus::Accepted
-    );
+    let (status, _) = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
     gov.execute_proposal(&pid).unwrap();
     assert!(executed.load(Ordering::SeqCst));
 }

--- a/crates/icn-governance/tests/custom.rs
+++ b/crates/icn-governance/tests/custom.rs
@@ -34,6 +34,6 @@ fn proposal_specific_quorum_and_threshold() {
     )
     .unwrap();
 
-    let status = gov.close_voting_period(&pid).unwrap();
+    let (status, _) = gov.close_voting_period(&pid).unwrap();
     assert_eq!(status, ProposalStatus::Rejected);
 }

--- a/crates/icn-governance/tests/execution.rs
+++ b/crates/icn-governance/tests/execution.rs
@@ -32,10 +32,8 @@ fn execute_new_member_invitation_proposal() {
         VoteOption::Yes,
     )
     .unwrap();
-    assert_eq!(
-        gov.close_voting_period(&pid).unwrap(),
-        ProposalStatus::Accepted
-    );
+    let (status, _) = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
     gov.execute_proposal(&pid).unwrap();
     assert!(gov
         .members()
@@ -74,10 +72,8 @@ fn execute_remove_member_proposal() {
         VoteOption::Yes,
     )
     .unwrap();
-    assert_eq!(
-        gov.close_voting_period(&pid).unwrap(),
-        ProposalStatus::Accepted
-    );
+    let (status, _) = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
     gov.execute_proposal(&pid).unwrap();
     assert!(!gov
         .members()

--- a/crates/icn-governance/tests/voting.rs
+++ b/crates/icn-governance/tests/voting.rs
@@ -39,8 +39,9 @@ fn vote_tally_and_execute() {
     .unwrap();
 
     // close immediately since early closing is allowed
-    let status = gov.close_voting_period(&pid).unwrap();
+    let (status, (yes, no, abstain)) = gov.close_voting_period(&pid).unwrap();
     assert_eq!(status, ProposalStatus::Accepted);
+    assert_eq!((yes, no, abstain), (2, 0, 0));
 
     gov.execute_proposal(&pid).unwrap();
     assert!(gov
@@ -80,8 +81,9 @@ fn reject_due_to_quorum() {
     )
     .unwrap();
 
-    let status = gov.close_voting_period(&pid).unwrap();
+    let (status, (yes, no, abstain)) = gov.close_voting_period(&pid).unwrap();
     assert_eq!(status, ProposalStatus::Rejected);
+    assert_eq!((yes, no, abstain), (1, 0, 0));
 }
 
 #[test]
@@ -119,8 +121,9 @@ fn reject_due_to_threshold() {
     )
     .unwrap();
 
-    let status = gov.close_voting_period(&pid).unwrap();
+    let (status, (yes, no, abstain)) = gov.close_voting_period(&pid).unwrap();
     assert_eq!(status, ProposalStatus::Rejected);
+    assert_eq!((yes, no, abstain), (1, 1, 0));
 }
 
 #[test]
@@ -204,10 +207,8 @@ fn close_before_deadline_errors() {
         VoteOption::Yes,
     )
     .unwrap();
-    assert_eq!(
-        gov.close_voting_period(&pid).unwrap(),
-        ProposalStatus::Accepted
-    );
+    let (status, _) = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
 }
 
 #[test]
@@ -253,6 +254,7 @@ fn member_removal_affects_outcome() {
 
     gov.remove_member(&Did::from_str("did:example:charlie").unwrap());
 
-    let status = gov.close_voting_period(&pid).unwrap();
+    let (status, (yes, no, abstain)) = gov.close_voting_period(&pid).unwrap();
     assert_eq!(status, ProposalStatus::Accepted);
+    assert_eq!((yes, no, abstain), (2, 0, 0));
 }

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1730,7 +1730,7 @@ async fn gov_close_handler(
         &req.proposal_id,
     )
     .await;
-    let status = match result {
+    let status_json = match result {
         Ok(s) => s,
         Err(e) => {
             return map_rust_error_to_json_response(
@@ -1740,7 +1740,17 @@ async fn gov_close_handler(
             .into_response()
         }
     };
-    if status == format!("{:?}", icn_governance::ProposalStatus::Accepted) {
+    let close: icn_api::governance_trait::CloseProposalResponse = match serde_json::from_str(&status_json) {
+        Ok(c) => c,
+        Err(e) => {
+            return map_rust_error_to_json_response(
+                format!("Serialization error: {}", e),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .into_response()
+        }
+    };
+    if close.status == format!("{:?}", icn_governance::ProposalStatus::Accepted) {
         if let Err(e) =
             icn_runtime::host_execute_governance_proposal(&state.runtime_context, &req.proposal_id)
                 .await
@@ -1752,7 +1762,7 @@ async fn gov_close_handler(
             .into_response();
         }
     }
-    (StatusCode::OK, Json(status)).into_response()
+    (StatusCode::OK, Json(close)).into_response()
 }
 
 // POST /governance/execute – force execute an accepted proposal

--- a/crates/icn-runtime/src/context.rs
+++ b/crates/icn-runtime/src/context.rs
@@ -318,6 +318,14 @@ pub struct CastVotePayload {
     pub vote_option_str: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CloseProposalResult {
+    pub status: String,
+    pub yes: usize,
+    pub no: usize,
+    pub abstain: usize,
+}
+
 /// Mana cost deducted when creating a governance proposal.
 pub const PROPOSAL_COST_MANA: u64 = 10;
 
@@ -1695,7 +1703,7 @@ impl RuntimeContext {
             .map_err(|e| HostAbiError::InvalidParameters(format!("Invalid proposal id: {e}")))?;
 
         let mut gov = self.governance_module.lock().await;
-        let status = gov
+        let (status, (yes, no, abstain)) = gov
             .close_voting_period(&proposal_id)
             .map_err(HostAbiError::Common)?;
         let proposal = gov
@@ -1711,7 +1719,15 @@ impl RuntimeContext {
             log::warn!("Failed to broadcast proposal {:?}: {}", proposal_id, e);
         }
 
-        Ok(format!("{:?}", status))
+        let result = CloseProposalResult {
+            status: format!("{:?}", status),
+            yes,
+            no,
+            abstain,
+        };
+        Ok(serde_json::to_string(&result).map_err(|e| {
+            HostAbiError::InternalError(format!("Failed to serialize tally: {e}"))
+        })?)
     }
 
     pub async fn execute_governance_proposal(

--- a/crates/icn-runtime/tests/governance.rs
+++ b/crates/icn-runtime/tests/governance.rs
@@ -47,10 +47,13 @@ async fn proposal_can_be_closed_and_executed() {
         .unwrap();
     }
     // close voting
-    let status = host_close_governance_proposal_voting(&ctx, &pid_str)
+    let result_json = host_close_governance_proposal_voting(&ctx, &pid_str)
         .await
         .expect("close voting");
-    assert_eq!(status, format!("{:?}", ProposalStatus::Accepted));
+    let result: icn_api::governance_trait::CloseProposalResponse =
+        serde_json::from_str(&result_json).unwrap();
+    assert_eq!(result.status, format!("{:?}", ProposalStatus::Accepted));
+    assert_eq!((result.yes, result.no, result.abstain), (2, 0, 0));
     // execute proposal
     host_execute_governance_proposal(&ctx, &pid_str)
         .await
@@ -175,10 +178,13 @@ async fn lifecycle_with_member_add_and_remove() {
         )
         .unwrap();
     }
-    let status = host_close_governance_proposal_voting(&ctx, &pid_str)
+    let res_json = host_close_governance_proposal_voting(&ctx, &pid_str)
         .await
         .expect("close voting");
-    assert_eq!(status, format!("{:?}", ProposalStatus::Accepted));
+    let res: icn_api::governance_trait::CloseProposalResponse =
+        serde_json::from_str(&res_json).unwrap();
+    assert_eq!(res.status, format!("{:?}", ProposalStatus::Accepted));
+    assert_eq!((res.yes, res.no, res.abstain), (1, 0, 0));
 
     host_execute_governance_proposal(&ctx, &pid_str)
         .await
@@ -226,9 +232,12 @@ async fn execution_rewards_proposer() {
         )
         .unwrap();
     }
-    host_close_governance_proposal_voting(&ctx, &pid_str)
+    let res_json = host_close_governance_proposal_voting(&ctx, &pid_str)
         .await
         .expect("close voting");
+    let res: icn_api::governance_trait::CloseProposalResponse =
+        serde_json::from_str(&res_json).unwrap();
+    assert_eq!((res.yes, res.no, res.abstain), (1, 0, 0));
 
     let mana_before = ctx.mana_ledger.get_balance(&ctx.current_identity);
     let rep_before = ctx.reputation_store.get_reputation(&ctx.current_identity);

--- a/docs/API.md
+++ b/docs/API.md
@@ -59,6 +59,7 @@ curl -X POST https://localhost:8080/dag/get \
 | POST | `/governance/vote` | Cast a vote on a proposal | Yes |
 | GET | `/governance/proposals` | List all proposals | Yes |
 | GET | `/governance/proposal/:id` | Fetch a specific proposal | Yes |
+| POST | `/governance/close` | Close voting and return tally | Yes |
 
 ### Example Governance Operations
 ```bash
@@ -81,6 +82,20 @@ curl -X POST https://localhost:8080/governance/vote \
     "vote": "Yes"
   }'
 ```
+
+The `/governance/close` endpoint returns a JSON object:
+
+```json
+{
+  "status": "Accepted",
+  "yes": 2,
+  "no": 0,
+  "abstain": 1
+}
+```
+
+`status` is the final `ProposalStatus` string, and the numeric fields represent
+the counted votes.
 
 ## Mesh Computing Endpoints
 


### PR DESCRIPTION
## Summary
- extend Governance `close_voting_period` to return yes/no/abstain counts
- expose `CloseProposalResult` from runtime context and API types
- adjust node HTTP handler and CLI `Tally` command to show counts
- update governance tests to check vote tallies
- document `/governance/close` response in API docs

## Testing
- `cargo test -p icn-governance --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686d72a0a83083248871e97260879345