### PR TITLE
[node] add test mode flag and network selection

### DIFF
--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -81,7 +81,7 @@ where
     Fut: std::future::Future<Output = Result<T, MeshNetworkError>>,
 {
     use std::time::Duration;
-    let mut breaker = NETWORK_BREAKER.lock().await;
+    let breaker = NETWORK_BREAKER.lock().await;
     breaker
         .call(|| async {
             retry_with_backoff(
@@ -497,7 +497,7 @@ pub async fn send_network_ping(
 
     use std::time::Duration;
     {
-        let mut breaker = NETWORK_BREAKER.lock().await;
+        let breaker = NETWORK_BREAKER.lock().await;
         breaker
             .call(|| async {
                 retry_with_backoff(

--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -77,6 +77,8 @@ pub struct NodeConfig {
     pub bootstrap_peers: Option<Vec<String>>,
     pub enable_p2p: bool,
     pub enable_mdns: bool,
+    /// Force stub services for development and testing
+    pub test_mode: bool,
     pub api_key: Option<String>,
     /// Optional bearer token for Authorization header auth.
     pub auth_token: Option<String>,
@@ -145,6 +147,7 @@ impl Default for NodeConfig {
             bootstrap_peers: None,
             enable_p2p: cfg!(feature = "enable-libp2p"),
             enable_mdns: true, // Enable mDNS by default for local networks
+            test_mode: false,
             api_key: None,
             auth_token: None,
             auth_token_path: None,
@@ -227,6 +230,7 @@ struct FileNodeConfig {
     bootstrap_peers: Option<Vec<String>>,
     enable_p2p: Option<bool>,
     enable_mdns: Option<bool>,
+    test_mode: Option<bool>,
     api_key: Option<String>,
     auth_token: Option<String>,
     auth_token_path: Option<PathBuf>,
@@ -304,6 +308,9 @@ impl NodeConfig {
         }
         if let Some(v) = file.enable_mdns {
             self.enable_mdns = v;
+        }
+        if let Some(v) = file.test_mode {
+            self.test_mode = v;
         }
         if let Some(v) = file.api_key {
             self.api_key = Some(v);
@@ -439,6 +446,7 @@ impl NodeConfig {
         });
         set_from_env!(enable_p2p, "ICN_ENABLE_P2P", |v: &str| v.parse::<bool>());
         set_from_env!(enable_mdns, "ICN_ENABLE_MDNS", |v: &str| v.parse::<bool>());
+        set_from_env!(test_mode, "ICN_TEST_MODE", |v: &str| v.parse::<bool>());
         set_from_env!(open_rate_limit, "ICN_OPEN_RATE_LIMIT", |v: &str| v
             .parse::<u64>());
 
@@ -572,6 +580,9 @@ impl NodeConfig {
         }
         if matches.contains_id("enable_mdns") {
             self.enable_mdns = true;
+        }
+        if cli.test_mode || matches.contains_id("test_mode") {
+            self.test_mode = true;
         }
         if let Some(v) = &cli.api_key {
             self.api_key = Some(v.clone());

--- a/crates/icn-node/tests/network_selection.rs
+++ b/crates/icn-node/tests/network_selection.rs
@@ -1,0 +1,32 @@
+use clap::{CommandFactory, FromArgMatches};
+use icn_node::config::NodeConfig;
+use icn_node::node::{build_network_service, Cli};
+
+#[tokio::test]
+async fn enable_p2p_uses_libp2p() {
+    let args = ["icn-node", "--enable-p2p"];
+    let cmd = Cli::command();
+    let matches = cmd.get_matches_from(args);
+    let cli = Cli::from_arg_matches(&matches).unwrap();
+    let mut cfg = NodeConfig::default();
+    cfg.apply_cli_overrides(&cli, &matches);
+
+    let svc = build_network_service(&cfg).await.unwrap();
+    #[cfg(feature = "enable-libp2p")]
+    assert!(svc
+        .as_any()
+        .is::<icn_network::libp2p_service::Libp2pNetworkService>());
+}
+
+#[tokio::test]
+async fn test_mode_forces_stub() {
+    let args = ["icn-node", "--enable-p2p", "--test-mode"];
+    let cmd = Cli::command();
+    let matches = cmd.get_matches_from(args);
+    let cli = Cli::from_arg_matches(&matches).unwrap();
+    let mut cfg = NodeConfig::default();
+    cfg.apply_cli_overrides(&cli, &matches);
+
+    let svc = build_network_service(&cfg).await.unwrap();
+    assert!(svc.as_any().is::<icn_network::StubNetworkService>());
+}


### PR DESCRIPTION
## Summary
- add `test_mode` configuration flag to force stub services
- add `build_network_service` helper and use it in `run_node`
- add network selection tests for p2p/test-mode behavior
- fix unused mut warnings in network crate

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features --workspace` *(failed: environment timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6870b2e80e0c8324a881093b3a354252