### PR TITLE
[testing] add property tests for ccl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --workspace --exclude icn-integration-tests
 
+      - name: Run CCL property tests
+        run: just test-ccl
+
       - name: Run icn-cli integration tests
         run: cargo test --all-features -p icn-cli
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ license = "Apache-2.0"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
+proptest = "1.4"
 
 

--- a/icn-ccl/Cargo.toml
+++ b/icn-ccl/Cargo.toml
@@ -68,6 +68,8 @@ icn-mesh = { path = "../crates/icn-mesh" }
 tokio = { version = "1.0", features = ["full"] }
 # For temporary DAG stores in integration tests
 icn-dag = { path = "../crates/icn-dag" }
+# Property testing
+proptest = "1.4"
 # Add test dependencies
 
 

--- a/icn-ccl/test_ccl_devnet_integration.rs
+++ b/icn-ccl/test_ccl_devnet_integration.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::uninlined_format_args)]
+#![allow(unused_imports)]
 
 use icn_ccl::{compile_ccl_file_to_wasm, compile_ccl_source_to_wasm};
 use std::path::Path;

--- a/icn-ccl/test_individual_contracts.rs
+++ b/icn-ccl/test_individual_contracts.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::manual_flatten)]
 use icn_ccl::*;
 use std::fs;
 
