### PR TITLE
Update devnet docs with 10‑node load test

### DIFF
--- a/icn-devnet/README.md
+++ b/icn-devnet/README.md
@@ -36,6 +36,22 @@ Once running, you can access:
    if TLS is desired, provide `ICN_TLS_CERT_PATH` and `ICN_TLS_KEY_PATH`.
 5. **Launch the federation** with `./launch_federation.sh`.
 
+### 10-Node Load Test
+
+The repository includes a helper script for spinning up a **10 node** devnet
+and submitting a configurable number of test jobs:
+
+```bash
+# From the repository root
+NUM_JOBS=50 ./scripts/run_10node_devnet.sh
+```
+
+`NUM_JOBS` controls how many jobs are submitted to the first node (default
+`20`). The script automatically starts Prometheus and Grafana, so you can run
+`docker-compose --profile monitoring up -d` to visualize metrics. See the
+[deployment guide’s monitoring section](../docs/deployment-guide.md#monitoring-with-prometheus--grafana)
+for more details.
+
 ### Test Job Submission
 
 > **⚠️ Important**: Use `X-API-Key` header (not `Authorization: Bearer`)


### PR DESCRIPTION
## Summary
- describe `run_10node_devnet.sh` in devnet README
- mention using `docker-compose --profile monitoring`
- link to Deployment Guide monitoring section

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused import, uninlined format args)*
- `cargo test --workspace` *(fails: could not compile `icn-runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_686e85d13be08324a425f215546319b3