### PR TITLE
Add 10-node scale integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,18 +58,19 @@ jobs:
       - name: Run benchmarks
         run: cargo bench --workspace --all-features
 
-      - name: Start devnet (nightly only)
+      - name: Start 10-node devnet (nightly only)
         if: matrix.rust == 'nightly'
         run: |
-          ./icn-devnet/launch_federation.sh --start-only
+          ./scripts/run_10node_devnet.sh --start-only
       - name: Run integration tests (nightly only)
         if: matrix.rust == 'nightly'
         env:
           ICN_DEVNET_RUNNING: "true"
         run: cargo test --all-features -p icn-integration-tests -- --nocapture
-      - name: Stop devnet (nightly only)
+      - name: Stop 10-node devnet (nightly only)
         if: matrix.rust == 'nightly'
-        run: docker-compose -f icn-devnet/docker-compose.yml down --volumes --remove-orphans
+        run: |
+          ./scripts/run_10node_devnet.sh --stop-only
 
       - name: Build release (nightly only, for early detection of issues)
         if: matrix.rust == 'nightly'

--- a/scripts/run_10node_devnet.sh
+++ b/scripts/run_10node_devnet.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 set -e
 
-# Spin up 10 node federation and run basic load tests
+# Spin up a 10 node federation and optionally run basic load tests.
+#
+# Usage:
+#   run_10node_devnet.sh [--start-only|--jobs-only|--stop-only]
+#
+#   --start-only : Start the federation containers and exit.
+#   --jobs-only  : Run the job submission loop against an already
+#                  running federation.
+#   --stop-only  : Stop the federation containers and exit.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -11,17 +19,34 @@ CLI_BIN="$ROOT_DIR/target/debug/icn-cli"
 
 NUM_JOBS=${NUM_JOBS:-20}
 
+MODE="full"
+case "$1" in
+    --start-only)
+        MODE="start"
+        ;;
+    --jobs-only)
+        MODE="jobs"
+        ;;
+    --stop-only)
+        MODE="stop"
+        ;;
+esac
+
 cd "$ROOT_DIR/icn-devnet"
 
-docker-compose up -d icn-node-a icn-node-b icn-node-c icn-node-d icn-node-e icn-node-f icn-node-g icn-node-h icn-node-i icn-node-j postgres prometheus grafana
+if [[ "$MODE" == "start" || "$MODE" == "full" ]]; then
+    docker-compose up -d icn-node-a icn-node-b icn-node-c icn-node-d icn-node-e icn-node-f icn-node-g icn-node-h icn-node-i icn-node-j postgres prometheus grafana
+    # Simple wait for services
+    sleep 20
+fi
 
-# Simple wait for services
-sleep 20
+if [[ "$MODE" == "jobs" || "$MODE" == "full" ]]; then
+    for i in $(seq 1 "$NUM_JOBS"); do
+        "$CLI_BIN" --api-url http://localhost:5001 submit-job "$(cat "$JOB_FILE")" >/dev/null || true
+    done
+    echo "Submitted $NUM_JOBS jobs to Node A"
+fi
 
-for i in $(seq 1 "$NUM_JOBS"); do
-    "$CLI_BIN" --api-url http://localhost:5001 submit-job "$(cat "$JOB_FILE")" >/dev/null || true
-done
-
-echo "Submitted $NUM_JOBS jobs to Node A"
-
-docker-compose down
+if [[ "$MODE" == "stop" || "$MODE" == "full" ]]; then
+    docker-compose down --volumes --remove-orphans
+fi

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -43,6 +43,10 @@ path = "integration/parameter_change.rs"
 name = "ccl_operator_precedence"
 path = "../icn-ccl/tests/operator_precedence.rs"
 
+[[test]]
+name = "ten_node_scale"
+path = "integration/ten_node_scale.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true

