### PR TITLE
Fix winning bid ID linkage

### DIFF
--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -991,14 +991,16 @@ impl RuntimeContext {
         };
         
         // 6. Find the winning bid
-        let winning_bid = bids.iter()
-            .find(|bid| bid.executor_did == selected_executor)
+        let (winning_index, winning_bid) = bids
+            .iter()
+            .enumerate()
+            .find(|(_, bid)| bid.executor_did == selected_executor)
             .ok_or_else(|| HostAbiError::InternalError("Selected executor bid not found".to_string()))?;
         
         // 7. Create and store assignment
         let assignment = JobAssignment {
             job_id: job_id.clone(),
-            winning_bid_id: "winning_bid".to_string(), // TODO: Use actual bid ID
+            winning_bid_id: format!("bid_{}", winning_index),
             assigned_executor_did: selected_executor.clone(),
             assigned_at: self.time_provider.unix_seconds(),
             final_price_mana: winning_bid.price_mana,

--- a/tests/integration/network_resilience.rs
+++ b/tests/integration/network_resilience.rs
@@ -262,8 +262,6 @@ async fn test_long_partition_circuit_breaker() {
         assert!(interval2 >= interval1);
     }
 }
-<<<<<<< HEAD
-=======
 
 #[tokio::test]
 async fn test_stub_network_breaker_open_close() {
@@ -309,4 +307,3 @@ async fn test_stub_network_breaker_open_close() {
         .expect_err("expected send failure");
     assert!(!matches!(err2, icn_network::MeshNetworkError::Timeout(_)));
 }
->>>>>>> develop


### PR DESCRIPTION
## Summary
- link job assignments to the real winning bid
- clean up merge conflict markers in `network_resilience` test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: writing `&PathBuf` instead of `&Path`, function has too many arguments, and other warnings)*
- `just validate` *(fails: `format` step failed)*

------
https://chatgpt.com/codex/tasks/task_e_68717fd8bbac8324b99591fbde7e18dc