### PR TITLE
Network service injection and examples

### DIFF
--- a/crates/icn-api/README.md
+++ b/crates/icn-api/README.md
@@ -17,6 +17,11 @@ The API is designed to be accessible via common RPC mechanisms such as JSON-RPC 
 *   **Modularity:** Separating concerns for different aspects of the ICN functionality.
 *   **Extensibility:** Allowing for new API endpoints and versions to be added as the ICN evolves.
 
+Networking helpers like `discover_peers_api` and `send_network_message_api` now
+accept a generic [`NetworkService`] trait object. This allows callers to inject
+the real `Libp2pNetworkService` when running in a full node, while tests can
+pass the `StubNetworkService` for deterministic behavior.
+
 Refer to the `lib.rs` documentation for specific API function signatures and data types.
 
 ## Contributing
@@ -24,5 +29,4 @@ Refer to the `lib.rs` documentation for specific API function signatures and dat
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.
 
 ## License
-
 Licensed under the Apache License, Version 2.0. See [LICENSE](../../LICENSE). 

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -404,12 +404,13 @@ impl GovernanceApi for GovernanceApiImpl {
 
 // --- Network API Functions ---
 
-/// API endpoint to discover network peers (currently uses StubNetworkService).
-/// Takes a list of bootstrap node addresses (currently ignored by stub but good for API design).
+/// API endpoint to discover network peers. The caller supplies a [`NetworkService`]
+/// implementation, allowing either the default stub or a real libp2p service.
+/// `bootstrap_nodes_str` are optional bootstrap addresses for discovery.
 pub async fn discover_peers_api(
+    network_service: Arc<dyn NetworkService>,
     bootstrap_nodes_str: Vec<String>,
 ) -> Result<Vec<PeerId>, CommonError> {
-    let network_service = StubNetworkService::default();
     // In a real scenario, bootstrap_nodes_str might need parsing into a more specific type.
     // For discover_peers, we might want to pass a single optional peer, or handle multiple if the underlying service supports it.
     // For now, let's take the first bootstrap node as an example if provided, or None.
@@ -425,14 +426,15 @@ pub async fn discover_peers_api(
         })
 }
 
