### PR TITLE
[runtime] use actual job cost in assignment

### DIFF
--- a/crates/icn-runtime/src/context/mesh_network.rs
+++ b/crates/icn-runtime/src/context/mesh_network.rs
@@ -25,6 +25,7 @@ use icn_network::libp2p_service::Libp2pNetworkService as ActualLibp2pNetworkServ
 pub struct JobAssignmentNotice {
     pub job_id: JobId,
     pub executor_did: Did,
+    pub agreed_cost_mana: u64,
 }
 
 /// Local mesh submit receipt message.
@@ -260,7 +261,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
         let assignment_message = MeshJobAssignmentMessage {
             job_id: notice.job_id.clone().into(),
             executor_did: notice.executor_did.clone(),
-            agreed_cost_mana: PROPOSAL_COST_MANA,
+            agreed_cost_mana: notice.agreed_cost_mana,
             completion_deadline: current_timestamp() + 3600,
             manifest_cid: None,
         };

--- a/crates/icn-runtime/src/context/stubs.rs
+++ b/crates/icn-runtime/src/context/stubs.rs
@@ -296,9 +296,10 @@ impl MeshNetworkService for StubMeshNetworkService {
         notice: &JobAssignmentNotice,
     ) -> Result<(), HostAbiError> {
         log::debug!(
-            "StubMeshNetworkService: notify_executor_of_assignment called for job {:?} -> executor {}",
+            "StubMeshNetworkService: notify_executor_of_assignment called for job {:?} -> executor {} with cost {}",
             notice.job_id,
-            notice.executor_did
+            notice.executor_did,
+            notice.agreed_cost_mana
         );
         Ok(())
     }

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -246,6 +246,7 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let assignment_notice = JobAssignmentNotice {
         job_id: submitted_job_id.clone(),
         executor_did: executor_did.clone(),
+        agreed_cost_mana: collected_bids[0].price_mana,
     };
     let assignment_result = job_manager_network_stub
         .notify_executor_of_assignment(&assignment_notice)
@@ -877,7 +878,7 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
         MessagePayload::MeshJobAssignment(MeshJobAssignmentMessage {
             job_id: job_id.clone(),
             executor_did: executor_did.clone(),
-            agreed_cost_mana: 0,
+            agreed_cost_mana: test_job.cost_mana,
             completion_deadline: 0,
             manifest_cid: None,
         }),
@@ -890,7 +891,10 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
         loop {
             if let Some(message) = recv_b.recv().await {
                 if let MessagePayload::MeshJobAssignment(assign) = &message.payload {
-                    if assign.job_id == job_id && assign.executor_did == executor_did {
+                    if assign.job_id == job_id
+                        && assign.executor_did == executor_did
+                        && assign.agreed_cost_mana == test_job.cost_mana
+                    {
                         break;
                     }
                 }


### PR DESCRIPTION
## Summary
- include agreed cost in `JobAssignmentNotice`
- forward agreed cost to executors in `notify_executor_of_assignment`
- adjust stub logging for cost
- update job assignment integration tests to validate cost propagation

## Testing
- `cargo fmt -- /workspace/icn-core/crates/icn-runtime/src/context/mesh_network.rs /workspace/icn-core/crates/icn-runtime/src/context/stubs.rs /workspace/icn-core/crates/icn-runtime/tests/integration/cross_node_job_execution.rs /workspace/icn-core/crates/icn-runtime/tests/mesh.rs`

------
https://chatgpt.com/codex/tasks/task_e_6870b2e741f4832488f493b9e043c6f3