### PR TITLE
[cli] remove unused DagBlockMetadata import

### DIFF
--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -16,7 +16,6 @@ use std::process::exit; // Added for reading from stdin
 // Types from our ICN crates that CLI will interact with (serialize/deserialize)
 // These types are expected to be sent to/received from the icn-node HTTP API.
 use icn_common::{Cid, DagBlock, NodeInfo, NodeStatus};
-use icn_dag::DagBlockMetadata;
 // Using aliased request structs from icn-api for clarity, these are what the node expects
 use icn_api::governance_trait::{
     CastVoteRequest as ApiCastVoteRequest, SubmitProposalRequest as ApiSubmitProposalRequest,


### PR DESCRIPTION
## Summary
- clean up unused import in icn-cli to clear build warnings

## Testing
- `cargo fmt --all -- --check` *(fails: some files are not formatted)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: command timed out)*
- `cargo test --all-features --workspace` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686eca1e59248324894f60bb6103574d