### PR TITLE
Add 10-node devnet config and tests

### DIFF
--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -74,3 +74,9 @@ required-features = ["enable-libp2p"]
 name = "cross_node_governance"
 path = "tests/integration/cross_node_governance.rs"
 required-features = ["enable-libp2p"]
+
+[[test]]
+name = "ten_node_propagation"
+path = "tests/integration/ten_node_propagation.rs"
+required-features = ["enable-libp2p"]
+

--- a/crates/icn-runtime/tests/integration/ten_node_propagation.rs
+++ b/crates/icn-runtime/tests/integration/ten_node_propagation.rs
@@ -1,0 +1,158 @@
+#[cfg(feature = "enable-libp2p")]
+mod ten_node_propagation {
+    use anyhow::Result;
+    use icn_common::{Cid, Did};
+    use icn_governance::ProposalId;
+    use icn_identity::SignatureBytes;
+    use icn_mesh::{ActualMeshJob, JobKind, JobSpec, Resources};
+    use icn_network::NetworkService;
+    use icn_runtime::context::RuntimeContext;
+    use icn_runtime::{host_create_governance_proposal, DefaultMeshNetworkService};
+    use libp2p::{Multiaddr, PeerId as Libp2pPeerId};
+    use std::str::FromStr;
+    use std::sync::Arc;
+    use tokio::time::{sleep, timeout, Duration};
+
+    async fn create_ctx(
+        suffix: &str,
+        bootstrap: Option<Vec<(Libp2pPeerId, Multiaddr)>>,
+    ) -> Result<Arc<RuntimeContext>> {
+        let did = format!("did:key:z6MkTenNode{}", suffix);
+        let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
+        let path = format!("./dag_store_{}", suffix);
+        let ctx = RuntimeContext::new_with_real_libp2p(
+            &did,
+            listen,
+            bootstrap,
+            path.clone().into(),
+            format!("./mana_{}.sled", suffix).into(),
+            format!("./rep_{}.sled", suffix).into(),
+        )
+        .await?;
+        let did_parsed = Did::from_str(&did)?;
+        ctx.mana_ledger
+            .set_balance(&did_parsed, 1000)
+            .expect("init mana");
+        Ok(ctx)
+    }
+
+    #[tokio::test]
+    async fn job_announcement_reaches_all_nodes() -> Result<()> {
+        let node_a = create_ctx("A", None).await?;
+        let a_net = node_a.get_libp2p_service()?;
+        let a_peer = *a_net.local_peer_id();
+        let mut addrs = Vec::new();
+        for _ in 0..10 {
+            sleep(Duration::from_millis(500)).await;
+            addrs = a_net.listening_addresses();
+            if !addrs.is_empty() {
+                break;
+            }
+        }
+        assert!(!addrs.is_empty());
+        let bootstrap = vec![(a_peer, addrs[0].clone())];
+
+        let mut receivers = Vec::new();
+        let mut others = Vec::new();
+        for s in ["B", "C", "D", "E", "F", "G", "H", "I", "J"] {
+            let ctx = create_ctx(s, Some(bootstrap.clone())).await?;
+            let net = ctx.get_libp2p_service()?;
+            let rx = net.subscribe().await?;
+            others.push(ctx);
+            receivers.push(rx);
+        }
+        sleep(Duration::from_secs(2)).await;
+
+        let submitter_did = Did::from_str("did:key:z6MkTenNodeA")?;
+        let job = ActualMeshJob {
+            id: Cid::new_v1_sha256(0x55, b"ten_node_job"),
+            manifest_cid: Cid::new_v1_sha256(0x55, b"manifest"),
+            spec: JobSpec {
+                kind: JobKind::Echo {
+                    payload: "hello".into(),
+                },
+                ..Default::default()
+            },
+            creator_did: submitter_did.clone(),
+            cost_mana: 10,
+            max_execution_wait_ms: None,
+            signature: SignatureBytes(vec![0u8; 64]),
+        };
+        let network = DefaultMeshNetworkService::new(a_net.clone());
+        network.announce_job(&job).await?;
+
+        for mut rx in receivers {
+            let received = timeout(Duration::from_secs(10), async {
+                loop {
+                    if let Some(msg) = rx.recv().await {
+                        if let icn_protocol::MessagePayload::MeshJobAnnouncement(ann) = &msg.payload
+                        {
+                            if ann.id == job.id {
+                                break;
+                            }
+                        }
+                    }
+                }
+            })
+            .await;
+            assert!(received.is_ok(), "job announcement missing");
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn governance_propagates_to_all_nodes() -> Result<()> {
+        let node_a = create_ctx("A1", None).await?;
+        let a_net = node_a.get_libp2p_service()?;
+        let a_peer = *a_net.local_peer_id();
+        let mut addrs = Vec::new();
+        for _ in 0..10 {
+            sleep(Duration::from_millis(500)).await;
+            addrs = a_net.listening_addresses();
+            if !addrs.is_empty() {
+                break;
+            }
+        }
+        assert!(!addrs.is_empty());
+        let bootstrap = vec![(a_peer, addrs[0].clone())];
+
+        let mut receivers = Vec::new();
+        let mut others = Vec::new();
+        for s in ["B1", "C1", "D1", "E1", "F1", "G1", "H1", "I1", "J1"] {
+            let ctx = create_ctx(s, Some(bootstrap.clone())).await?;
+            let net = ctx.get_libp2p_service()?;
+            let rx = net.subscribe().await?;
+            others.push(ctx);
+            receivers.push(rx);
+        }
+        sleep(Duration::from_secs(2)).await;
+
+        let payload = serde_json::json!({
+            "proposal_type_str": "GenericText",
+            "type_specific_payload": b"hi".to_vec(),
+            "description": "ten node",
+            "duration_secs": 60
+        });
+        let pid = host_create_governance_proposal(&node_a, &payload.to_string()).await?;
+        let pid = ProposalId(pid);
+
+        for (ctx, mut rx) in others.into_iter().zip(receivers.into_iter()) {
+            let bytes = timeout(Duration::from_secs(10), async {
+                loop {
+                    if let Some(msg) = rx.recv().await {
+                        if let icn_protocol::MessagePayload::GovernanceProposalAnnouncement(b) =
+                            &msg.payload
+                        {
+                            break b.clone();
+                        }
+                    }
+                }
+            })
+            .await?;
+            ctx.ingest_external_proposal(&bytes).await?;
+            let gov = ctx.governance_module.lock().await;
+            assert!(gov.get_proposal(&pid)?.is_some());
+        }
+        Ok(())
+    }
+}

--- a/icn-devnet/docker-compose.yml
+++ b/icn-devnet/docker-compose.yml
@@ -101,6 +101,244 @@ services:
       retries: 3
       start_period: 40s
 
+  # Node D - Worker node
+  icn-node-d:
+    build:
+      context: ..
+      dockerfile: icn-devnet/Dockerfile
+    container_name: icn-node-d
+    hostname: icn-node-d
+    environment:
+      - ICN_NODE_NAME=Federation-Node-D
+      - ICN_HTTP_LISTEN_ADDR=0.0.0.0:7845
+      - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
+      - ICN_ENABLE_P2P=true
+      - ICN_ENABLE_MDNS=true
+      - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001
+      - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-d-key
+      - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
+    ports:
+      - "5004:7845"  # HTTP API
+      - "4004:4001"  # P2P networking
+    networks:
+      - icn-federation
+    volumes:
+      - node-d-data:/app/data
+      - ./certs:/app/certs:ro
+    depends_on:
+      - icn-node-a
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-API-Key: devnet-d-key", "http://localhost:7845/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Node E - Worker node
+  icn-node-e:
+    build:
+      context: ..
+      dockerfile: icn-devnet/Dockerfile
+    container_name: icn-node-e
+    hostname: icn-node-e
+    environment:
+      - ICN_NODE_NAME=Federation-Node-E
+      - ICN_HTTP_LISTEN_ADDR=0.0.0.0:7845
+      - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
+      - ICN_ENABLE_P2P=true
+      - ICN_ENABLE_MDNS=true
+      - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001
+      - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-e-key
+      - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
+    ports:
+      - "5005:7845"  # HTTP API
+      - "4005:4001"  # P2P networking
+    networks:
+      - icn-federation
+    volumes:
+      - node-e-data:/app/data
+      - ./certs:/app/certs:ro
+    depends_on:
+      - icn-node-a
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-API-Key: devnet-e-key", "http://localhost:7845/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Node F - Worker node
+  icn-node-f:
+    build:
+      context: ..
+      dockerfile: icn-devnet/Dockerfile
+    container_name: icn-node-f
+    hostname: icn-node-f
+    environment:
+      - ICN_NODE_NAME=Federation-Node-F
+      - ICN_HTTP_LISTEN_ADDR=0.0.0.0:7845
+      - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
+      - ICN_ENABLE_P2P=true
+      - ICN_ENABLE_MDNS=true
+      - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001
+      - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-f-key
+      - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
+    ports:
+      - "5006:7845"  # HTTP API
+      - "4006:4001"  # P2P networking
+    networks:
+      - icn-federation
+    volumes:
+      - node-f-data:/app/data
+      - ./certs:/app/certs:ro
+    depends_on:
+      - icn-node-a
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-API-Key: devnet-f-key", "http://localhost:7845/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Node G - Worker node
+  icn-node-g:
+    build:
+      context: ..
+      dockerfile: icn-devnet/Dockerfile
+    container_name: icn-node-g
+    hostname: icn-node-g
+    environment:
+      - ICN_NODE_NAME=Federation-Node-G
+      - ICN_HTTP_LISTEN_ADDR=0.0.0.0:7845
+      - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
+      - ICN_ENABLE_P2P=true
+      - ICN_ENABLE_MDNS=true
+      - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001
+      - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-g-key
+      - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
+    ports:
+      - "5007:7845"  # HTTP API
+      - "4007:4001"  # P2P networking
+    networks:
+      - icn-federation
+    volumes:
+      - node-g-data:/app/data
+      - ./certs:/app/certs:ro
+    depends_on:
+      - icn-node-a
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-API-Key: devnet-g-key", "http://localhost:7845/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Node H - Worker node
+  icn-node-h:
+    build:
+      context: ..
+      dockerfile: icn-devnet/Dockerfile
+    container_name: icn-node-h
+    hostname: icn-node-h
+    environment:
+      - ICN_NODE_NAME=Federation-Node-H
+      - ICN_HTTP_LISTEN_ADDR=0.0.0.0:7845
+      - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
+      - ICN_ENABLE_P2P=true
+      - ICN_ENABLE_MDNS=true
+      - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001
+      - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-h-key
+      - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
+    ports:
+      - "5008:7845"  # HTTP API
+      - "4008:4001"  # P2P networking
+    networks:
+      - icn-federation
+    volumes:
+      - node-h-data:/app/data
+      - ./certs:/app/certs:ro
+    depends_on:
+      - icn-node-a
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-API-Key: devnet-h-key", "http://localhost:7845/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Node I - Worker node
+  icn-node-i:
+    build:
+      context: ..
+      dockerfile: icn-devnet/Dockerfile
+    container_name: icn-node-i
+    hostname: icn-node-i
+    environment:
+      - ICN_NODE_NAME=Federation-Node-I
+      - ICN_HTTP_LISTEN_ADDR=0.0.0.0:7845
+      - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
+      - ICN_ENABLE_P2P=true
+      - ICN_ENABLE_MDNS=true
+      - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001
+      - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-i-key
+      - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
+    ports:
+      - "5009:7845"  # HTTP API
+      - "4009:4001"  # P2P networking
+    networks:
+      - icn-federation
+    volumes:
+      - node-i-data:/app/data
+      - ./certs:/app/certs:ro
+    depends_on:
+      - icn-node-a
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-API-Key: devnet-i-key", "http://localhost:7845/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Node J - Worker node
+  icn-node-j:
+    build:
+      context: ..
+      dockerfile: icn-devnet/Dockerfile
+    container_name: icn-node-j
+    hostname: icn-node-j
+    environment:
+      - ICN_NODE_NAME=Federation-Node-J
+      - ICN_HTTP_LISTEN_ADDR=0.0.0.0:7845
+      - ICN_P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/4001
+      - ICN_ENABLE_P2P=true
+      - ICN_ENABLE_MDNS=true
+      - ICN_BOOTSTRAP_PEERS=/ip4/172.20.0.2/tcp/4001
+      - ICN_STORAGE_BACKEND=memory
+      - ICN_HTTP_API_KEY=devnet-j-key
+      - RUST_LOG=info,icn_node=debug,icn_runtime=debug,icn_network=debug
+    ports:
+      - "5010:7845"  # HTTP API
+      - "4010:4001"  # P2P networking
+    networks:
+      - icn-federation
+    volumes:
+      - node-j-data:/app/data
+      - ./certs:/app/certs:ro
+    depends_on:
+      - icn-node-a
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-API-Key: devnet-j-key", "http://localhost:7845/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
   # Optional: Prometheus for metrics monitoring
   prometheus:
     image: prom/prometheus:latest
@@ -149,6 +387,21 @@ services:
     profiles:
       - monitoring
 
+  # Shared Postgres database for persistence testing
+  postgres:
+    image: postgres:15
+    container_name: icn-postgres
+    environment:
+      - POSTGRES_USER=icn
+      - POSTGRES_PASSWORD=icn_devnet
+      - POSTGRES_DB=icn_devnet
+    ports:
+      - "5432:5432"
+    networks:
+      - icn-federation
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
 networks:
   icn-federation:
     driver: bridge
@@ -159,5 +412,12 @@ networks:
 volumes:
   node-a-data:
   node-b-data:
-  node-c-data:
-  grafana-data: 
+  node-c-data:  node-d-data:
+  node-e-data:
+  node-f-data:
+  node-g-data:
+  node-h-data:
+  node-i-data:
+  node-j-data:
+  postgres-data:
+  grafana-data:

--- a/scripts/run_10node_devnet.sh
+++ b/scripts/run_10node_devnet.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Spin up 10 node federation and run basic load tests
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$ROOT_DIR/icn-devnet/docker-compose.yml"
+JOB_FILE="$ROOT_DIR/icn-devnet/job_test.json"
+CLI_BIN="$ROOT_DIR/target/debug/icn-cli"
+
+NUM_JOBS=${NUM_JOBS:-20}
+
+cd "$ROOT_DIR/icn-devnet"
+
+docker-compose up -d icn-node-a icn-node-b icn-node-c icn-node-d icn-node-e icn-node-f icn-node-g icn-node-h icn-node-i icn-node-j postgres prometheus grafana
+
+# Simple wait for services
+sleep 20
+
+for i in $(seq 1 "$NUM_JOBS"); do
+    "$CLI_BIN" --api-url http://localhost:5001 submit-job "$(cat "$JOB_FILE")" >/dev/null || true
+done
+
+echo "Submitted $NUM_JOBS jobs to Node A"
+
+docker-compose down


### PR DESCRIPTION
## Summary
- expand docker-compose to run 10 ICN nodes plus Postgres
- provide script to spin up the 10-node federation and submit jobs
- add integration tests checking job and governance propagation across a 10-node network

## Testing
- `cargo test -p icn-runtime --features enable-libp2p` *(fails: trait `Future` not implemented for `Result<MutexGuard<'_, dyn StorageService<DagBlock> + Send>, ...>`)*

------
https://chatgpt.com/codex/tasks/task_e_686e109197808324a8068a7f94fa7481