### PR TITLE
Unify DAG CID encoding

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1625,7 +1625,7 @@ async fn dag_put_handler(
     };
     let mut store = state.runtime_context.dag_store.lock().await;
     match store.put(&dag_block).await {
-        Ok(()) => (StatusCode::CREATED, Json(dag_block.cid)).into_response(),
+        Ok(()) => (StatusCode::CREATED, Json(dag_block.cid.to_string())).into_response(),
         Err(e) => map_rust_error_to_json_response(
             format!("DAG put error: {}", e),
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/icn-node/tests/dag.rs
+++ b/crates/icn-node/tests/dag.rs
@@ -1,4 +1,4 @@
-use icn_common::Cid;
+use icn_common::{parse_cid_from_string, Cid};
 use icn_node::app_router;
 use reqwest::Client;
 use tokio::task;
@@ -19,7 +19,8 @@ async fn dag_put_and_get_round_trip() {
         .await
         .unwrap();
     assert_eq!(put_resp.status(), reqwest::StatusCode::CREATED);
-    let cid: Cid = put_resp.json().await.unwrap();
+    let cid_str: String = put_resp.json().await.unwrap();
+    let cid = parse_cid_from_string(&cid_str).expect("invalid cid returned");
 
     let get_resp = client
         .post(format!("http://{addr}/dag/get"))

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,11 +46,12 @@ curl -X GET https://localhost:8080/info \
 
 ### Example DAG Operations
 ```bash
-# Store a DAG block
+# Store a DAG block and receive a CID string
 curl -X POST https://localhost:8080/dag/put \
   -H "Content-Type: application/json" \
   -H "x-api-key: your-api-key" \
-  -d '{"data": "your-data", "links": []}'
+  -d '{"data": "your-data"}'
+# => "bafy...cid-string"
 
 # Retrieve a DAG block
 curl -X POST https://localhost:8080/dag/get \

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -203,39 +203,16 @@ This section provides examples for all major `icn-cli` commands. Ensure an `icn-
 **3. DAG Operations:**
 
    *   **Store a DAG Block (`dag put`):**
-      Requires a JSON string representing the `DagBlock`.
-      Example `DagBlock` JSON (note: CIDs are complex; this is illustrative):
-      ```json
-      {
-        "cid": {
-          "version": 1,
-          "codec": 85, // dag-cbor
-          "hash_alg": 18, // sha2-256
-          "hash_bytes": [72,101,108,108,111,87,111,114,108,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0] // Example hash
-        },
-        "data": [72,101,108,108,111,32,87,111,114,108,100,33], // "Hello World!" in bytes
-        "links": []
-      }
-      ```
-      CLI command (pass the JSON as a single string argument):
+      Provide JSON containing the block data. The endpoint returns the CID as a base32 string.
       ```sh
-      cargo run -p icn-cli -- dag put '{ "cid": { "version": 1, "codec": 85, "hash_alg": 18, "hash_bytes": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32] }, "data": [104,101,108,108,111], "links": [] }'
+      cargo run -p icn-cli -- dag put '{ "data": [104,101,108,108,111] }'
+      # => "bafy...cid-string"
       ```
 
    *   **Retrieve a DAG Block (`dag get`):**
-      Requires a JSON string representing the `Cid`.
-      Example `Cid` JSON (matching the one above):
-      ```json
-      {
-        "version": 1,
-        "codec": 85,
-        "hash_alg": 18,
-        "hash_bytes": [72,101,108,108,111,87,111,114,108,100,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
-      }
-      ```
-      CLI command:
+      Send the CID string returned from `dag put`.
       ```sh
-      cargo run -p icn-cli -- dag get '{ "version": 1, "codec": 85, "hash_alg": 18, "hash_bytes": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32] }'
+      cargo run -p icn-cli -- dag get '{ "cid": "bafy...cid-string" }'
       ```
 
 **4. Governance Operations:**

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -227,11 +227,11 @@ paths:
               $ref: '#/components/schemas/DagBlockPayload'
       responses:
         '200':
-          description: Cid
+          description: CID string
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Cid'
+                type: string
   /dag/get:
     post:
       summary: Retrieve data from DAG


### PR DESCRIPTION
## Summary
- use CID strings for `/dag/put` output
- parse returned string in integration test
- update docs and OpenAPI for new representation

## Testing
- `cargo test -p icn-node -- --nocapture` *(fails: missing field `body` in SubmitProposalRequest)*

------
https://chatgpt.com/codex/tasks/task_e_686f2db3e4148324acb6096d2e7f48d1