### PR TITLE
Add CCL reference and new example contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,8 @@ More detailed information can be found in the `README.md` file within each crate
 * [RFC Index](icn-docs/rfcs/README.md) – design proposals and specifications
 * [RFC 0010: ICN Governance Core](icn-docs/rfcs/0010-governance-core.md) – governance framework
 * [Mana Policies](docs/mana_policies.md) – economic policy examples
-* [CCL Examples](icn-ccl/tests/contracts/) – governance contract templates
+* [CCL Language Reference](docs/CCL_LANGUAGE_REFERENCE.md) – full syntax guide
+* [CCL Examples](icn-ccl/examples/) – governance contract templates
 
 ### **Development Resources**
 * Crate documentation: [icn-common](crates/icn-common/README.md), [icn-dag](crates/icn-dag/README.md), [icn-identity](crates/icn-identity/README.md), [icn-mesh](crates/icn-mesh/README.md), [icn-governance](crates/icn-governance/README.md), [icn-runtime](crates/icn-runtime/README.md), [icn-network](crates/icn-network/README.md)

--- a/docs/CCL_LANGUAGE_REFERENCE.md
+++ b/docs/CCL_LANGUAGE_REFERENCE.md
@@ -1,0 +1,104 @@
+# Cooperative Contract Language (CCL) Reference
+
+This reference summarizes all syntax currently supported by the CCL compiler.
+It is intended for cooperative developers writing governance policies and
+economic logic for ICN nodes.
+
+## Basic Concepts
+
+CCL source files consist of function definitions, optional struct definitions,
+and policy rules. Whitespace and `//` comments are ignored.
+
+```ccl
+// simple entry point
+fn run() -> Integer { return 0; }
+```
+
+### Types
+
+Built in primitive types:
+
+- `Integer` – 64‑bit signed integer
+- `Mana` – alias of `Integer` for economic values
+- `Bool`  – boolean (`true` / `false`)
+- `String` – UTF‑8 text stored in memory
+- `Array<T>` – dynamic arrays
+- `Option` and `Result` – for nullable values and error handling
+- `Did` – decentralized identifier
+- `Proposal` and `Vote` – governance primitives
+
+User defined structs can bundle fields:
+
+```ccl
+struct Member { id: Did, name: String }
+```
+
+### Functions
+
+Functions declare typed parameters and return a type:
+
+```ccl
+fn add(a: Integer, b: Integer) -> Integer {
+    return a + b;
+}
+```
+
+### Statements
+
+Supported statements inside blocks:
+
+- variable binding with `let`
+- expression statements
+- `return` expressions
+- `if` / `else` conditional blocks
+- `while` loops
+
+### Expressions
+
+Expressions support numeric and boolean operators, string concatenation, array
+literals, and function calls. Arrays use helper functions such as `array_push`
+and `array_len` for mutation.
+
+Option and Result values use the variants `Some`, `None`, `Ok` and `Err`.
+Pattern matching inspects these variants:
+
+```ccl
+fn divide(a: Integer, b: Integer) -> Result<Integer> {
+    if b == 0 { return Err(1); }
+    return Ok(a / b);
+}
+
+let result = divide(10, 2);
+match result {
+    Ok(v) => log_success(v),
+    Err(e) => log_error(e),
+}
+```
+
+### Policy Rules
+
+Policy oriented contracts can declare rules which evaluate an expression and then
+perform an action:
+
+```ccl
+rule charge_high when cost > 100 then charge cost
+rule allow_basic when cost <= 100 then allow
+```
+
+Actions are `allow`, `deny`, or `charge <expr>`.
+
+### Imports
+
+External files can be imported with an alias:
+
+```ccl
+import "./common.ccl" as common;
+```
+
+### Entry Point
+
+Contracts executed as mesh jobs expose a `run` function. Additional helper
+functions may be defined as needed.
+
+See `icn-ccl/examples/` for real‑world contract templates demonstrating the
+language.

