### PR TITLE
Add module linking support to CCL runtime

### DIFF
--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -13,6 +13,7 @@ use icn_identity::{
     VerifyingKey as IdentityVerifyingKey,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 pub mod metrics;
 
 /// Unique identifier for a mesh job.
@@ -150,6 +151,9 @@ pub struct JobSpec {
     /// CIDs of input data necessary to run the job.
     #[serde(default)]
     pub inputs: Vec<Cid>,
+    /// Additional compiled modules required for execution.
+    #[serde(default)]
+    pub modules: BTreeMap<String, Cid>,
     /// Logical names for outputs that the executor is expected to produce.
     #[serde(default)]
     pub outputs: Vec<String>,
@@ -163,6 +167,7 @@ impl Default for JobSpec {
         Self {
             kind: JobKind::GenericPlaceholder,
             inputs: Vec::new(),
+            modules: BTreeMap::new(),
             outputs: Vec::new(),
             required_resources: Resources::default(),
         }

--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -13,8 +13,8 @@ string_inner = { "\\" ~ ANY | !("\"" | NEWLINE) ~ ANY }
 string_literal = @{ "\"" ~ string_inner* ~ "\"" }
 boolean_literal = { "true" | "false" }
 
-// Top-level: A CCL policy is a sequence of statements or definitions
-policy = { SOI ~ (function_definition | struct_definition | policy_statement)* ~ EOI }
+// Top-level: A CCL policy/module may declare a name and list exports
+policy = { SOI ~ module_statement? ~ (function_definition | struct_definition | policy_statement | export_statement)* ~ EOI }
 
 // Example: Function Definition
 function_definition = { "fn" ~ identifier ~ "(" ~ (parameter ~ ("," ~ parameter)*)? ~ ")" ~ "->" ~ type_annotation ~ block }
@@ -26,6 +26,8 @@ type_annotation = { identifier }
 policy_statement = { rule_definition | import_statement }
 rule_definition = { "rule" ~ identifier ~ "when" ~ expression ~ "then" ~ action }
 import_statement = { "import" ~ string_literal ~ "as" ~ identifier ~ ";" }
+export_statement = { "export" ~ identifier ~ ";" }
+module_statement = { "module" ~ identifier ~ ";" }
 
 // Example: Block of statements
 block = { "{" ~ statement* ~ "}" }
@@ -55,7 +57,8 @@ none_expr = { "None" }
 ok_expr = { "Ok" ~ "(" ~ expression ~ ")" }
 err_expr = { "Err" ~ "(" ~ expression ~ ")" }
 array_literal = { "[" ~ expression ~ ("," ~ expression)* ~ "]" }
-function_call = { identifier ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
+module_path = { identifier ~ "::" ~ identifier }
+function_call = { (module_path | identifier) ~ "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 
 ADD_OP = { "+" }
 SUB_OP = { "-" }

--- a/icn-ccl/src/optimizer.rs
+++ b/icn-ccl/src/optimizer.rs
@@ -59,6 +59,8 @@ impl Optimizer {
                 PolicyStatementNode::Import { path, alias }
             }
             PolicyStatementNode::StructDef(s) => PolicyStatementNode::StructDef(self.fold_ast(s)),
+            PolicyStatementNode::Export { name } => PolicyStatementNode::Export { name },
+            PolicyStatementNode::Module { name } => PolicyStatementNode::Module { name },
         }
     }
 
@@ -156,7 +158,12 @@ impl Optimizer {
                     right: Box::new(r),
                 }
             }
-            ExpressionNode::FunctionCall { name, arguments } => ExpressionNode::FunctionCall {
+            ExpressionNode::FunctionCall {
+                module,
+                name,
+                arguments,
+            } => ExpressionNode::FunctionCall {
+                module,
                 name,
                 arguments: arguments.into_iter().map(|a| self.fold_expr(a)).collect(),
             },

--- a/icn-ccl/src/semantic_analyzer.rs
+++ b/icn-ccl/src/semantic_analyzer.rs
@@ -224,6 +224,8 @@ impl SemanticAnalyzer {
             crate::ast::PolicyStatementNode::StructDef(def) => {
                 self.visit_node(def)?;
             }
+            crate::ast::PolicyStatementNode::Export { .. } => {}
+            crate::ast::PolicyStatementNode::Module { .. } => {}
         }
         Ok(())
     }
@@ -395,7 +397,11 @@ impl SemanticAnalyzer {
                     name
                 ))),
             },
