### PR TITLE
Add DAG block pinning and TTL pruning

### DIFF
--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -16,6 +16,10 @@ The `icn-dag` crate is responsible for:
 
 This forms a foundational layer for data representation and exchange within the ICN.
 
+## Pinning and TTL
+
+Every block stored in a DAG backend can have associated metadata indicating whether it is pinned and an optional TTL (expiration timestamp). Pinned blocks are preserved during pruning even if their TTL has passed. TTL values are expressed as seconds since the Unix epoch and may be updated after a block is stored. Implementations provide `pin_block`, `unpin_block`, and `prune_expired` to manage this metadata and remove stale content.
+
 ## Public API Style
 
 The API style prioritizes:

--- a/crates/icn-dag/src/rocksdb_store.rs
+++ b/crates/icn-dag/src/rocksdb_store.rs
@@ -1,10 +1,11 @@
-use crate::{Cid, CommonError, DagBlock, StorageService};
+use crate::{BlockMetadata, Cid, CommonError, DagBlock, StorageService};
 use rocksdb::{Options, DB};
 use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct RocksDagStore {
     db: DB,
+    meta: std::collections::HashMap<Cid, BlockMetadata>,
 }
 
 impl RocksDagStore {
@@ -14,7 +15,10 @@ impl RocksDagStore {
         opts.create_if_missing(true);
         let db = DB::open(&opts, path)
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open RocksDB: {}", e)))?;
-        Ok(Self { db })
+        Ok(Self {
+            db,
+            meta: std::collections::HashMap::new(),
+        })
     }
 }
 
@@ -30,6 +34,8 @@ impl StorageService<DagBlock> for RocksDagStore {
         self.db.put(block.cid.to_string(), encoded).map_err(|e| {
             CommonError::DatabaseError(format!("Failed to store block {}: {}", block.cid, e))
         })?;
+        self.meta
+            .insert(block.cid.clone(), BlockMetadata::default());
         Ok(())
     }
 
@@ -60,6 +66,7 @@ impl StorageService<DagBlock> for RocksDagStore {
         self.db.delete(cid.to_string()).map_err(|e| {
             CommonError::DatabaseError(format!("Failed to delete block {}: {}", cid, e))
         })?;
+        self.meta.remove(cid);
         Ok(())
     }
 
@@ -82,6 +89,74 @@ impl StorageService<DagBlock> for RocksDagStore {
             blocks.push(block);
         }
         Ok(blocks)
+    }
+
+    fn pin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        match self.meta.get_mut(cid) {
+            Some(m) => {
+                m.pinned = true;
+                Ok(())
+            }
+            None => Err(CommonError::ResourceNotFound(format!(
+                "Block {} not found",
+                cid
+            ))),
+        }
+    }
+
+    fn unpin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        match self.meta.get_mut(cid) {
+            Some(m) => {
+                m.pinned = false;
+                Ok(())
+            }
+            None => Err(CommonError::ResourceNotFound(format!(
+                "Block {} not found",
+                cid
+            ))),
+        }
+    }
+
+    fn prune_expired(&mut self, now: u64) -> Result<Vec<Cid>, CommonError> {
+        use rocksdb::WriteBatch;
+        let mut removed = Vec::new();
+        let to_remove: Vec<Cid> = self
+            .meta
+            .iter()
+            .filter(|(_, m)| !m.pinned && m.ttl.map(|t| t <= now).unwrap_or(false))
+            .map(|(c, _)| c.clone())
+            .collect();
+        let mut batch = WriteBatch::default();
+        for cid in &to_remove {
+            batch.delete(cid.to_string());
+        }
+        if !to_remove.is_empty() {
+            self.db
+                .write(batch)
+                .map_err(|e| CommonError::DatabaseError(format!("Batch delete failed: {}", e)))?;
+        }
+        for cid in to_remove {
+            self.meta.remove(&cid);
+            removed.push(cid);
+        }
+        Ok(removed)
+    }
+
+    fn set_ttl(&mut self, cid: &Cid, ttl: Option<u64>) -> Result<(), CommonError> {
+        match self.meta.get_mut(cid) {
+            Some(m) => {
+                m.ttl = ttl;
+                Ok(())
+            }
+            None => Err(CommonError::ResourceNotFound(format!(
+                "Block {} not found",
+                cid
+            ))),
+        }
+    }
+
+    fn get_metadata(&self, cid: &Cid) -> Result<Option<BlockMetadata>, CommonError> {
+        Ok(self.meta.get(cid).cloned())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/icn-dag/src/sqlite_store.rs
+++ b/crates/icn-dag/src/sqlite_store.rs
@@ -1,10 +1,11 @@
-use crate::{Cid, CommonError, DagBlock, StorageService};
+use crate::{BlockMetadata, Cid, CommonError, DagBlock, StorageService};
 use rusqlite::{params, Connection};
 use std::path::PathBuf;
 
 #[derive(Debug)]
 pub struct SqliteDagStore {
     conn: Connection,
+    meta: std::collections::HashMap<Cid, BlockMetadata>,
 }
 
 impl SqliteDagStore {
@@ -17,7 +18,10 @@ impl SqliteDagStore {
             [],
         )
         .map_err(|e| CommonError::DatabaseError(format!("Failed to create table: {}", e)))?;
-        Ok(Self { conn })
+        Ok(Self {
+            conn,
+            meta: std::collections::HashMap::new(),
+        })
     }
 }
 
