### PR TITLE
[monitoring] Add standalone Prometheus stack

### DIFF
--- a/docker-compose-monitoring.yml
+++ b/docker-compose-monitoring.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./monitoring/rules:/etc/prometheus/rules
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - ./monitoring/dashboards:/var/lib/grafana/dashboards
+      - ./monitoring/provisioning:/etc/grafana/provisioning
+
+  alertmanager:
+    image: prom/alertmanager:latest
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./monitoring/alertmanager.yml:/etc/alertmanager/alertmanager.yml

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -512,11 +512,15 @@ The repository includes a containerized devnet for quickly spinning up a three-n
    ```
 3. **Run with monitoring (Prometheus & Grafana):**
    ```bash
-   cd icn-devnet
-   docker-compose --profile monitoring up -d
+  cd icn-devnet
+  docker-compose --profile monitoring up -d
+  ```
+  Prometheus will be available at <http://localhost:9090> and Grafana at
+  <http://localhost:3000> (login `admin` / `icnfederation`).
+   Alternatively, run the standalone monitoring stack:
+   ```bash
+   docker compose -f docker-compose-monitoring.yml up -d
    ```
-   Prometheus will be available at <http://localhost:9090> and Grafana at
-   <http://localhost:3000> (login `admin` / `icnfederation`).
 4. **Submit your own job:**
    ```bash
    curl -X POST http://localhost:5001/mesh/submit \

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -181,6 +181,11 @@ cd icn-devnet
 docker-compose --profile monitoring up -d
 ```
 
+To monitor existing nodes without the devnet, run the standalone stack:
+```bash
+docker compose -f docker-compose-monitoring.yml up -d
+```
+
 Prometheus will be reachable at <http://localhost:9090> and Grafana at
 <http://localhost:3000> (`admin` / `icnfederation`). Import the dashboards from
 `icn-devnet/grafana/` to visualize node metrics.

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,6 @@
+route:
+  receiver: 'icn-default'
+receivers:
+  - name: 'icn-default'
+    email_configs:
+      - to: alerts@example.com

--- a/monitoring/dashboards/governance_activity.json
+++ b/monitoring/dashboards/governance_activity.json
@@ -1,0 +1,15 @@
+{
+  "uid": "governance-activity",
+  "title": "Governance Activity",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Proposals Submitted",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "governance_submit_proposal_calls"}],
+      "gridPos": {"h":4,"w":6,"x":0,"y":0}
+    }
+  ]
+}

--- a/monitoring/dashboards/icn_overview.json
+++ b/monitoring/dashboards/icn_overview.json
@@ -1,0 +1,15 @@
+{
+  "uid": "icn-overview",
+  "title": "ICN Overview",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Jobs Submitted",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "jobs_submitted_total"}],
+      "gridPos": {"h":4,"w":6,"x":0,"y":0}
+    }
+  ]
+}

--- a/monitoring/dashboards/job_execution.json
+++ b/monitoring/dashboards/job_execution.json
@@ -1,0 +1,15 @@
+{
+  "uid": "job-execution",
+  "title": "Job Execution",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Job Process Time",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "mesh_job_process_time_seconds"}],
+      "gridPos": {"h":6,"w":12,"x":0,"y":0}
+    }
+  ]
+}

--- a/monitoring/dashboards/network_health.json
+++ b/monitoring/dashboards/network_health.json
@@ -1,0 +1,15 @@
+{
+  "uid": "network-health",
+  "title": "Network Health",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Peer Count",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "network_peer_count"}],
+      "gridPos": {"h":4,"w":6,"x":0,"y":0}
+    }
+  ]
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+rule_files:
+  - /etc/prometheus/rules/alert.rules.yml
+
+scrape_configs:
+  - job_name: 'icn-node'
+    static_configs:
+      - targets: ['localhost:7845']
+    metrics_path: '/metrics'

--- a/monitoring/provisioning/dashboards.yml
+++ b/monitoring/provisioning/dashboards.yml
@@ -1,0 +1,7 @@
+dashboardProviders:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/rules/alert.rules.yml
+++ b/monitoring/rules/alert.rules.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: icn-alerts
+    rules:
+      - alert: NodeDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "ICN node down"
+          description: "The node {{ $labels.instance }} is not responding."


### PR DESCRIPTION
## Summary
- add `docker-compose-monitoring.yml` for Prometheus, Grafana and Alertmanager
- provide example dashboards and alert rules
- document standalone monitoring stack in onboarding and deployment guides

## Testing
- `cargo fmt --all -- --check` *(fails: found formatting differences)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to complete due to timeout)*
- `cargo test --all-features --workspace` *(failed to complete due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68709271bf648324a36e74bac00d0932