### PR TITLE
[icn-ccl] support else-if chain

### DIFF
--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -32,7 +32,8 @@ statement = { let_statement | expression_statement | return_statement | if_state
 let_statement = { "let" ~ identifier ~ "=" ~ expression ~ ";" }
 expression_statement = { expression ~ ";" }
 return_statement = { "return" ~ expression ~ ";" }
-if_statement = { "if" ~ expression ~ block ~ ("else" ~ block)? }
+if_statement = { "if" ~ expression ~ block ~ else_clause? }
+else_clause = { "else" ~ (if_statement | block) }
 while_statement = { "while" ~ expression ~ block }
 
 // Example: Expressions with proper precedence and unary operators

--- a/icn-ccl/test_ccl_devnet_integration.rs
+++ b/icn-ccl/test_ccl_devnet_integration.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::uninlined_format_args)]
+#![allow(unused_imports)]
 
 use icn_ccl::{compile_ccl_file_to_wasm, compile_ccl_source_to_wasm};
+use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::fs;
 
 fn main() {
     println!("🚀 ICN CCL → Devnet Integration Test 🚀\n");
@@ -38,7 +39,8 @@ fn main() {
 
             // Test 2: Show what a CCL WASM job submission would look like
             println!("\n=== Step 2: CCL WASM Job Specification ===");
-            let ccl_job_spec = format!(r#"{{
+            let ccl_job_spec = format!(
+                r#"{{
     "manifest_cid": "{}",
     "spec_json": {{
         "kind": {{
@@ -52,7 +54,9 @@ fn main() {
         }}
     }},
     "cost_mana": 100
-}}"#, metadata.cid);
+}}"#,
+                metadata.cid
+            );
 
             println!("📋 CCL WASM Job Specification:");
             println!("{}", ccl_job_spec);
@@ -81,16 +85,13 @@ fn main() {
   }'"#;
 
             println!("🌐 Submitting Echo job to test devnet connectivity...");