@@ -38,6 +42,8 @@ impl StorageService<DagBlock> for SqliteDagStore {
             .map_err(|e| {
                 CommonError::DatabaseError(format!("Failed to store block {}: {}", block.cid, e))
             })?;
+        self.meta
+            .insert(block.cid.clone(), BlockMetadata::default());
         Ok(())
     }
 
@@ -83,6 +89,7 @@ impl StorageService<DagBlock> for SqliteDagStore {
             .map_err(|e| {
                 CommonError::DatabaseError(format!("Failed to delete block {}: {}", cid, e))
             })?;
+        self.meta.remove(cid);
         Ok(())
     }
 
@@ -118,6 +125,74 @@ impl StorageService<DagBlock> for SqliteDagStore {
             blocks.push(block);
         }
         Ok(blocks)
+    }
+
+    fn pin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        match self.meta.get_mut(cid) {
+            Some(m) => {
+                m.pinned = true;
+                Ok(())
+            }
+            None => Err(CommonError::ResourceNotFound(format!(
+                "Block {} not found",
+                cid
+            ))),
+        }
+    }
+
+    fn unpin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        match self.meta.get_mut(cid) {
+            Some(m) => {
+                m.pinned = false;
+                Ok(())
+            }
+            None => Err(CommonError::ResourceNotFound(format!(
+                "Block {} not found",
+                cid
+            ))),
+        }
+    }
+
+    fn prune_expired(&mut self, now: u64) -> Result<Vec<Cid>, CommonError> {
+        let mut removed = Vec::new();
+        let to_remove: Vec<Cid> = self
+            .meta
+            .iter()
+            .filter(|(_, m)| !m.pinned && m.ttl.map(|t| t <= now).unwrap_or(false))
+            .map(|(c, _)| c.clone())
+            .collect();
+        for cid in &to_remove {
+            self.conn
+                .execute(
+                    "DELETE FROM blocks WHERE cid = ?1",
+                    params![cid.to_string()],
+                )
+                .map_err(|e| {
+                    CommonError::DatabaseError(format!("Failed to delete block {}: {}", cid, e))
+                })?;
+        }
+        for cid in to_remove {
+            self.meta.remove(&cid);
+            removed.push(cid);
+        }
+        Ok(removed)
+    }
+
+    fn set_ttl(&mut self, cid: &Cid, ttl: Option<u64>) -> Result<(), CommonError> {
+        match self.meta.get_mut(cid) {
+            Some(m) => {
+                m.ttl = ttl;
+                Ok(())
+            }
+            None => Err(CommonError::ResourceNotFound(format!(
+                "Block {} not found",
+                cid
+            ))),
+        }
+    }
+
+    fn get_metadata(&self, cid: &Cid) -> Result<Option<BlockMetadata>, CommonError> {
+        Ok(self.meta.get(cid).cloned())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/icn-dag/tests/prune.rs
+++ b/crates/icn-dag/tests/prune.rs
@@ -1,0 +1,44 @@
+use icn_common::{compute_merkle_cid, DagBlock, Did};
+use icn_dag::{InMemoryDagStore, StorageService};
+
+fn create_block(id: &str) -> DagBlock {
+    let data = format!("data {id}").into_bytes();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig = None;
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig, &None);
+    DagBlock {
+        cid,
+        data,
+        links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig,
+        scope: None,
+    }
+}
+
+#[test]
+fn prune_expired_unpinned() {
+    let mut store = InMemoryDagStore::new();
+    let block = create_block("b");
+    store.put(&block).unwrap();
+    store.set_ttl(&block.cid, Some(10)).unwrap();
+    assert!(store.prune_expired(5).unwrap().is_empty());
+    assert!(store.contains(&block.cid).unwrap());
+    let removed = store.prune_expired(11).unwrap();
+    assert_eq!(removed.len(), 1);
+    assert!(!store.contains(&block.cid).unwrap());
+}
+
+#[test]
+fn prune_keeps_pinned() {
+    let mut store = InMemoryDagStore::new();
+    let block = create_block("p");
+    store.put(&block).unwrap();
+    store.set_ttl(&block.cid, Some(10)).unwrap();
+    store.pin_block(&block.cid).unwrap();
+    let removed = store.prune_expired(20).unwrap();
+    assert!(removed.is_empty());
+    assert!(store.contains(&block.cid).unwrap());
+}

--- a/crates/icn-node/README.md
+++ b/crates/icn-node/README.md
@@ -24,6 +24,7 @@ The `main.rs` in this crate currently serves as a demonstration of integrating a
 
 1.  **Node Information & Status:** Calls `icn-api` functions (`get_node_info`, `get_node_status`) to retrieve and display node details. It demonstrates handling both successful calls and simulated error conditions (e.g., node offline).
 2.  **DAG Operations:** Demonstrates submitting a sample `DagBlock` to the local DAG store (via `icn-api` which uses `icn-dag`) and then retrieving it.
+    Additional endpoints allow pinning or unpinning blocks and pruning expired content based on TTL metadata.
 3.  **Network Operations:**
     *   When built with `with-libp2p`, the node spawns a real `Libp2pNetworkService` and discovers peers via bootstrap addresses.
     *   Demonstrates submitting another `DagBlock` and broadcasting its announcement using `broadcast_message`.


### PR DESCRIPTION
## Summary
- extend `StorageService` with block metadata support
- add pinning and TTL fields and implement in all backends
- expose pin/unpin/prune endpoints in `icn-node`
- add CLI commands for the new DAG operations
- document metadata behavior and add pruning tests

## Testing
- `cargo check`
- _`cargo test` failed due to environment limitations_

------
https://chatgpt.com/codex/tasks/task_e_686d72940f548324ba78095a666c5f69