### PR TITLE
[icn-node] remove redundant block_on

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -727,7 +727,7 @@ pub async fn app_router_from_context(
         let rate_opt = rate_limiter.clone();
         let param_store_opt: Option<Arc<TokioMutex<ParameterStore>>> = None;
         let handle = tokio::runtime::Handle::current();
-        let mut gov = handle.block_on(async { gov_mod.lock().await });
+        let mut gov = gov_mod.lock().await;
         gov.set_callback(move |proposal| {
             if let icn_governance::ProposalType::SystemParameterChange(param, value) =
                 &proposal.proposal_type


### PR DESCRIPTION
## Summary
- remove unnecessary use of `Handle::block_on` in `app_router_from_context`

## Testing
- `cargo fmt --all -- --check`
- `cargo check`
- *(tests and clippy were attempted but did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_686ecfb239ec8324b85b5cdcd6e1b97e