### PR TITLE
Add mesh crate integration tests

### DIFF
--- a/crates/icn-mesh/tests/executor.rs
+++ b/crates/icn-mesh/tests/executor.rs
@@ -1,0 +1,91 @@
+use icn_common::Did;
+use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+use icn_mesh::{select_executor, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy};
+use icn_economics::ManaLedger;
+use icn_reputation::InMemoryReputationStore;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Mutex;
+
+struct InMemoryLedger {
+    balances: Mutex<HashMap<Did, u64>>,
+}
+
+impl InMemoryLedger {
+    fn new() -> Self {
+        Self { balances: Mutex::new(HashMap::new()) }
+    }
+}
+
+impl icn_economics::ManaLedger for InMemoryLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        *self.balances.lock().unwrap().get(did).unwrap_or(&0)
+    }
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        self.balances.lock().unwrap().insert(did.clone(), amount);
+        Ok(())
+    }
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let bal = map.get_mut(did).ok_or_else(|| icn_common::CommonError::DatabaseError("account".into()))?;
+        if *bal < amount {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= amount;
+        Ok(())
+    }
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let entry = map.entry(did.clone()).or_insert(0);
+        *entry += amount;
+        Ok(())
+    }
+}
+
+#[test]
+fn executor_selection_prefers_reputation() {
+    let job_id = JobId(icn_common::Cid::new_v1_sha256(0x55, b"job"));
+    let (sk_h, vk_h) = generate_ed25519_keypair();
+    let high = Did::from_str(&did_key_from_verifying_key(&vk_h)).unwrap();
+    let (sk_l, vk_l) = generate_ed25519_keypair();
+    let low = Did::from_str(&did_key_from_verifying_key(&vk_l)).unwrap();
+
+    let rep_store = InMemoryReputationStore::new();
+    rep_store.set_score(high.clone(), 5);
+    rep_store.set_score(low.clone(), 1);
+
+    let ledger = InMemoryLedger::new();
+    ledger.set_balance(&high, 50).unwrap();
+    ledger.set_balance(&low, 50).unwrap();
+
+    let bid_high = MeshJobBid {
+        job_id: job_id.clone(),
+        executor_did: high.clone(),
+        price_mana: 10,
+        resources: Resources::default(),
+        signature: SignatureBytes(vec![]),
+    }
+    .sign(&sk_h)
+    .unwrap();
+    let bid_low = MeshJobBid {
+        job_id: job_id.clone(),
+        executor_did: low.clone(),
+        price_mana: 5,
+        resources: Resources::default(),
+        signature: SignatureBytes(vec![]),
+    }
+    .sign(&sk_l)
+    .unwrap();
+
+    let policy = SelectionPolicy::default();
+    let spec = JobSpec::default();
+    let selected = select_executor(
+        &job_id,
+        &spec,
+        vec![bid_high, bid_low],
+        &policy,
+        &rep_store,
+        &ledger,
+    );
+    assert_eq!(selected.unwrap(), high);
+}

--- a/crates/icn-mesh/tests/job.rs
+++ b/crates/icn-mesh/tests/job.rs
@@ -1,0 +1,25 @@
+use icn_common::{Cid, Did};
+use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+use icn_mesh::{ActualMeshJob, JobId, JobSpec};
+use std::str::FromStr;
+
+#[test]
+fn job_creation_sign_verify() {
+    let (sk, vk) = generate_ed25519_keypair();
+    let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+    let job = ActualMeshJob {
+        id: JobId(Cid::new_v1_sha256(0x55, b"job")),
+        manifest_cid: Cid::new_v1_sha256(0x55, b"manifest"),
+        spec: JobSpec::default(),
+        creator_did: did.clone(),
+        cost_mana: 42,
+        max_execution_wait_ms: None,
+        signature: SignatureBytes(vec![]),
+    };
+    let signed = job.clone().sign(&sk).unwrap();
+    assert!(signed.verify_signature(&vk).is_ok());
+
+    let mut tampered = signed.clone();
+    tampered.cost_mana = 100;
+    assert!(tampered.verify_signature(&vk).is_err());
+}

