### PR TITLE
Add WASM limiter denial metrics

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1340,7 +1340,8 @@ async fn metrics_handler() -> impl IntoResponse {
     use icn_runtime::metrics::{
         HOST_ACCOUNT_GET_MANA_CALLS, HOST_ACCOUNT_SPEND_MANA_CALLS,
         HOST_GET_PENDING_MESH_JOBS_CALLS, HOST_SUBMIT_MESH_JOB_CALLS, JOBS_ACTIVE_GAUGE,
-        JOBS_COMPLETED, JOBS_FAILED, JOBS_SUBMITTED, RECEIPTS_ANCHORED,
+        JOBS_COMPLETED, JOBS_FAILED, JOBS_SUBMITTED, RECEIPTS_ANCHORED, WASM_MEMORY_GROWTH_DENIED,
+        WASM_TABLE_GROWTH_DENIED,
     };
     use prometheus_client::metrics::{counter::Counter, gauge::Gauge, histogram::Histogram};
 
@@ -1453,6 +1454,16 @@ async fn metrics_handler() -> impl IntoResponse {
         "receipts_anchored_total",
         "Execution receipts anchored",
         RECEIPTS_ANCHORED.clone(),
+    );
+    registry.register(
+        "wasm_memory_growth_denied_total",
+        "WASM memory growth denials",
+        WASM_MEMORY_GROWTH_DENIED.clone(),
+    );
+    registry.register(
+        "wasm_table_growth_denied_total",
+        "WASM table growth denials",
+        WASM_TABLE_GROWTH_DENIED.clone(),
     );
 
     // Network metrics

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -1,6 +1,7 @@
 //! This module provides executor-side functionality for running mesh jobs.
 
 use crate::context::RuntimeContext;
+use crate::metrics::{WASM_MEMORY_GROWTH_DENIED, WASM_TABLE_GROWTH_DENIED};
 use crate::{host_account_get_mana, host_get_reputation};
 use icn_ccl::ContractMetadata;
 use icn_common::{Cid, CommonError, Did};
@@ -99,6 +100,7 @@ impl ResourceLimiter for ICNResourceLimiter {
                 "WASM memory limit exceeded: {} bytes > {} bytes",
                 desired, self.max_memory_bytes
             );
+            WASM_MEMORY_GROWTH_DENIED.inc();
             return Ok(false); // Deny the growth
         }
         Ok(true)
@@ -113,6 +115,7 @@ impl ResourceLimiter for ICNResourceLimiter {
         // Limit table growth (simple check)
         if desired > 1000 {
             warn!("WASM table size limit exceeded: {} > {}", desired, 1000);
+            WASM_TABLE_GROWTH_DENIED.inc();
             return Ok(false); // Deny the growth
         }
         Ok(true)

--- a/crates/icn-runtime/src/metrics.rs
+++ b/crates/icn-runtime/src/metrics.rs
@@ -27,3 +27,9 @@ pub static JOBS_ACTIVE_GAUGE: Lazy<Gauge<i64>> = Lazy::new(Gauge::default);
 
 /// Counts receipts anchored to the DAG.
 pub static RECEIPTS_ANCHORED: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Counts denied memory growth attempts inside the WASM resource limiter.
+pub static WASM_MEMORY_GROWTH_DENIED: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Counts denied table growth attempts inside the WASM resource limiter.
+pub static WASM_TABLE_GROWTH_DENIED: Lazy<Counter> = Lazy::new(Counter::default);

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -171,4 +171,11 @@ Prometheus will be reachable at <http://localhost:9090> and Grafana at
 <http://localhost:3000> (`admin` / `icnfederation`). Import the dashboards from
 `icn-devnet/grafana/` to visualize node metrics.
 
+Runtime metrics now include counters for WASM resource limiter denials:
+
+```text
+wasm_memory_growth_denied_total - memory growth denied by the limiter
+wasm_table_growth_denied_total  - table growth denied by the limiter
+```
+
 

--- a/icn-devnet/grafana/icn-devnet-dashboard.json
+++ b/icn-devnet/grafana/icn-devnet-dashboard.json
@@ -78,6 +78,20 @@
       "datasource": "Prometheus",
       "gridPos": {"h":8, "w":12, "x":12, "y":22},
       "targets": [{"expr": "economics_spend_mana_calls", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "wasm_memory_growth_denied_total",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":0, "y":30},
+      "targets": [{"expr": "wasm_memory_growth_denied_total", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "wasm_table_growth_denied_total",
+      "datasource": "Prometheus",
+      "gridPos": {"h":8, "w":12, "x":12, "y":30},
+      "targets": [{"expr": "wasm_table_growth_denied_total", "refId": "A"}]
     }
   ]
 }

--- a/icn-devnet/grafana/icn-devnet-overview.json
+++ b/icn-devnet/grafana/icn-devnet-overview.json
@@ -43,6 +43,22 @@
       "datasource": "Prometheus",
       "targets": [{ "expr": "economics_credit_mana_calls" }],
       "gridPos": { "h": 4, "w": 6, "x": 12, "y": 4 }
+    },
+    {
+      "type": "stat",
+      "title": "WASM Memory Denials",
+      "id": 6,
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "wasm_memory_growth_denied_total" }],
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 8 }
+    },
+    {
+      "type": "stat",
+      "title": "WASM Table Denials",
+      "id": 7,
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "wasm_table_growth_denied_total" }],
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 8 }
     }
   ]
 }

--- a/icn-devnet/grafana/icn-jobs-network.json
+++ b/icn-devnet/grafana/icn-jobs-network.json
@@ -12,5 +12,7 @@
     {"type": "gauge", "title": "Kademlia Peers", "id": 6, "datasource": "Prometheus", "targets": [{"expr": "network_kademlia_peers"}], "gridPos": {"h":4,"w":6,"x":6,"y":4}},
     {"type": "timeseries", "title": "Bytes Sent", "id": 7, "datasource": "Prometheus", "targets": [{"expr": "network_bytes_sent_total"}], "gridPos": {"h":8,"w":12,"x":12,"y":4}},
     {"type": "timeseries", "title": "Bytes Received", "id": 8, "datasource": "Prometheus", "targets": [{"expr": "network_bytes_received_total"}], "gridPos": {"h":8,"w":12,"x":0,"y":8}}
+    ,{"type": "stat", "title": "WASM Memory Denials", "id": 9, "datasource": "Prometheus", "targets": [{"expr": "wasm_memory_growth_denied_total"}], "gridPos": {"h":4,"w":6,"x":12,"y":12}}
+    ,{"type": "stat", "title": "WASM Table Denials", "id": 10, "datasource": "Prometheus", "targets": [{"expr": "wasm_table_growth_denied_total"}], "gridPos": {"h":4,"w":6,"x":18,"y":12}}
   ]
 }


### PR DESCRIPTION
## Summary
- track WASM memory/table growth denials
- expose new counters in metrics registry
- update Grafana dashboards and deployment docs

## Testing
- `cargo test --all-features --workspace` *(fails: could not compile `icn-dag`)*
- `cargo test -p icn-runtime` *(fails: could not compile `icn-runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_686eaa8e6ea08324881514556dda85bf