### PR TITLE
Fix job assignment cost

### DIFF
--- a/crates/icn-runtime/src/context/mesh_network.rs
+++ b/crates/icn-runtime/src/context/mesh_network.rs
@@ -25,6 +25,7 @@ use icn_network::libp2p_service::Libp2pNetworkService as ActualLibp2pNetworkServ
 pub struct JobAssignmentNotice {
     pub job_id: JobId,
     pub executor_did: Did,
+    pub agreed_cost_mana: u64,
 }
 
 /// Local mesh submit receipt message.
@@ -260,7 +261,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
         let assignment_message = MeshJobAssignmentMessage {
             job_id: notice.job_id.clone().into(),
             executor_did: notice.executor_did.clone(),
-            agreed_cost_mana: PROPOSAL_COST_MANA,
+            agreed_cost_mana: notice.agreed_cost_mana,
             completion_deadline: current_timestamp() + 3600,
             manifest_cid: None,
         };

--- a/crates/icn-runtime/src/context/mod.rs
+++ b/crates/icn-runtime/src/context/mod.rs
@@ -25,6 +25,7 @@ pub use mesh_network::{
 };
 pub use runtime_context::{
     RuntimeContext, RuntimeContextParams, MeshNetworkServiceType, CreateProposalPayload, CastVotePayload, CloseProposalResult,
+    MANA_MAX_CAPACITY_KEY,
 };
 pub use service_config::{ServiceConfig, ServiceConfigBuilder, ServiceEnvironment};
 pub use signers::{Ed25519Signer, HsmKeyStore, Signer, StubSigner};

--- a/crates/icn-runtime/tests/cross_node_job_execution.rs
+++ b/crates/icn-runtime/tests/cross_node_job_execution.rs
@@ -39,13 +39,12 @@ mod runtime_host_abi_tests {
         let base = tmp.into_path();
         let listen: Vec<Multiaddr> = vec!["/ip4/0.0.0.0/tcp/0".parse().unwrap()];
 
+        let signer = Arc::new(icn_runtime::context::StubSigner::new());
         let runtime_ctx = RuntimeContext::new_with_real_libp2p(
             &identity_did_str,
             listen,
             bootstrap_peers,
-            base.join("dag"),
-            base.join("mana"),
-            base.join("reputation"),
+            signer,
         )
         .await
         .map_err(|e| anyhow::anyhow!("Failed to create runtime context: {}", e))?;

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -246,6 +246,7 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let assignment_notice = JobAssignmentNotice {
         job_id: submitted_job_id.clone(),
         executor_did: executor_did.clone(),
+        agreed_cost_mana: job_cost,
     };
     let assignment_result = job_manager_network_stub
         .notify_executor_of_assignment(&assignment_notice)
@@ -877,7 +878,7 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
         MessagePayload::MeshJobAssignment(MeshJobAssignmentMessage {
             job_id: job_id.clone(),
             executor_did: executor_did.clone(),
-            agreed_cost_mana: 0,
+            agreed_cost_mana: test_job.cost_mana,
             completion_deadline: 0,
             manifest_cid: None,
         }),
@@ -891,6 +892,7 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
             if let Some(message) = recv_b.recv().await {
                 if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
                     if assign.job_id == job_id && assign.executor_did == executor_did {
+                        assert_eq!(assign.agreed_cost_mana, test_job.cost_mana);
                         break;
                     }
                 }


### PR DESCRIPTION
## Summary
- track `agreed_cost_mana` in `JobAssignmentNotice`
- propagate actual bid cost when notifying executors
- export `MANA_MAX_CAPACITY_KEY`
- update integration tests to verify assignment cost

## Testing
- `cargo test -p icn-runtime --no-run`
- `cargo test -p icn-runtime --test mesh --no-run`
- `cargo test -p icn-runtime --test cross_node_job_execution --no-run --features enable-libp2p`


------
https://chatgpt.com/codex/tasks/task_e_6870b2e63d4c832485eefd3213e8afa8