### PR TITLE
Add persist-postgres feature

### DIFF
--- a/crates/icn-node/Cargo.toml
+++ b/crates/icn-node/Cargo.toml
@@ -43,6 +43,7 @@ enable-libp2p = []
 persist-sqlite = ["icn-dag/persist-sqlite", "icn-runtime/persist-sqlite", "icn-economics/persist-sqlite"]
 persist-sled = ["icn-dag/persist-sled", "icn-runtime/persist-sled", "icn-economics/persist-sled"]
 persist-rocksdb = ["icn-dag/persist-rocksdb", "icn-runtime/persist-rocksdb", "icn-economics/persist-rocksdb"]
+persist-postgres = ["icn-dag/persist-postgres", "icn-runtime/persist-postgres"]
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -63,6 +63,7 @@ enable-libp2p = ["dep:libp2p"]
 persist-sled = ["icn-governance/persist-sled", "icn-reputation/persist-sled"]
 persist-sqlite = ["icn-governance/persist-sled", "icn-reputation/persist-sqlite", "icn-economics/persist-sqlite", "icn-dag/persist-sqlite"]
 persist-rocksdb = ["icn-governance/persist-sled", "icn-reputation/persist-rocksdb", "icn-economics/persist-rocksdb", "icn-dag/persist-rocksdb"]
+persist-postgres = ["icn-dag/persist-postgres"]
 cli = ["dep:clap"]
 async = ["icn-dag/async"]
 


### PR DESCRIPTION
## Summary
- enable a `persist-postgres` feature in `icn-node`
- pass the feature through to `icn-dag` and `icn-runtime`
- gate Postgres support in node config behind the new feature
- fix `PostgresDagStore` to compile with mutexed client

## Testing
- `cargo check`
- `cargo check -p icn-node --features persist-postgres`

------
https://chatgpt.com/codex/tasks/task_e_686ecef8bda883249b8a9c75161070b1