--- a/icn-ccl/README.md
+++ b/icn-ccl/README.md
@@ -71,13 +71,35 @@ cargo run -p icn-cli -- --api-url http://localhost:7845 submit-job \
 
 ### Included Governance Examples
 
-Several example contracts live in `tests/contracts/`:
+Several example contracts live in `examples/`:
 
 * `proposal_flow.ccl` – illustrates proposal creation, voting and finalization.
 * `voting_logic.ccl` – demonstrates an open/cast/close voting sequence.
 
 These files can be compiled with `compile_ccl_file_to_wasm` and executed using
 the `WasmExecutor` as shown in the integration tests.
+
+## Option and Result Handling
+
+CCL includes `Option` and `Result` types for nullable values and explicit error
+handling. Pattern matching can inspect these variants:
+
+```ccl
+fn lookup(id: Integer) -> Option<Integer> {
+    if id == 1 { return Some(100); }
+    return None;
+}
+
+fn safe_div(a: Integer, b: Integer) -> Result<Integer> {
+    if b == 0 { return Err(1); }
+    return Ok(a / b);
+}
+
+match safe_div(10, 2) {
+    Ok(v) => log_success(v),
+    Err(e) => log_error(e),
+}
+```
 
 ## Array and String Operations
 

--- a/icn-ccl/examples/childcare_cooperative_schedule.ccl
+++ b/icn-ccl/examples/childcare_cooperative_schedule.ccl
@@ -1,0 +1,15 @@
+// Childcare Cooperative Scheduling Example
+// Demonstrates Option handling and simple control flow
+
+fn find_slot(day: Integer) -> Option<Integer> {
+    if day % 2 == 0 { return Some(day); }
+    return None;
+}
+
+fn run() -> Integer {
+    let slot = find_slot(3);
+    match slot {
+        Some(d) => return d,
+        None => return -1,
+    }
+}

--- a/icn-ccl/examples/cooperative_energy_distribution.ccl
+++ b/icn-ccl/examples/cooperative_energy_distribution.ccl
@@ -1,0 +1,19 @@
+// Community Energy Distribution Example
+// Uses loops and array operations
+
+fn distribute(total_kw: Integer, houses: Array<Integer>) -> Array<Integer> {
+    let count = array_len(houses);
+    let per = total_kw / count;
+    let i = 0;
+    while i < count {
+        houses[i] = houses[i] + per;
+        let i = i + 1;
+    }
+    return houses;
+}
+
+fn run() -> Integer {
+    let households = [10, 12, 15];
+    let final = distribute(30, households);
+    return array_len(final);
+}

--- a/icn-ccl/examples/cooperative_housing_maintenance.ccl
+++ b/icn-ccl/examples/cooperative_housing_maintenance.ccl
@@ -1,0 +1,25 @@
+// Cooperative Housing Maintenance Example
+// Demonstrates struct usage and simple result handling
+
+struct Request { unit: Integer, urgent: Bool, cost: Integer }
+
+fn find_slot(urgent: Bool) -> Option<Integer> {
+    if urgent { return Some(0); }
+    return None;
+}
+
+fn schedule_repair(req: Request) -> Result<Integer> {
+    let slot = find_slot(req.urgent);
+    match slot {
+        Some(day) => Ok(day),
+        None => Err(1), // no slot available
+    }
+}
+
+fn run() -> Integer {
+    let req = Request { unit: 5, urgent: true, cost: 200 };
+    match schedule_repair(req) {
+        Ok(day) => return day,
+        Err(_) => return -1,
+    }
+}


### PR DESCRIPTION
## Summary
- document all CCL syntax in `docs/CCL_LANGUAGE_REFERENCE.md`
- link the language reference in README
- update CCL README with Option/Result section and new examples path
- add real‑world example contracts under `icn-ccl/examples/`

## Testing
- `cargo test --all-features --workspace` *(failed: command not found / incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_686f5eadbbd48324a06db18f8f0ffa16