### PR TITLE
[devnet] fix volume lines in compose

### DIFF
--- a/icn-devnet/docker-compose.yml
+++ b/icn-devnet/docker-compose.yml
@@ -412,7 +412,8 @@ networks:
 volumes:
   node-a-data:
   node-b-data:
-  node-c-data:  node-d-data:
+  node-c-data:
+  node-d-data:
   node-e-data:
   node-f-data:
   node-g-data:


### PR DESCRIPTION
## Summary
- separate devnet docker volumes onto their own lines

## Testing
- `docker compose config`
- `cargo fmt --all -- --check`
- `timeout 20s cargo clippy --all-targets --all-features -- -D warnings`
- `timeout 20s cargo test --all-features --workspace`
- `timeout 20s cargo test -p icn-ccl`
- `timeout 20s just test-ccl-contracts` *(fails: `just` not found)*
- `timeout 20s just test-covm-execution` *(fails: `just` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2178a7b88324b91d6bd23e4283d3