### PR TITLE
[network] add connect endpoint and service

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -594,6 +594,7 @@ pub async fn app_router_with_options(
             .route("/metrics", get(metrics_handler))
             .route("/network/local-peer-id", get(network_local_peer_id_handler))
             .route("/network/peers", get(network_peers_handler))
+            .route("/network/connect", post(network_connect_handler))
             .route("/dag/put", post(dag_put_handler)) // These will use RT context's DAG store
             .route("/dag/get", post(dag_get_handler)) // These will use RT context's DAG store
             .route("/transaction/submit", post(tx_submit_handler))
@@ -705,6 +706,7 @@ pub async fn app_router_from_context(
         .route("/metrics", get(metrics_handler))
         .route("/network/local-peer-id", get(network_local_peer_id_handler))
         .route("/network/peers", get(network_peers_handler))
+        .route("/network/connect", post(network_connect_handler))
         .route("/dag/put", post(dag_put_handler))
         .route("/dag/get", post(dag_get_handler))
         .route("/transaction/submit", post(tx_submit_handler))
@@ -2240,6 +2242,44 @@ async fn network_peers_handler(State(_state): State<AppState>) -> impl IntoRespo
     }
 }
 
+// POST /network/connect - connect to a peer via multiaddress
+async fn network_connect_handler(
+    State(state): State<AppState>,
+    Json(payload): Json<PeerPayload>,
+) -> impl IntoResponse {
+    #[cfg(feature = "enable-libp2p")]
+    {
+        match state.runtime_context.get_libp2p_service() {
+            Ok(service) => match payload.peer.parse::<Multiaddr>() {
+                Ok(addr) => match service.connect_peer(addr).await {
+                    Ok(()) => (
+                        StatusCode::OK,
+                        Json(serde_json::json!({ "connected": payload.peer })),
+                    )
+                        .into_response(),
+                    Err(e) => {
+                        map_rust_error_to_json_response(e, StatusCode::BAD_REQUEST).into_response()
+                    }
+                },
+                Err(e) => (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": format!("invalid multiaddr: {}", e) })),
+                )
+                    .into_response(),
+            },
+            Err(e) => map_rust_error_to_json_response(e, StatusCode::BAD_REQUEST).into_response(),
+        }
+    }
+    #[cfg(not(feature = "enable-libp2p"))]
+    {
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({ "connected": payload.peer })),
+        )
+            .into_response()
+    }
+}
+
 // --- Test module (can be expanded later) ---
 #[cfg(test)]
 mod tests {
@@ -2613,5 +2653,23 @@ mod tests {
             serde_json::from_slice(&receipt_bytes).unwrap();
         assert_eq!(receipt.job_id, job_id);
         assert_eq!(receipt.executor_did, exec_did);
+    }
+
+    #[tokio::test]
+    async fn network_connect_endpoint_basic() {
+        let app = test_app().await;
+        let payload = serde_json::json!({ "peer": "/ip4/127.0.0.1/tcp/1234" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/network/connect")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,6 +142,7 @@ curl -X POST https://localhost:8080/federation/leave \
 |--------|------|-------------|---------------|
 | POST | `/network/discover-peers` | Trigger peer discovery | Yes |
 | POST | `/network/send-message` | Send a message to a specific peer | Yes |
+| POST | `/network/connect` | Connect to a peer by multiaddress | Yes |
 | GET | `/network/peers` | List currently connected peers | Yes |
 
 ## Contract & WASM Endpoints


### PR DESCRIPTION
## Summary
- extend `NetworkService` with `connect_peer`
- implement libp2p and stub versions
- expose `/network/connect` endpoint in `icn-node`
- document API
- add basic unit test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: environment constraints)*
- `cargo test --all-features --workspace` *(failed: environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_686d72869b108324affe912c245c7c66