--- a/tests/integration/ten_node_scale.rs
+++ b/tests/integration/ten_node_scale.rs
@@ -1,0 +1,174 @@
+use once_cell::sync::OnceCell;
+use serde_json::Value;
+use std::{process::Command, time::Duration};
+use tokio::{sync::Mutex, time::sleep};
+
+const NODE_PORTS: [u16; 10] = [5001, 5002, 5003, 5004, 5005, 5006, 5007, 5008, 5009, 5010];
+const MAX_RETRIES: u32 = 30;
+const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+static DEVNET_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
+
+pub struct TenDevnetGuard {
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+impl Drop for TenDevnetGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("bash")
+            .arg("./scripts/run_10node_devnet.sh")
+            .arg("--stop-only")
+            .status();
+    }
+}
+
+pub async fn ensure_10node_devnet() -> Option<TenDevnetGuard> {
+    if std::env::var("ICN_DEVNET_RUNNING").is_ok() {
+        wait_for_10node_ready().await.ok();
+        return None;
+    }
+    let lock = DEVNET_LOCK.get_or_init(|| Mutex::new(()));
+    let guard = lock.lock_owned().await;
+
+    Command::new("bash")
+        .arg("./scripts/run_10node_devnet.sh")
+        .arg("--start-only")
+        .status()
+        .expect("Failed to start 10 node devnet");
+
+    wait_for_10node_ready()
+        .await
+        .expect("10 node devnet not ready");
+    Some(TenDevnetGuard { _guard: guard })
+}
+
+pub async fn wait_for_10node_ready() -> Result<(), Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    for _ in 0..MAX_RETRIES {
+        let mut all = true;
+        for port in NODE_PORTS.iter() {
+            let url = format!("http://localhost:{}/info", port);
+            match client.get(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {}
+                _ => {
+                    all = false;
+                    break;
+                }
+            }
+        }
+        if all {
+            return Ok(());
+        }
+        sleep(RETRY_DELAY).await;
+    }
+    Err("devnet not ready".into())
+}
+
+fn parse_metric(text: &str, name: &str) -> f64 {
+    for line in text.lines() {
+        if line.starts_with(name) {
+            if let Some(v) = line.split_whitespace().nth(1) {
+                if let Ok(val) = v.parse() {
+                    return val;
+                }
+            }
+        }
+    }
+    0.0
+}
+
+#[tokio::test]
+async fn scale_test_10node_load() {
+    let _devnet = ensure_10node_devnet().await;
+
+    // Run load scenario via script
+    Command::new("bash")
+        .arg("./scripts/run_10node_devnet.sh")
+        .arg("--jobs-only")
+        .status()
+        .expect("failed to run load script");
+
+    sleep(Duration::from_secs(10)).await;
+
+    let client = reqwest::Client::new();
+    let mut nodes_with_jobs = 0;
+    for port in NODE_PORTS.iter() {
+        let metrics = client
+            .get(&format!("http://localhost:{}/metrics", port))
+            .send()
+            .await
+            .expect("metrics")
+            .text()
+            .await
+            .expect("metrics text");
+        let peers = parse_metric(&metrics, "network_peer_count");
+        assert!(peers >= 0.0, "node {} missing peer count", port);
+        let completed = parse_metric(&metrics, "jobs_completed_total");
+        if completed > 0.0 {
+            nodes_with_jobs += 1;
+        }
+    }
+    assert!(
+        nodes_with_jobs >= 2,
+        "jobs were not distributed across nodes"
+    );
+
+    // Submit proposal to node A
+    let proposal = serde_json::json!({
+        "proposer_did": "did:example:alice",
+        "proposal": { "GenericText": { "text": "scale test" } },
+        "description": "scale test",
+        "duration_secs": 60,
+        "quorum": null,
+        "threshold": null,
+        "body": null
+    });
+    let resp = client
+        .post("http://localhost:5001/governance/submit")
+        .json(&proposal)
+        .send()
+        .await
+        .expect("submit proposal");
+    assert!(resp.status().is_success());
+    let proposal_id: String = resp.json().await.expect("proposal id");
+
+    // Wait for propagation
+    for _ in 0..MAX_RETRIES {
+        let mut all_seen = true;
+        for port in NODE_PORTS.iter() {
+            let list: Vec<Value> = client
+                .get(&format!("http://localhost:{}/governance/proposals", port))
+                .send()
+                .await
+                .expect("list proposals")
+                .json()
+                .await
+                .expect("list json");
+            if !list.iter().any(|p| p["id"] == proposal_id) {
+                all_seen = false;
+                break;
+            }
+        }
+        if all_seen {
+            break;
+        }
+        sleep(RETRY_DELAY).await;
+    }
+
+    // Final assertion on propagation
+    for port in NODE_PORTS.iter() {
+        let list: Vec<Value> = client
+            .get(&format!("http://localhost:{}/governance/proposals", port))
+            .send()
+            .await
+            .expect("list proposals")
+            .json()
+            .await
+            .expect("list json");
+        assert!(
+            list.iter().any(|p| p["id"] == proposal_id),
+            "proposal missing on node {}",
+            port
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add script options for 10-node devnet
- create `ten_node_scale` integration test
- register the new test crate
- run 10-node scale test in nightly CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml scripts/run_10node_devnet.sh tests/Cargo.toml tests/integration/ten_node_scale.rs` *(fails: git checkout stable)*
- `cargo test --all-features --workspace --exclude icn-integration-tests` *(failed: could not compile `icn-dag`)*

------
https://chatgpt.com/codex/tasks/task_e_686e85d510f48324b20578cfbf30e4af