### PR TITLE
[ccl] add template crate and examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "icn-ccl",
     "tests",
     "crates/icn-sdk",
+    "crates/icn-ccl-templates",
 ]
 resolver = "2"
 

--- a/crates/icn-ccl-templates/Cargo.toml
+++ b/crates/icn-ccl-templates/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "icn-ccl-templates"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[package.metadata]
+# optional custom

--- a/crates/icn-ccl-templates/README.md
+++ b/crates/icn-ccl-templates/README.md
@@ -1,0 +1,15 @@
+# ICN CCL Templates
+
+This crate ships reusable Cooperative Contract Language (CCL) templates.
+
+These templates capture common governance patterns so cooperatives can
+quickly bootstrap new policies. Copy a template and modify the functions
+or thresholds to fit your needs.
+
+Available templates:
+- `VOTING_TEMPLATE` – basic voting workflow
+- `TREASURY_TEMPLATE` – simple treasury accounting
+
+The template source is embedded at compile time and exposed as `&'static str`.
+You can write the string to a `.ccl` file or pass it directly to the
+`icn-ccl` compiler.

--- a/crates/icn-ccl-templates/src/lib.rs
+++ b/crates/icn-ccl-templates/src/lib.rs
@@ -1,0 +1,7 @@
+#![doc = include_str!("../README.md")]
+
+/// Source code for a simple voting contract template.
+pub const VOTING_TEMPLATE: &str = include_str!("../templates/voting_template.ccl");
+
+/// Source code for a basic treasury management contract template.
+pub const TREASURY_TEMPLATE: &str = include_str!("../templates/treasury_template.ccl");

--- a/crates/icn-ccl-templates/templates/treasury_template.ccl
+++ b/crates/icn-ccl-templates/templates/treasury_template.ccl
@@ -1,0 +1,14 @@
+// Simple treasury accounting template
+// Adjust deposit and spend rules for your cooperative
+fn deposit(balance: Integer, amount: Integer) -> Integer {
+    return balance + amount;
+}
+
+fn spend(balance: Integer, amount: Integer) -> Integer {
+    return balance - amount;
+}
+
+fn run() -> Integer {
+    let bal = deposit(0, 10);
+    return spend(bal, 4);
+}

--- a/crates/icn-ccl-templates/templates/voting_template.ccl
+++ b/crates/icn-ccl-templates/templates/voting_template.ccl
@@ -1,0 +1,11 @@
+// Basic voting contract template
+// Replace tally logic or thresholds as needed
+fn tally(votes_for: Integer, votes_against: Integer) -> Integer {
+    if votes_for > votes_against { return 1; }
+    return 0;
+}
+
+fn run() -> Integer {
+    // customize initial vote counts
+    return tally(0, 0);
+}

--- a/icn-ccl/Cargo.toml
+++ b/icn-ccl/Cargo.toml
@@ -68,6 +68,8 @@ icn-mesh = { path = "../crates/icn-mesh" }
 tokio = { version = "1.0", features = ["full"] }
 # For temporary DAG stores in integration tests
 icn-dag = { path = "../crates/icn-dag" }
+# Template examples
+icn-ccl-templates = { path = "../crates/icn-ccl-templates" }
 # Add test dependencies
 
 

--- a/icn-ccl/test_ccl_devnet_integration.rs
+++ b/icn-ccl/test_ccl_devnet_integration.rs
@@ -1,9 +1,8 @@
 #![allow(clippy::uninlined_format_args)]
 
-use icn_ccl::{compile_ccl_file_to_wasm, compile_ccl_source_to_wasm};
-use std::path::Path;
-use std::process::Command;
+use icn_ccl::compile_ccl_source_to_wasm;
 use std::fs;
+use std::process::Command;
 
 fn main() {
     println!("🚀 ICN CCL → Devnet Integration Test 🚀\n");
@@ -38,7 +37,8 @@ fn main() {
 
             // Test 2: Show what a CCL WASM job submission would look like
             println!("\n=== Step 2: CCL WASM Job Specification ===");
-            let ccl_job_spec = format!(r#"{{
+            let ccl_job_spec = format!(
+                r#"{{
     "manifest_cid": "{}",
     "spec_json": {{
         "kind": {{
@@ -52,7 +52,9 @@ fn main() {
         }}
     }},
     "cost_mana": 100
-}}"#, metadata.cid);
+}}"#,
+                metadata.cid
+            );
 
             println!("📋 CCL WASM Job Specification:");
             println!("{}", ccl_job_spec);
@@ -81,16 +83,13 @@ fn main() {
   }'"#;
 
             println!("🌐 Submitting Echo job to test devnet connectivity...");