--- a/crates/icn-mesh/tests/scoring.rs
+++ b/crates/icn-mesh/tests/scoring.rs
@@ -1,0 +1,90 @@
+use icn_common::Did;
+use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+use icn_mesh::{score_bid, JobSpec, MeshJobBid, Resources, SelectionPolicy};
+use icn_economics::ManaLedger;
+use icn_reputation::InMemoryReputationStore;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Mutex;
+
+struct InMemoryLedger {
+    balances: Mutex<HashMap<Did, u64>>,
+}
+
+impl InMemoryLedger {
+    fn new() -> Self {
+        Self { balances: Mutex::new(HashMap::new()) }
+    }
+}
+
+impl icn_economics::ManaLedger for InMemoryLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        *self.balances.lock().unwrap().get(did).unwrap_or(&0)
+    }
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        self.balances.lock().unwrap().insert(did.clone(), amount);
+        Ok(())
+    }
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let bal = map.get_mut(did).ok_or_else(|| icn_common::CommonError::DatabaseError("account".into()))?;
+        if *bal < amount {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= amount;
+        Ok(())
+    }
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let entry = map.entry(did.clone()).or_insert(0);
+        *entry += amount;
+        Ok(())
+    }
+}
+
+#[test]
+fn resource_weight_affects_score() {
+    let (sk_fast, vk_fast) = generate_ed25519_keypair();
+    let fast = Did::from_str(&did_key_from_verifying_key(&vk_fast)).unwrap();
+    let (sk_slow, vk_slow) = generate_ed25519_keypair();
+    let slow = Did::from_str(&did_key_from_verifying_key(&vk_slow)).unwrap();
+
+    let rep_store = InMemoryReputationStore::new();
+    rep_store.set_score(fast.clone(), 1);
+    rep_store.set_score(slow.clone(), 1);
+
+    let ledger = InMemoryLedger::new();
+    ledger.set_balance(&fast, 100).unwrap();
+    ledger.set_balance(&slow, 100).unwrap();
+
+    let spec = JobSpec {
+        required_resources: Resources { cpu_cores: 2, memory_mb: 1024 },
+        ..JobSpec::default()
+    };
+
+    let bid_fast = MeshJobBid {
+        job_id: icn_mesh::JobId(icn_common::Cid::new_v1_sha256(0x55, b"job")),
+        executor_did: fast.clone(),
+        price_mana: 10,
+        resources: Resources { cpu_cores: 4, memory_mb: 4096 },
+        signature: SignatureBytes(vec![]),
+    }
+    .sign(&sk_fast)
+    .unwrap();
+
+    let bid_slow = MeshJobBid {
+        job_id: icn_mesh::JobId(icn_common::Cid::new_v1_sha256(0x55, b"job")),
+        executor_did: slow.clone(),
+        price_mana: 10,
+        resources: Resources { cpu_cores: 1, memory_mb: 512 },
+        signature: SignatureBytes(vec![]),
+    }
+    .sign(&sk_slow)
+    .unwrap();
+
+    let policy = SelectionPolicy { weight_price: 1.0, weight_reputation: 0.0, weight_resources: 10.0 };
+
+    let fast_score = score_bid(&bid_fast, &spec, &policy, &rep_store, ledger.get_balance(&fast));
+    let slow_score = score_bid(&bid_slow, &spec, &policy, &rep_store, ledger.get_balance(&slow));
+    assert!(fast_score > slow_score);
+}

--- a/tests/integration/network_resilience.rs
+++ b/tests/integration/network_resilience.rs
@@ -262,8 +262,6 @@ async fn test_long_partition_circuit_breaker() {
         assert!(interval2 >= interval1);
     }
 }
-<<<<<<< HEAD
-=======
 
 #[tokio::test]
 async fn test_stub_network_breaker_open_close() {
@@ -309,4 +307,3 @@ async fn test_stub_network_breaker_open_close() {
         .expect_err("expected send failure");
     assert!(!matches!(err2, icn_network::MeshNetworkError::Timeout(_)));
 }
->>>>>>> develop


### PR DESCRIPTION
## Summary
- add integration tests for `icn-mesh` covering job creation, executor selection and resource scoring
- fix merge conflict markers in `network_resilience` test

## Testing
- `cargo test -p icn-mesh --test job --test executor --test scoring`

------
https://chatgpt.com/codex/tasks/task_e_68717fdae7c08324931d0094d3889e2f