### PR TITLE
Add DAG metadata endpoints

### DIFF
--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -12,6 +12,7 @@ icn-governance = { path = "../icn-governance" }
 icn-network = { path = "../icn-network" }
 icn-mesh = { path = "../icn-mesh" }
 icn-ccl = { path = "../../icn-ccl" }
+icn-dag = { path = "../icn-dag" }
 anyhow = "1.0"
 
 clap = { version = "4.0", features = ["derive"] }

--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -16,6 +16,7 @@ use std::process::exit; // Added for reading from stdin
 // Types from our ICN crates that CLI will interact with (serialize/deserialize)
 // These types are expected to be sent to/received from the icn-node HTTP API.
 use icn_common::{Cid, DagBlock, NodeInfo, NodeStatus};
+use icn_dag::DagBlockMetadata;
 // Using aliased request structs from icn-api for clarity, these are what the node expects
 use icn_api::governance_trait::{
     CastVoteRequest as ApiCastVoteRequest, SubmitProposalRequest as ApiSubmitProposalRequest,
@@ -116,6 +117,11 @@ enum DagCommands {
     /// Retrieve a DAG block by its CID (provide CID as JSON string)
     Get {
         #[clap(help = "CID of the block to retrieve, as a JSON string")]
+        cid_json: String,
+    },
+    /// Retrieve metadata for a DAG block by CID
+    Meta {
+        #[clap(help = "CID of the block to inspect, as a JSON string")]
         cid_json: String,
     },
     /// Backup the DAG store to the specified directory
@@ -262,6 +268,7 @@ async fn run_command(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
                 block_json_or_stdin,
             } => handle_dag_put(cli, client, block_json_or_stdin).await?,
             DagCommands::Get { cid_json } => handle_dag_get(cli, client, cid_json).await?,
+            DagCommands::Meta { cid_json } => handle_dag_meta(cli, client, cid_json).await?,
             DagCommands::Backup { path } => handle_dag_backup(path)?,
             DagCommands::Restore { path } => handle_dag_restore(path)?,
             DagCommands::Verify { full } => handle_dag_verify(*full)?,
@@ -479,6 +486,17 @@ async fn handle_dag_get(cli: &Cli, client: &Client, cid_json: &str) -> Result<()
     println!("--- Retrieved DAG Block ---");
     println!("{}", serde_json::to_string_pretty(&response_block)?);
     println!("-------------------------");
+    Ok(())
+}
+
+async fn handle_dag_meta(cli: &Cli, client: &Client, cid_json: &str) -> Result<(), anyhow::Error> {
+    let cid: Cid = serde_json::from_str(cid_json)
+        .map_err(|e| anyhow::anyhow!("Invalid CID JSON provided: {}. Error: {}", cid_json, e))?;
+    let meta: icn_dag::DagBlockMetadata =
+        post_request(&cli.api_url, client, "/dag/meta", &cid).await?;
+    println!("--- DAG Block Metadata ---");
+    println!("{}", serde_json::to_string_pretty(&meta)?);
+    println!("--------------------------");
     Ok(())
 }
 

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -41,6 +41,29 @@ pub struct BlockMetadata {
     pub ttl: Option<u64>,
 }
 
+/// Basic metadata describing a [`DagBlock`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DagBlockMetadata {
+    /// Size of the block's data payload in bytes.
+    pub size: u64,
+    /// Creation timestamp of the block.
+    pub timestamp: u64,
+    /// DID of the block author.
+    pub author_did: Did,
+    /// Links contained in the block.
+    pub links: Vec<DagLink>,
+}
+
+/// Create [`DagBlockMetadata`] from a [`DagBlock`].
+pub fn metadata_from_block(block: &DagBlock) -> DagBlockMetadata {
+    DagBlockMetadata {
+        size: block.data.len() as u64,
+        timestamp: block.timestamp,
+        author_did: block.author_did.clone(),
+        links: block.links.clone(),
+    }
+}
+
 // --- Storage Service Trait ---
 
 /// Defines the interface for a DAG block storage backend.

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -21,7 +21,7 @@ use icn_api::governance_trait::{
     RevokeDelegationRequest as ApiRevokeDelegationRequest,
     SubmitProposalRequest as ApiSubmitProposalRequest,
 };
