### PR TITLE
Add GitHub Pages docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ More detailed information can be found in the `README.md` file within each crate
 
 ### **Development Resources**
 * Crate documentation: [icn-common](crates/icn-common/README.md), [icn-dag](crates/icn-dag/README.md), [icn-identity](crates/icn-identity/README.md), [icn-mesh](crates/icn-mesh/README.md), [icn-governance](crates/icn-governance/README.md), [icn-runtime](crates/icn-runtime/README.md), [icn-network](crates/icn-network/README.md)
+* [Rust API Documentation](https://intercooperative-network.github.io/icn-core/) – automatically built by [docs.yml](.github/workflows/docs.yml)
 * [API Documentation](docs/API.md) – HTTP endpoints and programmatic interfaces
 * [Deployment Guide](docs/deployment-guide.md) – production deployment instructions (see [circuit breaker & retry settings](docs/deployment-guide.md#circuit-breaker-and-retry))
 


### PR DESCRIPTION
## Summary
- link to auto-generated Rust API documentation under Development Resources

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: compilation times out)*
- `cargo test --workspace --all-features --no-run` *(fails: compilation times out)*

------
https://chatgpt.com/codex/tasks/task_e_686db75a7c7483248965dad6e09e6289