### PR TITLE
[cli] add ccl lint and explain commands

### DIFF
--- a/crates/icn-cli/tests/mesh_network_ccl.rs
+++ b/crates/icn-cli/tests/mesh_network_ccl.rs
@@ -124,6 +124,32 @@ async fn mesh_network_and_ccl_commands() {
     .await
     .unwrap();
 
+    // ccl lint command
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let lint_file = file_path.to_str().unwrap().to_string();
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["ccl", "lint", &lint_file])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("passed linting"));
+    })
+    .await
+    .unwrap();
+
+    // ccl explain command
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let explain_file = file_path.to_str().unwrap().to_string();
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["ccl", "explain", &explain_file])
+            .assert()
+            .success()
+            .stdout(predicates::str::contains("Function"));
+    })
+    .await
+    .unwrap();
+
     // federation join, status, leave commands
     let bin = env!("CARGO_BIN_EXE_icn-cli");
     let base = format!("http://{addr}");

--- a/docs/CONTRIBUTOR_SETUP.md
+++ b/docs/CONTRIBUTOR_SETUP.md
@@ -1,0 +1,36 @@
+# Contributor Setup
+
+This short guide covers the basic environment configuration needed to work on `icn-core`.
+
+1. **Install Rust and tools**
+   ```bash
+   rustup toolchain install stable
+   rustup override set stable
+   rustup component add clippy rustfmt
+   rustup target add wasm32-unknown-unknown
+   cargo install wasm-tools --locked
+   ```
+2. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd icn-core
+   ```
+3. **Run initial checks**
+   ```bash
+   cargo build
+   cargo test --all-features --workspace
+   ```
+4. **Install optional helpers**
+   ```bash
+   cargo install just
+   just --list
+   ```
+5. **Set up pre-commit hooks**
+   ```bash
+   pre-commit install
+   ```
+6. **VS Code Extension (optional)**
+   ```bash
+   cd vscode-extension && npm install
+   ```
+   Launch the extension with `F5` to get CCL syntax highlighting and a compile command.

--- a/icn-ccl/test_individual_contracts.rs
+++ b/icn-ccl/test_individual_contracts.rs
@@ -3,7 +3,7 @@ use std::fs;
 
 fn main() {
     println!("🌟 ICN Cooperative Contracts Testing 🌟\n");
-    
+
     let contracts = vec![
         "cooperative_dividend_distribution.ccl",
         "cooperative_membership_management.ccl",
@@ -17,27 +17,28 @@ fn main() {
         "cooperative_educational_governance.ccl",
         "cooperative_simple_governance.ccl",
     ];
-    
+
     let mut successful_contracts = 0;
     let mut failed_contracts = 0;
-    
+
     for contract_file in contracts {
         println!("=== Testing {} ===", contract_file);
-        
+
         // Read the contract file
         let ccl_source = match fs::read_to_string(contract_file) {
             Ok(source) => source,
             Err(e) => {
-                println!("❌ Failed to readw            continue;
+                println!("❌ Failed to read {}: {}", contract_file, e);
+                continue;
             }
         };
-        
+
         // Try to compile the contract
         match compile_ccl_source_to_wasm(&ccl_source) {
             Ok((wasm_bytes, metadata)) => {
                 println!("✅ Successfully compiled {}!", contract_file);
                 println!("📦 WASM size: {} bytes", wasm_bytes.len());
-                
+
                 // Try to parse the WASM to get export information
                 let mut exports = Vec::new();
                 for payload in wasmparser::Parser::new(0).parse_all(&wasm_bytes) {
@@ -51,7 +52,7 @@ fn main() {
                 }
                 println!("📋 Exports: {:?}", exports);
                 println!("📋 Metadata: {:?}", metadata);
-                
+
                 successful_contracts += 1;
             }
             Err(e) => {
@@ -59,12 +60,15 @@ fn main() {
                 failed_contracts += 1;
             }
         }
-        
+
         println!();
     }
-    
+
     println!("🎉 Testing Complete!");
     println!("✅ Successful contracts: {}", successful_contracts);
     println!("❌ Failed contracts: {}", failed_contracts);
-    println!("📊 Success rate: {:.1}%", (successful_contracts as f64 / (successful_contracts + failed_contracts) as f64) * 100.0);
-} 
+    println!(
+        "📊 Success rate: {:.1}%",
+        (successful_contracts as f64 / (successful_contracts + failed_contracts) as f64) * 100.0
+    );
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,17 @@
+# ICN CCL Tools
+
+This VS Code extension adds basic language support for the
+Cooperative Contract Language (CCL).
+
+## Features
+
+- Syntax highlighting for `.ccl` files
+- Command and task to compile the current CCL file using `icn-cli`
+
+## Usage
+
+1. Install dependencies with `npm install` inside the `vscode-extension` folder.
+2. Press `F5` in VS Code to launch an Extension Development Host.
+3. Use the `CCL: Compile CCL File` command or run the `ccl: Compile Current CCL` task.
+
+The task runs `icn-cli ccl compile <active file>` in a new terminal.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -1,0 +1,38 @@
+const vscode = require('vscode');
+
+function activate(context) {
+  const compileCmd = vscode.commands.registerCommand('icn-ccl.compile', () => {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      vscode.window.showInformationMessage('No active CCL file');
+      return;
+    }
+    const file = editor.document.fileName;
+    const terminal = vscode.window.createTerminal('CCL Compile');
+    terminal.show(true);
+    terminal.sendText(`icn-cli ccl compile "${file}"`);
+  });
+
+  const provider = vscode.tasks.registerTaskProvider('ccl', {
+    provideTasks: () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) return [];
+      const file = editor.document.fileName;
+      const task = new vscode.Task(
+        { type: 'ccl', file },
+        vscode.TaskScope.Workspace,
+        'Compile Current CCL',
+        'ccl',
+        new vscode.ShellExecution(`icn-cli ccl compile "${file}"`)
+      );
+      return [task];
+    },
+    resolveTask: (task) => task
+  });
+
+  context.subscriptions.push(compileCmd, provider);
+}
+
+function deactivate() {}
+
+module.exports = { activate, deactivate };

--- a/vscode-extension/language-configuration.json
+++ b/vscode-extension/language-configuration.json
@@ -1,0 +1,18 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["(", ")"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    {"open": "{", "close": "}"},
+    {"open": "[", "close": "]"},
+    {"open": "(", "close": ")"},
+    {"open": '"', "close": '"'},
+    {"open": "'", "close": "'"}
+  ]
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "icn-ccl-tools",
+  "displayName": "ICN CCL Tools",
+  "description": "Syntax highlighting and build tasks for Cooperative Contract Language (CCL)",
+  "version": "0.1.0",
+  "publisher": "icn",
+  "engines": { "vscode": "^1.80.0" },
+  "categories": ["Programming Languages"],
+  "activationEvents": [
+    "onLanguage:ccl"
+  ],
+  "main": "extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "ccl",
+        "aliases": ["CCL", "ccl"],
+        "extensions": [".ccl"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "ccl",
+        "scopeName": "source.ccl",
+        "path": "./syntaxes/ccl.tmLanguage.json"
+      }
+    ],
+    "commands": [
+      {
+        "command": "icn-ccl.compile",
+        "title": "Compile CCL File"
+      }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "ccl",
+        "required": [],
+        "properties": {
+          "file": {
+            "type": "string",
+            "description": "CCL file to compile"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/vscode-extension/syntaxes/ccl.tmLanguage.json
+++ b/vscode-extension/syntaxes/ccl.tmLanguage.json
@@ -1,0 +1,9 @@
+{
+  "scopeName": "source.ccl",
+  "patterns": [
+    {"match": "\\b(fn|rule|when|then|allow|deny|charge|let|if|else|while|return)\\b", "name": "keyword.control.ccl"},
+    {"match": "\\b(true|false)\\b", "name": "constant.language.ccl"},
+    {"match": "\"[^\"]*\"", "name": "string.quoted.double.ccl"},
+    {"match": "//.*$", "name": "comment.line.ccl"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add lint and explain subcommands to `icn-cli`
- supply VS Code extension for syntax highlighting and compile tasks
- fix an example compilation issue in `test_individual_contracts`
- document development setup for contributors

## Testing
- `cargo fmt --all -- --check` *(passes)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: errors in icn-ccl tests)*
- `cargo test --all-features --workspace` *(failed to complete)*
- `cargo test -p icn-ccl` *(failed: compilation errors)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f55f5662083248b7dcddcea6e483e