-            ExpressionNode::FunctionCall { name, arguments } => {
+            ExpressionNode::FunctionCall {
+                module: _,
+                name,
+                arguments,
+            } => {
                 let symbol = self.lookup_symbol(name).cloned();
                 match symbol {
                     Some(Symbol::Function {

--- a/icn-ccl/src/wasm_backend.rs
+++ b/icn-ccl/src/wasm_backend.rs
@@ -266,7 +266,11 @@ impl WasmBackend {
                 instrs.push(Instruction::LocalGet(idx));
                 Ok(ty)
             }
-            ExpressionNode::FunctionCall { name, arguments } => {
+            ExpressionNode::FunctionCall {
+                module: _,
+                name,
+                arguments,
+            } => {
                 match name.as_str() {
                     "array_len" => {
                         let ptr_ty =

--- a/icn-ccl/test_ccl_devnet_integration.rs
+++ b/icn-ccl/test_ccl_devnet_integration.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::uninlined_format_args)]
+#![allow(unused_imports)]
 
 use icn_ccl::{compile_ccl_file_to_wasm, compile_ccl_source_to_wasm};
+use std::fs;
 use std::path::Path;
 use std::process::Command;
-use std::fs;
 
 fn main() {
     println!("🚀 ICN CCL → Devnet Integration Test 🚀\n");
@@ -38,7 +39,8 @@ fn main() {
 
             // Test 2: Show what a CCL WASM job submission would look like
             println!("\n=== Step 2: CCL WASM Job Specification ===");
-            let ccl_job_spec = format!(r#"{{
+            let ccl_job_spec = format!(
+                r#"{{
     "manifest_cid": "{}",
     "spec_json": {{
         "kind": {{
@@ -52,7 +54,9 @@ fn main() {
         }}
     }},
     "cost_mana": 100
-}}"#, metadata.cid);
+}}"#,
+                metadata.cid
+            );
 
             println!("📋 CCL WASM Job Specification:");
             println!("{}", ccl_job_spec);
@@ -81,16 +85,13 @@ fn main() {
   }'"#;
 
             println!("🌐 Submitting Echo job to test devnet connectivity...");
-            let output = Command::new("bash")
-                .arg("-c")
-                .arg(echo_job_cmd)
-                .output();
+            let output = Command::new("bash").arg("-c").arg(echo_job_cmd).output();
 
             match output {
                 Ok(result) => {
                     let stdout = String::from_utf8_lossy(&result.stdout);
                     let stderr = String::from_utf8_lossy(&result.stderr);
-                    
+
                     if result.status.success() {
                         println!("✅ Echo job submitted successfully!");
                         println!("📋 Response: {}", stdout);
@@ -112,13 +113,12 @@ fn main() {
             println!("   • 🔍 Content ID (CID) calculated for addressing");
             println!("   • 📊 Job specification formatted for mesh submission");
             println!("   • 🌐 Devnet connectivity verified");
-            
+
             println!("\n🎯 **Next Steps for Full CCL Integration:**");
             println!("   • 🔧 Implement CclWasm job kind in mesh system");
             println!("   • 🏃 Add WASM executor for CCL policies");
             println!("   • 📊 Test end-to-end CCL policy execution");
             println!("   • 🏛️  Deploy governance policies via CCL WASM");
-
         }
         Err(e) => {
             println!("❌ CCL compilation failed: {:?}", e);
@@ -126,4 +126,4 @@ fn main() {
     }
 
     println!("\n🎉 CCL → Devnet Integration Test Complete!");
-} 
+}

--- a/icn-ccl/tests/ast_pair.rs
+++ b/icn-ccl/tests/ast_pair.rs
@@ -129,6 +129,30 @@ fn test_pair_to_ast_policy_statement_import() {
 }
 
 #[test]
+fn test_pair_to_ast_export_statement() {
+    let src = "export run;";
+    let mut pairs = CclParser::parse(Rule::export_statement, src).unwrap();
+    let pair = pairs.next().unwrap();
+    let ast = ast::pair_to_ast(pair).unwrap();
+    let expected = AstNode::Policy(vec![PolicyStatementNode::Export {
+        name: "run".to_string(),
+    }]);
+    assert_eq!(ast, expected);
+}
+
+#[test]
+fn test_pair_to_ast_module_statement() {
+    let src = "module mymod;";
+    let mut pairs = CclParser::parse(Rule::module_statement, src).unwrap();
+    let pair = pairs.next().unwrap();
+    let ast = ast::pair_to_ast(pair).unwrap();
+    let expected = AstNode::Policy(vec![PolicyStatementNode::Module {
+        name: "mymod".to_string(),
+    }]);
+    assert_eq!(ast, expected);
+}
+
+#[test]
 fn test_pair_to_ast_statement_return() {
     let src = "return 5;";
     let mut pairs = CclParser::parse(Rule::statement, src).unwrap();


### PR DESCRIPTION
## Summary
- extend the CCL grammar with `module` and `export` statements
- parse new statements into the AST and CLI rendering
- add module list to `JobSpec` and cache loaded modules in `RuntimeContext`
- update `WasmExecutor` to link additional modules
- adjust tests for new grammar rules

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: build timeout)*
- `cargo test --all-features --workspace -- --test-threads=1 --quiet` *(fails: build timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686f5f45141083249f7563e066a97175