### PR TITLE
Add module registry to runtime

### DIFF
--- a/crates/icn-runtime/src/context/mesh_network.rs
+++ b/crates/icn-runtime/src/context/mesh_network.rs
@@ -1,7 +1,7 @@
 //! Mesh network service types and implementations for the ICN runtime.
 
 use super::errors::HostAbiError;
-use icn_common::Did;
+use icn_common::{CommonError, Did};
 use icn_identity::{ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes};
 use icn_mesh::{ActualMeshJob, JobId, MeshJobBid};
 use icn_network::NetworkService;

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -112,6 +112,7 @@ pub struct RuntimeContext {
     pub policy_enforcer: Option<Arc<dyn icn_governance::scoped_policy::ScopedPolicyEnforcer>>,
     pub time_provider: Arc<dyn icn_common::TimeProvider>,
     pub default_receipt_wait_ms: u64,
+    pub modules: Arc<DashMap<String, Vec<u8>>>,
 }
 
 // Import std::str::FromStr for Did::from_str
@@ -197,6 +198,7 @@ impl RuntimeContext {
             policy_enforcer,
             time_provider,
             default_receipt_wait_ms: 30000,
+            modules: Arc::new(DashMap::new()),
         }))
     }
 
@@ -233,6 +235,7 @@ impl RuntimeContext {
             policy_enforcer,
             time_provider,
             default_receipt_wait_ms: 30000,
+            modules: Arc::new(DashMap::new()),
         })
     }
 
@@ -307,6 +310,7 @@ impl RuntimeContext {
             policy_enforcer,
             time_provider,
             default_receipt_wait_ms: 30000,
+            modules: Arc::new(DashMap::new()),
         }))
     }
 
@@ -345,6 +349,7 @@ impl RuntimeContext {
             policy_enforcer,
             time_provider,
             default_receipt_wait_ms: 30000,
+            modules: Arc::new(DashMap::new()),
         })
     }
 
@@ -374,6 +379,21 @@ impl RuntimeContext {
     /// Credit mana to an account.
     pub async fn credit_mana(&self, account: &Did, amount: u64) -> Result<(), HostAbiError> {
         self.mana_ledger.credit(account, amount)
+    }
+
+    /// Load or replace a compiled WASM module by name.
+    pub fn load_module(&self, name: &str, wasm: Vec<u8>) {
+        self.modules.insert(name.to_string(), wasm);
+    }
+
+    /// Remove a loaded module.
+    pub fn unload_module(&self, name: &str) {
+        self.modules.remove(name);
+    }
+
+    /// Retrieve module bytes if loaded.
+    pub fn module_bytes(&self, name: &str) -> Option<Vec<u8>> {
+        self.modules.get(name).map(|e| e.value().clone())
     }
 
     /// Anchor an execution receipt.

--- a/icn-ccl/src/grammar/ccl.pest
+++ b/icn-ccl/src/grammar/ccl.pest
@@ -14,7 +14,7 @@ string_literal = @{ "\"" ~ string_inner* ~ "\"" }
 boolean_literal = { "true" | "false" }
 
 // Top-level: A CCL policy is a sequence of statements or definitions
-policy = { SOI ~ (function_definition | struct_definition | policy_statement)* ~ EOI }
+policy = { SOI ~ (module_definition | function_definition | struct_definition | policy_statement)* ~ EOI }
 
 // Example: Function Definition
 function_definition = { "fn" ~ identifier ~ "(" ~ (parameter ~ ("," ~ parameter)*)? ~ ")" ~ "->" ~ type_annotation ~ block }
@@ -22,10 +22,13 @@ struct_definition = { "struct" ~ identifier ~ "{" ~ (parameter ~ ("," ~ paramete
 parameter = { identifier ~ ":" ~ type_annotation }
 type_annotation = { identifier }
 
-// Example: Policy Statement (e.g., a rule)
-policy_statement = { rule_definition | import_statement }
+// Example: Policy Statement (e.g., a rule or import/export)
+policy_statement = { rule_definition | import_statement | export_statement }
 rule_definition = { "rule" ~ identifier ~ "when" ~ expression ~ "then" ~ action }
 import_statement = { "import" ~ string_literal ~ "as" ~ identifier ~ ";" }
+export_statement = { "export" ~ identifier ~ ";" }
+
+module_definition = { "module" ~ identifier ~ "{" ~ (function_definition | struct_definition | policy_statement)* ~ "}" }
 
 // Example: Block of statements
 block = { "{" ~ statement* ~ "}" }


### PR DESCRIPTION
## Summary
- extend CCL grammar to recognize module definitions, imports and exports
- allow `RuntimeContext` to store loaded WASM modules and expose helpers
- fix missing import in mesh network service

## Testing
- `cargo test --all-features --workspace` *(fails: could not compile `icn-node`)*

------
https://chatgpt.com/codex/tasks/task_e_6870065810148324ac5fea0c1001b2db