-use icn_api::{query_data, submit_transaction};
+use icn_api::{get_dag_metadata, query_data, submit_transaction};
 use icn_common::DagBlock as CoreDagBlock;
 use icn_common::{
     parse_cid_from_string, Cid, CommonError, Did, NodeInfo, NodeStatus, Transaction,
@@ -598,6 +598,7 @@ pub async fn app_router_with_options(
             .route("/network/peers", get(network_peers_handler))
             .route("/dag/put", post(dag_put_handler)) // These will use RT context's DAG store
             .route("/dag/get", post(dag_get_handler)) // These will use RT context's DAG store
+            .route("/dag/meta", post(dag_meta_handler))
             .route("/dag/pin", post(dag_pin_handler))
             .route("/dag/unpin", post(dag_unpin_handler))
             .route("/dag/prune", post(dag_prune_handler))
@@ -714,6 +715,7 @@ pub async fn app_router_from_context(
         .route("/network/peers", get(network_peers_handler))
         .route("/dag/put", post(dag_put_handler))
         .route("/dag/get", post(dag_get_handler))
+        .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1031,6 +1033,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         .route("/metrics", get(metrics_handler))
         .route("/dag/put", post(dag_put_handler))
         .route("/dag/get", post(dag_get_handler))
+        .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1481,6 +1484,44 @@ async fn dag_get_handler(
     }
 }
 
+// POST /dag/meta – Retrieve metadata for a DAG block. (Body: CID JSON)
+async fn dag_meta_handler(
+    State(state): State<AppState>,
+    Json(cid_request): Json<CidRequest>,
+) -> impl IntoResponse {
+    let cid = match parse_cid_from_string(&cid_request.cid) {
+        Ok(c) => c,
+        Err(e) => {
+            return map_rust_error_to_json_response(
+                format!("Invalid CID: {e}"),
+                StatusCode::BAD_REQUEST,
+            )
+            .into_response();
+        }
+    };
+    let cid_json = match serde_json::to_string(&cid) {
+        Ok(j) => j,
+        Err(e) => {
+            return map_rust_error_to_json_response(
+                format!("CID serialization error: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .into_response();
+        }
+    };
+
+    match get_dag_metadata(state.runtime_context.dag_store.clone(), cid_json).await {
+        Ok(Some(meta)) => (StatusCode::OK, Json(meta)).into_response(),
+        Ok(None) => map_rust_error_to_json_response("Block not found", StatusCode::NOT_FOUND)
+            .into_response(),
+        Err(e) => map_rust_error_to_json_response(
+            format!("DAG meta error: {e}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .into_response(),
+    }
+}
+
 // POST /dag/pin – Pin a block with optional TTL
 async fn dag_pin_handler(
     State(state): State<AppState>,
@@ -1869,16 +1910,17 @@ async fn gov_close_handler(
             .into_response()
         }
     };
-    let close: icn_api::governance_trait::CloseProposalResponse = match serde_json::from_str(&status_json) {
-        Ok(c) => c,
-        Err(e) => {
-            return map_rust_error_to_json_response(
-                format!("Serialization error: {}", e),
-                StatusCode::INTERNAL_SERVER_ERROR,
-            )
-            .into_response()
-        }
-    };
+    let close: icn_api::governance_trait::CloseProposalResponse =
+        match serde_json::from_str(&status_json) {
+            Ok(c) => c,
+            Err(e) => {
+                return map_rust_error_to_json_response(
+                    format!("Serialization error: {}", e),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                )
+                .into_response()
+            }
+        };
     if close.status == format!("{:?}", icn_governance::ProposalStatus::Accepted) {
         if let Err(e) =
             icn_runtime::host_execute_governance_proposal(&state.runtime_context, &req.proposal_id)

--- a/docs/API.md
+++ b/docs/API.md
@@ -35,6 +35,7 @@ curl -X GET https://localhost:8080/info \
 |--------|------|-------------|---------------|
 | POST | `/dag/put` | Store a content-addressed block | Yes |
 | POST | `/dag/get` | Retrieve a block by CID | Yes |
+| POST | `/dag/meta` | Retrieve metadata for a block | Yes |
 
 ### Example DAG Operations
 ```bash
@@ -46,6 +47,12 @@ curl -X POST https://localhost:8080/dag/put \
 
 # Retrieve a DAG block
 curl -X POST https://localhost:8080/dag/get \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{"cid": "your-cid-string"}'
+
+# Retrieve DAG block metadata
+curl -X POST https://localhost:8080/dag/meta \
   -H "Content-Type: application/json" \
   -H "x-api-key: your-api-key" \
   -d '{"cid": "your-cid-string"}'
@@ -262,6 +269,7 @@ export ICN_AUTH_TOKEN="your-bearer-token"
 icn-cli info
 icn-cli federation status
 icn-cli governance propose "Increase timeout to 300s"
+icn-cli dag meta '{"cid":"bafy..."}'
 ```
 
 ### HTTP Clients


### PR DESCRIPTION
## Summary
- add `DagBlockMetadata` struct and helper in `icn-dag`
- expose new `get_dag_metadata` function in `icn-api`
- serve `/dag/meta` endpoint from `icn-node`
- support `dag meta` subcommand in `icn-cli`
- document metadata endpoint and CLI usage

## Testing
- `cargo fmt --all`
- `cargo test -p icn-dag --lib --quiet` *(failed: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686d7a05cbc08324bc8d340478061158