### PR TITLE
[tests] enable network and node integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,19 +75,3 @@ jobs:
         if: matrix.rust == 'nightly'
         run: cargo build --release --all-features --workspace
 
-  libp2p_tests:
-    name: Libp2p Feature Tests
-    needs: test_and_lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ". -> target"
-      - name: Run libp2p tests
-        run: cargo test -p icn-network --features libp2p

--- a/crates/icn-network/tests/kad.rs
+++ b/crates/icn-network/tests/kad.rs
@@ -14,7 +14,6 @@ mod kademlia_peer_discovery_tests {
     use tokio::time::sleep;
 
     #[tokio::test]
-    #[ignore]
     async fn test_kademlia_two_node_peer_discovery() {
         println!("Starting Kademlia two_node_peer_discovery test...");
 
@@ -86,7 +85,6 @@ mod kademlia_peer_discovery_tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_kademlia_record_exchange() {
         let config1 = NetworkConfig::default();
         let node1_service = Libp2pNetworkService::new(config1).await.expect("n1");

--- a/crates/icn-network/tests/libp2p.rs
+++ b/crates/icn-network/tests/libp2p.rs
@@ -7,7 +7,6 @@ mod libp2p_tests {
     use tokio::time::{sleep, timeout, Duration};
 
     #[tokio::test]
-    #[ignore]
     async fn test_gossipsub_and_request_response() {
         let node_a = Libp2pNetworkService::new(NetworkConfig::default())
             .await

--- a/crates/icn-network/tests/libp2p_bootstrap.rs
+++ b/crates/icn-network/tests/libp2p_bootstrap.rs
@@ -13,7 +13,6 @@ mod libp2p_bootstrap_tests {
     use std::time::Duration;
     use tokio::time::sleep;
     #[tokio::test]
-    #[ignore]
     async fn test_two_nodes_discover_each_other() {
         println!("Starting test_two_nodes_discover_each_other...");
 

--- a/crates/icn-network/tests/libp2p_mesh_integration.rs
+++ b/crates/icn-network/tests/libp2p_mesh_integration.rs
@@ -246,7 +246,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    #[ignore = "Single-threaded runtime test for debugging event loop issues"]
     async fn test_single_threaded_gossipsub() -> Result<(), anyhow::Error> {
         println!("🔧 [DEBUG] Single-threaded runtime gossipsub test starting...");
 
@@ -539,7 +538,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test]
-    #[ignore = "Minimal event loop test to isolate hang issue"]
     async fn test_single_node_event_loop_startup() -> Result<(), anyhow::Error> {
         init_test_logger();
 
@@ -574,7 +572,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test]
-    #[ignore = "Test without Kademlia to isolate bootstrap hang"]
     async fn test_without_kademlia_bootstrap() -> Result<(), anyhow::Error> {
         init_test_logger();
 
@@ -850,7 +847,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test]
-    #[ignore = "Individual phase test: job announcement and bidding"]
     async fn test_job_announcement_and_bidding() -> Result<()> {
         init_test_logger();
         info!("🔧 [PHASE-TEST] Testing job announcement and bidding phase");
@@ -947,7 +943,6 @@ mod libp2p_mesh_integration {
     }
 
     #[tokio::test]
-    #[ignore = "Individual phase test: job execution with SimpleExecutor"]
     async fn test_job_execution_with_simple_executor() -> Result<()> {
         init_test_logger();
         info!("🔧 [PHASE-TEST] Testing job execution with SimpleExecutor");

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -2506,7 +2506,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn info_endpoint_works() {
         let app = test_app().await;
         let response = app
@@ -2527,7 +2526,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn mesh_submit_job_endpoint_basic() {
         let app = test_app().await;
 
@@ -2566,7 +2564,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn complete_http_to_mesh_pipeline() {
         let app = test_app().await;
 
@@ -2705,7 +2702,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn test_simple_job_submission_and_listing() {
         let app = test_app().await;
 
@@ -2764,7 +2760,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn wasm_contract_execution_via_http() {
         use icn_ccl::compile_ccl_source_to_wasm;
         use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};


### PR DESCRIPTION
## Summary
- remove `#[ignore]` from network and node tests
- ensure CI runs these tests by default by removing the separate libp2p job

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation exceeded limits)*
- `cargo test --all-features --workspace` *(failed: compilation exceeded limits)*
- `cargo test -p icn-ccl` *(failed: command not found)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e09abd274832488f6cd1b1cf4edc2