### PR TITLE
[node] add postgres persistence feature

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -43,6 +43,7 @@ enable-libp2p = []
 persist-sqlite = ["icn-dag/persist-sqlite", "icn-runtime/persist-sqlite", "icn-economics/persist-sqlite"]
 persist-sled = ["icn-dag/persist-sled", "icn-runtime/persist-sled", "icn-economics/persist-sled"]
 persist-rocksdb = ["icn-dag/persist-rocksdb", "icn-runtime/persist-rocksdb", "icn-economics/persist-rocksdb"]
+persist-postgres = ["icn-dag/persist-postgres", "icn-runtime/persist-postgres"]
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -63,6 +63,7 @@ enable-libp2p = ["dep:libp2p"]
 persist-sled = ["icn-governance/persist-sled", "icn-reputation/persist-sled"]
 persist-sqlite = ["icn-governance/persist-sled", "icn-reputation/persist-sqlite", "icn-economics/persist-sqlite", "icn-dag/persist-sqlite"]
 persist-rocksdb = ["icn-governance/persist-sled", "icn-reputation/persist-rocksdb", "icn-economics/persist-rocksdb", "icn-dag/persist-rocksdb"]
+persist-postgres = ["icn-governance/persist-sled", "icn-dag/persist-postgres"]
 cli = ["dep:clap"]
 async = ["icn-dag/async"]
 


### PR DESCRIPTION
## Summary
- allow enabling postgres persistence through new `persist-postgres` feature
- propagate feature to `icn-runtime`
- compile postgres backend code only when the feature is active

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-dag`)*
- `cargo check` *(fails: could not compile `icn-node`)*
- `cargo check --features persist-postgres` *(fails: could not compile `icn-dag`)*

------
https://chatgpt.com/codex/tasks/task_e_686ec9eba49c832489c021d8bddd1e53