@@ -28,7 +30,8 @@ fn main() {
         let ccl_source = match fs::read_to_string(contract_file) {
             Ok(source) => source,
             Err(e) => {
-                println!("❌ Failed to readw            continue;
+                println!("❌ Failed to read {}: {}", contract_file, e);
+                continue;
             }
         };
         

--- a/icn-ccl/tests/integration_tests.rs
+++ b/icn-ccl/tests/integration_tests.rs
@@ -180,7 +180,8 @@ async fn test_wasm_executor_with_ccl() {
 
     use icn_common::DagBlock;
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zTestExec", 10).unwrap();
+    let ctx = RuntimeContext::new_with_stubs("did:key:zTestExec").unwrap();
+    ctx.mana_ledger.set_balance(&ctx.current_identity, 10).unwrap();
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
@@ -196,7 +197,7 @@ async fn test_wasm_executor_with_ccl() {
     };
     {
         let mut store = ctx.dag_store.lock().await;
-        store.put(&block).unwrap();
+        store.put(&block).await.unwrap();
     }
     let cid = block.cid.clone();
 
@@ -327,7 +328,8 @@ async fn test_wasm_executor_runs_addition() {
 
     use icn_common::DagBlock;
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zAddExecInt", 10).unwrap();
+    let ctx = RuntimeContext::new_with_stubs("did:key:zAddExecInt").unwrap();
+    ctx.mana_ledger.set_balance(&ctx.current_identity, 10).unwrap();
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
@@ -343,7 +345,7 @@ async fn test_wasm_executor_runs_addition() {
     };
     {
         let mut store = ctx.dag_store.lock().await;
-        store.put(&block).unwrap();
+        store.put(&block).await.unwrap();
     }
     let cid = block.cid.clone();
 
@@ -384,7 +386,8 @@ async fn test_wasm_executor_runs_proposal_flow() {
         .join("tests/contracts/proposal_flow.ccl");
     let (wasm, _) = compile_ccl_file_to_wasm(&contract_path).expect("compile file");
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zPropFlow", 10).unwrap();
+    let ctx = RuntimeContext::new_with_stubs("did:key:zPropFlow").unwrap();
+    ctx.mana_ledger.set_balance(&ctx.current_identity, 10).unwrap();
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
@@ -400,7 +403,7 @@ async fn test_wasm_executor_runs_proposal_flow() {
     };
     {
         let mut store = ctx.dag_store.lock().await;
-        store.put(&block).unwrap();
+        store.put(&block).await.unwrap();
     }
     let cid = block.cid.clone();
 
@@ -446,7 +449,8 @@ async fn test_wasm_executor_runs_voting_logic() {
         .join("tests/contracts/voting_logic.ccl");
     let (wasm, _) = compile_ccl_file_to_wasm(&contract_path).expect("compile file");
 
-    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zVoteLogic", 10).unwrap();
+    let ctx = RuntimeContext::new_with_stubs("did:key:zVoteLogic").unwrap();
+    ctx.mana_ledger.set_balance(&ctx.current_identity, 10).unwrap();
     let ts = 0u64;
     let author = icn_common::Did::new("key", "tester");
     let sig_opt = None;
@@ -462,7 +466,7 @@ async fn test_wasm_executor_runs_voting_logic() {
     };
     {
         let mut store = ctx.dag_store.lock().await;
-        store.put(&block).unwrap();
+        store.put(&block).await.unwrap();
     }
     let cid = block.cid.clone();
 

--- a/icn-ccl/tests/property_tests.rs
+++ b/icn-ccl/tests/property_tests.rs
@@ -1,0 +1,49 @@
+use proptest::prelude::*;
+use icn_ccl::compile_ccl_source_to_wasm;
+use icn_common::{compute_merkle_cid, Cid, DagBlock, Did};
+use icn_identity::SignatureBytes;
+use icn_mesh::{ActualMeshJob, JobId, JobSpec};
+use icn_runtime::context::{RuntimeContext, StubSigner};
+use icn_runtime::executor::{JobExecutor, WasmExecutor, WasmExecutorConfig};
+use std::sync::Arc;
+
+proptest! {
+    #[test]
+    fn compiled_addition_deterministic(a in 0i64..1000, b in 0i64..1000) {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let ctx = RuntimeContext::new_with_stubs("did:key:zProp").unwrap();
+            ctx.mana_ledger.set_balance(&ctx.current_identity, 5).unwrap();
+            let source = format!("fn run() -> Integer {{ return {} + {}; }}", a, b);
+            let (wasm, _) = compile_ccl_source_to_wasm(&source).unwrap();
+
+            let ts = 0u64;
+            let author = Did::new("key", "tester");
+            let sig_opt = None;
+            let cid = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
+            let block = DagBlock { cid: cid.clone(), data: wasm.clone(), links: vec![], timestamp: ts, author_did: author, signature: sig_opt, scope: None };
+            {
+                let mut store = ctx.dag_store.lock().await;
+                store.put(&block).await.unwrap();
+            }
+
+            let job = ActualMeshJob {
+                id: JobId(Cid::new_v1_sha256(0x55, b"prop")),
+                manifest_cid: block.cid.clone(),
+                spec: JobSpec::default(),
+                creator_did: ctx.current_identity.clone(),
+                cost_mana: 0,
+                max_execution_wait_ms: None,
+                signature: SignatureBytes(vec![]),
+            };
+            let signer = Arc::new(StubSigner::new());
+            let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
+            let receipt1 = exec.execute_job(&job).await.unwrap();
+            let receipt2 = exec.execute_job(&job).await.unwrap();
+            let expected = Cid::new_v1_sha256(0x55, &(a + b).to_le_bytes());
+            assert_eq!(receipt1.result_cid, expected);
+            assert_eq!(receipt2.result_cid, expected);
+        });
+    }
+}
+

--- a/justfile
+++ b/justfile
@@ -52,3 +52,7 @@ metrics:
 # Build documentation for all crates
 docs:
     cargo doc --workspace --no-deps
+
+# Run CCL property tests
+test-ccl:
+    cargo test -p icn-ccl


### PR DESCRIPTION
## Summary
- add property-based test using proptest for deterministic CCL contract execution
- wire proptest into `icn-ccl` crate dev-deps
- provide simple `test-ccl` just task
- hook `just test-ccl` into CI workflow

## Testing
- `cargo fmt --all -- --check`
- ❌ `cargo clippy --all-targets --all-features -- -D warnings` *(failed: command timed out)*
- ❌ `cargo test --all-features --workspace` *(failed: command timed out)*
- ❌ `just test-ccl` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686f55f695e083248dfdb7c6df3f3ce0