-            let output = Command::new("bash")
-                .arg("-c")
-                .arg(echo_job_cmd)
-                .output();
+            let output = Command::new("bash").arg("-c").arg(echo_job_cmd).output();
 
             match output {
                 Ok(result) => {
                     let stdout = String::from_utf8_lossy(&result.stdout);
                     let stderr = String::from_utf8_lossy(&result.stderr);
-                    
+
                     if result.status.success() {
                         println!("✅ Echo job submitted successfully!");
                         println!("📋 Response: {}", stdout);
@@ -112,13 +111,12 @@ fn main() {
             println!("   • 🔍 Content ID (CID) calculated for addressing");
             println!("   • 📊 Job specification formatted for mesh submission");
             println!("   • 🌐 Devnet connectivity verified");
-            
+
             println!("\n🎯 **Next Steps for Full CCL Integration:**");
             println!("   • 🔧 Implement CclWasm job kind in mesh system");
             println!("   • 🏃 Add WASM executor for CCL policies");
             println!("   • 📊 Test end-to-end CCL policy execution");
             println!("   • 🏛️  Deploy governance policies via CCL WASM");
-
         }
         Err(e) => {
             println!("❌ CCL compilation failed: {:?}", e);
@@ -126,4 +124,4 @@ fn main() {
     }
 
     println!("\n🎉 CCL → Devnet Integration Test Complete!");
-} 
+}

--- a/icn-ccl/test_individual_contracts.rs
+++ b/icn-ccl/test_individual_contracts.rs
@@ -1,9 +1,11 @@
+#![allow(clippy::uninlined_format_args, clippy::manual_flatten)]
+
 use icn_ccl::*;
 use std::fs;
 
 fn main() {
     println!("🌟 ICN Cooperative Contracts Testing 🌟\n");
-    
+
     let contracts = vec![
         "cooperative_dividend_distribution.ccl",
         "cooperative_membership_management.ccl",
@@ -17,27 +19,28 @@ fn main() {
         "cooperative_educational_governance.ccl",
         "cooperative_simple_governance.ccl",
     ];
-    
+
     let mut successful_contracts = 0;
     let mut failed_contracts = 0;
-    
+
     for contract_file in contracts {
         println!("=== Testing {} ===", contract_file);
-        
+
         // Read the contract file
         let ccl_source = match fs::read_to_string(contract_file) {
             Ok(source) => source,
             Err(e) => {
-                println!("❌ Failed to readw            continue;
+                println!("❌ Failed to read {contract_file}: {e}");
+                continue;
             }
         };
-        
+
         // Try to compile the contract
         match compile_ccl_source_to_wasm(&ccl_source) {
             Ok((wasm_bytes, metadata)) => {
                 println!("✅ Successfully compiled {}!", contract_file);
                 println!("📦 WASM size: {} bytes", wasm_bytes.len());
-                
+
                 // Try to parse the WASM to get export information
                 let mut exports = Vec::new();
                 for payload in wasmparser::Parser::new(0).parse_all(&wasm_bytes) {
@@ -51,7 +54,7 @@ fn main() {
                 }
                 println!("📋 Exports: {:?}", exports);
                 println!("📋 Metadata: {:?}", metadata);
-                
+
                 successful_contracts += 1;
             }
             Err(e) => {
@@ -59,12 +62,15 @@ fn main() {
                 failed_contracts += 1;
             }
         }
-        
+
         println!();
     }
-    
+
     println!("🎉 Testing Complete!");
     println!("✅ Successful contracts: {}", successful_contracts);
     println!("❌ Failed contracts: {}", failed_contracts);
-    println!("📊 Success rate: {:.1}%", (successful_contracts as f64 / (successful_contracts + failed_contracts) as f64) * 100.0);
-} 
+    println!(
+        "📊 Success rate: {:.1}%",
+        (successful_contracts as f64 / (successful_contracts + failed_contracts) as f64) * 100.0
+    );
+}

--- a/icn-ccl/tests/contracts/treasury_from_template.ccl
+++ b/icn-ccl/tests/contracts/treasury_from_template.ccl
@@ -1,0 +1,13 @@
+// Example contract generated from TREASURY_TEMPLATE
+fn deposit(balance: Integer, amount: Integer) -> Integer {
+    return balance + amount;
+}
+
+fn spend(balance: Integer, amount: Integer) -> Integer {
+    return balance - amount;
+}
+
+fn run() -> Integer {
+    let bal = deposit(100, 50);
+    return spend(bal, 20);
+}

--- a/icn-ccl/tests/contracts/voting_from_template.ccl
+++ b/icn-ccl/tests/contracts/voting_from_template.ccl
@@ -1,0 +1,9 @@
+// Example contract generated from VOTING_TEMPLATE
+fn tally(votes_for: Integer, votes_against: Integer) -> Integer {
+    if votes_for > votes_against { return 1; }
+    return 0;
+}
+
+fn run() -> Integer {
+    return tally(3, 1); // customize starting votes
+}

--- a/icn-ccl/tests/templates.rs
+++ b/icn-ccl/tests/templates.rs
@@ -1,0 +1,14 @@
+use icn_ccl::compile_ccl_source_to_wasm;
+use icn_ccl_templates::{TREASURY_TEMPLATE, VOTING_TEMPLATE};
+
+#[test]
+fn compile_voting_template() {
+    let (wasm, _meta) = compile_ccl_source_to_wasm(VOTING_TEMPLATE).expect("compile");
+    assert!(wasm.starts_with(b"\0asm"));
+}
+
+#[test]
+fn compile_treasury_template() {
+    let (wasm, _meta) = compile_ccl_source_to_wasm(TREASURY_TEMPLATE).expect("compile");
+    assert!(wasm.starts_with(b"\0asm"));
+}


### PR DESCRIPTION
## Summary
- provide `icn-ccl-templates` crate with reusable contract templates
- demonstrate usage in `icn-ccl` tests
- add example contracts generated from the templates

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not finish due to environment limits)*
- `cargo test --all-features --workspace` *(failed: could not finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_686f55f75f0c83248cec98002f584423