-            let output = Command::new("bash")
-                .arg("-c")
-                .arg(echo_job_cmd)
-                .output();
+            let output = Command::new("bash").arg("-c").arg(echo_job_cmd).output();
 
             match output {
                 Ok(result) => {
                     let stdout = String::from_utf8_lossy(&result.stdout);
                     let stderr = String::from_utf8_lossy(&result.stderr);
-                    
+
                     if result.status.success() {
                         println!("✅ Echo job submitted successfully!");
                         println!("📋 Response: {}", stdout);
@@ -112,13 +113,12 @@ fn main() {
             println!("   • 🔍 Content ID (CID) calculated for addressing");
             println!("   • 📊 Job specification formatted for mesh submission");
             println!("   • 🌐 Devnet connectivity verified");
-            
+
             println!("\n🎯 **Next Steps for Full CCL Integration:**");
             println!("   • 🔧 Implement CclWasm job kind in mesh system");
             println!("   • 🏃 Add WASM executor for CCL policies");
             println!("   • 📊 Test end-to-end CCL policy execution");
             println!("   • 🏛️  Deploy governance policies via CCL WASM");
-
         }
         Err(e) => {
             println!("❌ CCL compilation failed: {:?}", e);
@@ -126,4 +126,4 @@ fn main() {
     }
 
     println!("\n🎉 CCL → Devnet Integration Test Complete!");
-} 
+}

--- a/icn-ccl/test_individual_contracts.rs
+++ b/icn-ccl/test_individual_contracts.rs
@@ -1,9 +1,11 @@
+#![allow(clippy::uninlined_format_args)]
+
 use icn_ccl::*;
 use std::fs;
 
 fn main() {
-    println!("🌟 ICN Cooperative Contracts Testing 🌟\n");
-    
+    println!("ICN Cooperative Contracts Testing");
+
     let contracts = vec![
         "cooperative_dividend_distribution.ccl",
         "cooperative_membership_management.ccl",
@@ -17,54 +19,39 @@ fn main() {
         "cooperative_educational_governance.ccl",
         "cooperative_simple_governance.ccl",
     ];
-    
+
     let mut successful_contracts = 0;
     let mut failed_contracts = 0;
-    
+
     for contract_file in contracts {
         println!("=== Testing {} ===", contract_file);
-        
-        // Read the contract file
+
         let ccl_source = match fs::read_to_string(contract_file) {
-            Ok(source) => source,
+            Ok(src) => src,
             Err(e) => {
-                println!("❌ Failed to readw            continue;
+                println!("Failed to read {}: {}", contract_file, e);
+                continue;
             }
         };
-        
-        // Try to compile the contract
+
         match compile_ccl_source_to_wasm(&ccl_source) {
-            Ok((wasm_bytes, metadata)) => {
-                println!("✅ Successfully compiled {}!", contract_file);
-                println!("📦 WASM size: {} bytes", wasm_bytes.len());
-                
-                // Try to parse the WASM to get export information
-                let mut exports = Vec::new();
-                for payload in wasmparser::Parser::new(0).parse_all(&wasm_bytes) {
-                    if let Ok(wasmparser::Payload::ExportSection(export_reader)) = payload {
-                        for export in export_reader {
-                            if let Ok(export) = export {
-                                exports.push(export.name.to_string());
-                            }
-                        }
-                    }
-                }
-                println!("📋 Exports: {:?}", exports);
-                println!("📋 Metadata: {:?}", metadata);
-                
+            Ok((wasm_bytes, _metadata)) => {
+                println!("Compiled {} ({} bytes)", contract_file, wasm_bytes.len());
                 successful_contracts += 1;
             }
             Err(e) => {
-                println!("❌ Failed to compile {}: {}", contract_file, e);
+                println!("Failed to compile {}: {}", contract_file, e);
                 failed_contracts += 1;
             }
         }
-        
-        println!();
     }
-    
-    println!("🎉 Testing Complete!");
-    println!("✅ Successful contracts: {}", successful_contracts);
-    println!("❌ Failed contracts: {}", failed_contracts);
-    println!("📊 Success rate: {:.1}%", (successful_contracts as f64 / (successful_contracts + failed_contracts) as f64) * 100.0);
-} 
+
+    println!("Successful contracts: {}", successful_contracts);
+    println!("Failed contracts: {}", failed_contracts);
+    println!(
+        "Success rate: {:.1}%",
+        (successful_contracts as f64
+            / (successful_contracts + failed_contracts) as f64)
+            * 100.0
+    );
+}

--- a/icn-ccl/tests/ast_pair.rs
+++ b/icn-ccl/tests/ast_pair.rs
@@ -139,3 +139,25 @@ fn test_pair_to_ast_statement_return() {
     });
     assert_eq!(ast, expected);
 }
+
+#[test]
+fn test_pair_to_ast_else_if() {
+    let src = r#"
+        if 1 < 2 {
+            return 1;
+        } else if 2 < 3 {
+            return 2;
+        } else {
+            return 3;
+        }
+    "#;
+    let mut pairs = CclParser::parse(Rule::statement, src).unwrap();
+    let pair = pairs.next().unwrap();
+    let ast = ast::pair_to_ast(pair).unwrap();
+    match ast {
+        AstNode::Block(BlockNode { statements }) => {
+            assert!(matches!(statements[0], StatementNode::If { .. }));
+        }
+        _ => panic!("Expected block AST"),
+    }
+}

--- a/icn-ccl/tests/control_flow.rs
+++ b/icn-ccl/tests/control_flow.rs
@@ -138,3 +138,24 @@ fn compile_comparison_operators() {
     let (wasm, _meta) = compile_ccl_source_to_wasm(src).expect("compile");
     assert!(wasm.starts_with(b"\0asm"));
 }
+
+#[test]
+fn compile_else_if_chain() {
+    let src = r#"
+        fn classify(x: Integer) -> Integer {
+            if x < 5 {
+                return 1;
+            } else if x < 10 {
+                return 2;
+            } else {
+                return 3;
+            }
+        }
+
+        fn run() -> Integer {
+            return classify(7);
+        }
+    "#;
+    let (wasm, _meta) = compile_ccl_source_to_wasm(src).expect("compile");
+    assert!(wasm.starts_with(b"\0asm"));
+}


### PR DESCRIPTION
## Summary
- allow `else if` in the CCL grammar
- parse nested else-if statements
- update sample binaries to satisfy clippy
- add unit tests for else-if support

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test --all-features --workspace` *(failed: process interrupted)*
- `cargo test -p icn-ccl` *(failed: process interrupted)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f55fb1bec8324bfdd666971dd3afa