### PR TITLE
Add persistent Postgres DAG store

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -938,11 +938,19 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
                 .expect("Invalid p2p listen multiaddr");
             let listen_addrs = vec![listen_addr];
 
+            let dag_store_for_rt = match config.init_dag_store() {
+                Ok(store) => store,
+                Err(e) => {
+                    error!("Failed to initialize DAG store: {}", e);
+                    std::process::exit(1);
+                }
+            };
+
             match RuntimeContext::new_with_real_libp2p_and_mdns(
                 &node_did_string,
                 listen_addrs,
                 bootstrap_peers,
-                config.storage_path.clone(),
+                dag_store_for_rt.clone(),
                 config.mana_ledger_path.clone(),
                 config.reputation_db_path.clone(),
                 config.enable_mdns,

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -240,7 +240,7 @@ impl RuntimeContext {
         node_did_string: &str,
         listen_addrs: Vec<libp2p::Multiaddr>,
         bootstrap_peers: Option<Vec<(libp2p::PeerId, libp2p::Multiaddr)>>,
-        _storage_path: PathBuf,
+        dag_store: Arc<DagStoreMutexType<DagStorageService>>,
         mana_ledger_path: PathBuf,
         _reputation_db_path: PathBuf,
         enable_mdns: bool,
@@ -277,9 +277,8 @@ impl RuntimeContext {
         let signer = Arc::new(super::signers::StubSigner::new());
         let did_resolver = Arc::new(icn_identity::KeyDidResolver);
 
-        // Create DAG store - for now use stub, but could be created from storage_path in real implementation
-        let dag_store = Arc::new(DagStoreMutexType::new(super::stubs::StubDagStore::new()))
-            as Arc<DagStoreMutexType<DagStorageService>>;
+        // Use provided DAG store
+        let dag_store = dag_store;
 
         // Create mana ledger
         let mana_ledger = SimpleManaLedger::new(mana_ledger_path);


### PR DESCRIPTION
## Summary
- persist DAG metadata in Postgres
- enable Postgres backend for runtime context
- wire Node to create Postgres store when requested

## Testing
- `cargo check`
- `cargo test -p icn-node --no-run`


------
https://chatgpt.com/codex/tasks/task_e_686f2da4ba508324ae09017f54da8d63