-/// API endpoint to send a message to a specific peer (currently uses StubNetworkService).
-/// `peer_id_str` is the string representation of the target PeerId.
+/// API endpoint to send a message to a specific peer. The caller supplies a [`NetworkService`]
+/// implementation (stub or libp2p).
+/// `peer_id_str` is the string representation of the target [`PeerId`].
 /// `message_json` is a JSON string representation of the [`ProtocolMessage`].
 pub async fn send_network_message_api(
+    network_service: Arc<dyn NetworkService>,
     peer_id_str: String,
     message_json: String,
 ) -> Result<(), CommonError> {
-    let network_service = StubNetworkService::default();
     let peer_id = PeerId(peer_id_str); // Assuming PeerId is a simple wrapper around String for now.
 
     // Deserialize the ProtocolMessage from JSON.
@@ -830,7 +832,8 @@ mod tests {
     async fn test_discover_peers_api() {
         // Made async
         let bootstrap_nodes = vec!["/ip4/127.0.0.1/tcp/12345/p2p/QmSimulatedPeer".to_string()];
-        match discover_peers_api(bootstrap_nodes).await {
+        let service = Arc::new(StubNetworkService::default()) as Arc<dyn NetworkService>;
+        match discover_peers_api(service, bootstrap_nodes).await {
             Ok(peers) => {
                 assert!(
                     !peers.is_empty(),
@@ -858,7 +861,8 @@ mod tests {
         );
         let message_json = serde_json::to_string(&message_to_send).unwrap();
 
-        let result = send_network_message_api(peer_id_str, message_json).await;
+        let service = Arc::new(StubNetworkService::default()) as Arc<dyn NetworkService>;
+        let result = send_network_message_api(service, peer_id_str, message_json).await;
         assert!(
             result.is_ok(),
             "send_network_message_api failed: {:?}",
@@ -881,7 +885,8 @@ mod tests {
         );
         let message_json = serde_json::to_string(&message_to_send).unwrap();
 
-        let result = send_network_message_api(peer_id_str, message_json).await;
+        let service = Arc::new(StubNetworkService::default()) as Arc<dyn NetworkService>;
+        let result = send_network_message_api(service, peer_id_str, message_json).await;
         assert!(result.is_err());
         match result.err().unwrap() {
             CommonError::ApiError(msg) => assert!(
@@ -898,7 +903,9 @@ mod tests {
         let peer_id_str = "QmTestPeerInvalidJson".to_string();
         let invalid_message_json = "this is not valid json for a network message";
 
-        match send_network_message_api(peer_id_str, invalid_message_json.to_string()).await {
+        let service = Arc::new(StubNetworkService::default()) as Arc<dyn NetworkService>;
+        match send_network_message_api(service, peer_id_str, invalid_message_json.to_string()).await
+        {
             Err(CommonError::DeserializationError(msg)) => {
                 assert!(msg.contains("Failed to parse ProtocolMessage JSON"));
             }

--- a/crates/icn-network/README.md
+++ b/crates/icn-network/README.md
@@ -78,6 +78,17 @@ This crate provides:
 
 The API aims for modularity, allowing different P2P backends to be integrated by implementing the `NetworkService` trait.
 
+## Examples
+
+The `tests` directory provides runnable examples that use the real libp2p
+networking stack. The [`handshake_pubsub.rs`](tests/handshake_pubsub.rs) test
+spawns two `Libp2pNetworkService` instances, performs a handshake, and
+exchanges a gossipsub message. Run it with:
+
+```bash
+cargo test -p icn-network --features libp2p handshake_pubsub
+```
+
 ## Contributing
 
 Please refer to the main `CONTRIBUTING.md` in the root of the `icn-core` repository.
@@ -89,5 +100,4 @@ Key areas for future contributions:
 *   Adding support for various transport protocols.
 
 ## License
-
 This crate is licensed under the Apache 2.0 license, as is the entire `icn-core` repository. 

--- a/crates/icn-network/tests/handshake_pubsub.rs
+++ b/crates/icn-network/tests/handshake_pubsub.rs
@@ -1,0 +1,62 @@
+#[cfg(feature = "libp2p")]
+mod handshake_pubsub {
+    use icn_common::Did;
+    use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
+    use icn_network::NetworkService;
+    use icn_protocol::{GossipMessage, MessagePayload, ProtocolMessage};
+    use libp2p::PeerId as Libp2pPeerId;
+    use std::str::FromStr;
+    use tokio::time::{sleep, timeout, Duration};
+
+    #[tokio::test]
+    async fn test_handshake_and_gossipsub() {
+        // start node A
+        let node_a = Libp2pNetworkService::new(NetworkConfig::default())
+            .await
+            .expect("node a");
+        sleep(Duration::from_secs(1)).await;
+        let addr = node_a.listening_addresses()[0].clone();
+        let peer_a = *node_a.local_peer_id();
+
+        // start node B bootstrapping to A
+        let mut config_b = NetworkConfig::default();
+        config_b.bootstrap_peers = vec![(peer_a, addr)];
+        let node_b = Libp2pNetworkService::new(config_b).await.expect("node b");
+
+        // give time for handshake
+        sleep(Duration::from_secs(3)).await;
+
+        // verify node B discovered node A
+        let discovered = node_b
+            .discover_peers(Some(node_a.local_peer_id().to_string()))
+            .await
+            .expect("discover");
+        assert!(discovered.iter().any(|p| p.0 == peer_a.to_string()));
+
+        // subscribe to gossipsub
+        let mut sub_a = node_a.subscribe().await.expect("sub a");
+        let mut sub_b = node_b.subscribe().await.expect("sub b");
+
+        // send message from A
+        let msg = ProtocolMessage::new(
+            MessagePayload::GossipMessage(GossipMessage {
+                topic: "demo".into(),
+                payload: b"hello".to_vec(),
+                ttl: 1,
+            }),
+            Did::from_str("did:key:testnode").unwrap(),
+            None,
+        );
+        node_a.broadcast_message(msg).await.expect("broadcast");
+
+        // expect B to receive
+        let recv = timeout(Duration::from_secs(10), sub_b.recv())
+            .await
+            .expect("recv timeout")
+            .expect("recv");
+        assert!(matches!(recv.payload, MessagePayload::GossipMessage(_)));
+
+        // also ensure A got its own broadcast
+        let _ = timeout(Duration::from_secs(10), sub_a.recv()).await;
+    }
+}


### PR DESCRIPTION
## Summary
- accept `Arc<dyn NetworkService>` in `discover_peers_api` and `send_network_message_api`
- document the new API usage
- add handshake and gossipsub example test
- document example in `icn-network` README

## Testing
- `cargo clippy -p icn-api -p icn-network --tests -- -D warnings` *(fails: could not compile `icn-runtime` due to 15 previous errors)*


------
https://chatgpt.com/codex/tasks/task_e_686d728b20248324843c7dc5ab64fd33