### PR TITLE
Align DAG storage with async trait

### DIFF
--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -163,6 +163,78 @@ where
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
+/// Wrapper to adapt synchronous [`StorageService`] implementations to the async interface.
+#[cfg(feature = "async")]
+pub struct CompatAsyncStore<S> {
+    inner: S,
+}
+
+#[cfg(feature = "async")]
+impl<S> CompatAsyncStore<S> {
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+#[cfg(feature = "async")]
+#[async_trait::async_trait]
+impl<B, S> AsyncStorageService<B> for CompatAsyncStore<S>
+where
+    B: Clone + serde::Serialize + for<'de> serde::Deserialize<'de> + Send + Sync,
+    S: StorageService<B> + Send + Sync,
+{
+    async fn put(&mut self, block: &B) -> Result<(), CommonError> {
+        self.inner.put(block)
+    }
+
+    async fn get(&self, cid: &Cid) -> Result<Option<B>, CommonError> {
+        self.inner.get(cid)
+    }
+
+    async fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        self.inner.delete(cid)
+    }
+
+    async fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
+        self.inner.contains(cid)
+    }
+
+    async fn list_blocks(&self) -> Result<Vec<B>, CommonError> {
+        self.inner.list_blocks()
+    }
+
+    async fn pin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        self.inner.pin_block(cid)
+    }
+
+    async fn unpin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        self.inner.unpin_block(cid)
+    }
+
+    async fn prune_expired(&mut self, now: u64) -> Result<Vec<Cid>, CommonError> {
+        self.inner.prune_expired(now)
+    }
+
+    async fn set_ttl(&mut self, cid: &Cid, ttl: Option<u64>) -> Result<(), CommonError> {
+        self.inner.set_ttl(cid, ttl)
+    }
+
+    async fn get_metadata(&self, cid: &Cid) -> Result<Option<BlockMetadata>, CommonError> {
+        self.inner.get_metadata(cid)
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.inner.as_any()
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self.inner.as_any_mut()
+    }
+}
+
 // --- In-Memory DAG Store ---
 
 /// Simple in-memory implementation of [`StorageService`] for tests and examples.

--- a/crates/icn-runtime/src/context/mod.rs
+++ b/crates/icn-runtime/src/context/mod.rs
@@ -27,5 +27,5 @@ pub use signers::{Ed25519Signer, HsmKeyStore, Signer, StubSigner};
 pub use stubs::{RuntimeStubDagStore, StubDagStore, StubMeshNetworkService};
 
 // Conditional compilation helpers for DAG storage service
-pub type DagStorageService = dyn icn_dag::StorageService<icn_common::DagBlock> + Send + Sync;
-pub type DagStoreMutexType<T> = tokio::sync::Mutex<T>; 
+pub type DagStorageService =
+    dyn icn_dag::AsyncStorageService<icn_common::DagBlock> + Send;pub type DagStoreMutexType<T> = tokio::sync::Mutex<T>; 

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -370,7 +370,9 @@ impl RuntimeContext {
         // Store in DAG
         {
             let mut dag_store = self.dag_store.lock().await;
-            dag_store.put(&block)
+            dag_store
+                .put(&block)
+                .await
                 .map_err(|e| HostAbiError::DagOperationFailed(format!("Failed to store receipt: {}", e)))?;
         }
         
@@ -448,8 +450,15 @@ impl RuntimeContext {
             };
             {
                 let mut dag_store = self.dag_store.lock().await;
-                dag_store.put(&block)
-                    .map_err(|e| HostAbiError::DagOperationFailed(format!("Failed to store proposal body: {}", e)))?;
+                dag_store
+                    .put(&block)
+                    .await
+                    .map_err(|e| {
+                        HostAbiError::DagOperationFailed(format!(
+                            "Failed to store proposal body: {}",
+                            e
+                        ))
+                    })?;
             }
             Some(block.cid.clone())
         } else {

--- a/crates/icn-runtime/src/executor.rs
+++ b/crates/icn-runtime/src/executor.rs
@@ -273,6 +273,7 @@ impl JobExecutor for SimpleExecutor {
                     let store = ctx.dag_store.lock().await;
                     store
                         .get(&job.manifest_cid)
+                        .await
                         .map_err(|e| CommonError::InternalError(e.to_string()))?
                         .ok_or_else(|| CommonError::ResourceNotFound("Metadata not found".into()))?
                         .data
@@ -289,6 +290,7 @@ impl JobExecutor for SimpleExecutor {
                     let store = ctx.dag_store.lock().await;
                     store
                         .get(&wasm_cid)
+                        .await
                         .map_err(|e| CommonError::InternalError(e.to_string()))?
                         .ok_or_else(|| {
                             CommonError::ResourceNotFound(
@@ -323,6 +325,7 @@ impl JobExecutor for SimpleExecutor {
                     let store = ctx.dag_store.lock().await;
                     store
                         .get(&job.manifest_cid)
+                        .await
                         .map_err(|e| CommonError::InternalError(e.to_string()))?
                 }
                 .ok_or_else(|| CommonError::ResourceNotFound("Manifest not found".into()))?
@@ -450,6 +453,7 @@ impl JobExecutor for WasmExecutor {
             let store = self.ctx.dag_store.lock().await;
             let block = store
                 .get(&job.manifest_cid)
+                .await
                 .map_err(|e| CommonError::InternalError(e.to_string()))?
                 .ok_or_else(|| CommonError::ResourceNotFound("WASM module not found".into()))?;
             block.data


### PR DESCRIPTION
## Summary
- use `AsyncStorageService` for DAG stores
- convert `NodeConfig::init_dag_store` to return async stores
- adapt runtime and node implementations to await DAG store calls
- add `CompatAsyncStore` wrapper for sync backends

## Testing
- `cargo check --workspace`

------
https://chatgpt.com/codex/tasks/task_e_686ec9e8aea083249df5ed559a19faff