### PR TITLE
[deps] unify libp2p version

### DIFF
--- a/crates/icn-network/Cargo.toml
+++ b/crates/icn-network/Cargo.toml
@@ -38,7 +38,7 @@ libp2p-tcp = { version = "0.44", features = ["tokio"], optional = true }
 # No specific dev-dependencies here yet, but could add things like criterion for benchmarks
 anyhow = "1.0"
 env_logger = "0.10"
-libp2p = { version = "0.53.2", features = ["tokio", "tcp", "dns", "kad", "gossipsub", "noise", "yamux", "macros", "request-response"] }
+libp2p = { version = "0.56", features = ["tokio", "tcp", "dns", "kad", "gossipsub", "noise", "yamux", "macros", "request-response"] }
 rand = "0.8"
 icn-common = { path = "../icn-common" }
 icn-mesh = { path = "../icn-mesh" }

--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -31,7 +31,7 @@ axum-server = { version = "0.7", features = ["tls-rustls"] }
 tower = { version = "0.4", features = ["full"] }
 hex = "0.4"
 bs58 = "0.5"
-libp2p = { version = "0.53.2", optional = true }
+libp2p = { version = "0.56", optional = true }
 async-trait = "0.1"
 prometheus-client = "0.22"
 subtle = "2"

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -2196,7 +2196,7 @@ async fn federation_status_handler(State(state): State<AppState>) -> impl IntoRe
 }
 
 // GET /network/local-peer-id - return this node's peer ID
-async fn network_local_peer_id_handler(State(_state): State<AppState>) -> impl IntoResponse {
+async fn network_local_peer_id_handler(State(state): State<AppState>) -> impl IntoResponse {
     #[cfg(feature = "enable-libp2p")]
     {
         match state.runtime_context.get_libp2p_service() {
@@ -2218,7 +2218,7 @@ async fn network_local_peer_id_handler(State(_state): State<AppState>) -> impl I
 }
 
 // GET /network/peers - list peers discovered via the network service
-async fn network_peers_handler(State(_state): State<AppState>) -> impl IntoResponse {
+async fn network_peers_handler(State(state): State<AppState>) -> impl IntoResponse {
     #[cfg(feature = "enable-libp2p")]
     {
         match state.runtime_context.get_libp2p_service() {

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["full", "test-util"] }
 async-trait = "0.1.77"
 log = "0.4"
 thiserror = "1.0"
-libp2p = { version = "0.53.2", optional = true }
+libp2p = { version = "0.56", optional = true }
 downcast-rs = "1.2.0"
 futures = "0.3"
 wasmtime = { version = "15", features = ["async"] }


### PR DESCRIPTION
## Summary
- align the libp2p version across icn-node, icn-runtime and icn-network
- fix compilation of select_executor benchmark
- adjust handlers that use the runtime context

## Testing
- `cargo build --workspace --features with-libp2p`
- `cargo clippy --workspace --features with-libp2p -- -D warnings` *(fails: borrowed expression warnings in icn-runtime)*
- `cargo test --workspace --features with-libp2p --no-run` *(fails: icn-runtime tests do not compile)*

------
https://chatgpt.com/codex/tasks/task_e_686d72855dd88324af1a7908deb773a8