### PR TITLE
[ccl] implement string concat

### DIFF
--- a/icn-ccl/Cargo.toml
+++ b/icn-ccl/Cargo.toml
@@ -69,5 +69,6 @@ tokio = { version = "1.0", features = ["full"] }
 # For temporary DAG stores in integration tests
 icn-dag = { path = "../crates/icn-dag" }
 # Add test dependencies
+wasmtime = { version = "15", features = ["async"] }
 
 

--- a/icn-ccl/src/wasm_backend.rs
+++ b/icn-ccl/src/wasm_backend.rs
@@ -446,8 +446,133 @@ impl WasmBackend {
                         Ok(ValType::I32)
                     }
                     (ValType::I32, ValType::I32, BinaryOperator::Concat) => {
-                        // String concatenation - simplified: combine pointers
+                        // Runtime string concatenation. Strings are stored as
+                        // [len: u32][bytes]. Allocate new memory and copy bytes.
+
+                        let left_ptr = locals.get_or_add("__concat_left", ValType::I32);
+                        instrs.push(Instruction::LocalTee(left_ptr));
+                        let right_ptr = locals.get_or_add("__concat_right", ValType::I32);
+                        instrs.push(Instruction::LocalTee(right_ptr));
+                        instrs.push(Instruction::Drop);
+                        instrs.push(Instruction::Drop);
+
+                        let left_len = locals.get_or_add("__concat_left_len", ValType::I32);
+                        instrs.push(Instruction::LocalGet(left_ptr));
+                        instrs.push(Instruction::I32Load(wasm_encoder::MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        instrs.push(Instruction::LocalSet(left_len));
+
+                        let right_len = locals.get_or_add("__concat_right_len", ValType::I32);
+                        instrs.push(Instruction::LocalGet(right_ptr));
+                        instrs.push(Instruction::I32Load(wasm_encoder::MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        instrs.push(Instruction::LocalSet(right_len));
+
+                        let total_len = locals.get_or_add("__concat_total_len", ValType::I32);
+                        instrs.push(Instruction::LocalGet(left_len));
+                        instrs.push(Instruction::LocalGet(right_len));
                         instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::LocalSet(total_len));
+
+                        let out_ptr = locals.get_or_add("__concat_out_ptr", ValType::I32);
+                        instrs.push(Instruction::GlobalGet(0));
+                        instrs.push(Instruction::LocalTee(out_ptr));
+                        instrs.push(Instruction::LocalGet(total_len));
+                        instrs.push(Instruction::I32Const(4));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::GlobalSet(0));
+
+                        instrs.push(Instruction::LocalGet(out_ptr));
+                        instrs.push(Instruction::LocalGet(total_len));
+                        instrs.push(Instruction::I32Store(wasm_encoder::MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+
+                        let idx = locals.get_or_add("__concat_idx", ValType::I32);
+
+                        instrs.push(Instruction::I32Const(0));
+                        instrs.push(Instruction::LocalSet(idx));
+                        instrs.push(Instruction::Block(wasm_encoder::BlockType::Empty));
+                        instrs.push(Instruction::Loop(wasm_encoder::BlockType::Empty));
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::LocalGet(left_len));
+                        instrs.push(Instruction::I32GeU);
+                        instrs.push(Instruction::BrIf(1));
+                        instrs.push(Instruction::LocalGet(out_ptr));
+                        instrs.push(Instruction::I32Const(4));
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::LocalGet(left_ptr));
+                        instrs.push(Instruction::I32Const(4));
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::I32Load8U(wasm_encoder::MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        instrs.push(Instruction::I32Store8(wasm_encoder::MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::I32Const(1));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::LocalSet(idx));
+                        instrs.push(Instruction::Br(0));
+                        instrs.push(Instruction::End);
+                        instrs.push(Instruction::End);
+
+                        instrs.push(Instruction::I32Const(0));
+                        instrs.push(Instruction::LocalSet(idx));
+                        instrs.push(Instruction::Block(wasm_encoder::BlockType::Empty));
+                        instrs.push(Instruction::Loop(wasm_encoder::BlockType::Empty));
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::LocalGet(right_len));
+                        instrs.push(Instruction::I32GeU);
+                        instrs.push(Instruction::BrIf(1));
+                        instrs.push(Instruction::LocalGet(out_ptr));
+                        instrs.push(Instruction::I32Const(4));
+                        instrs.push(Instruction::LocalGet(left_len));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::LocalGet(right_ptr));
+                        instrs.push(Instruction::I32Const(4));
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::I32Load8U(wasm_encoder::MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        instrs.push(Instruction::I32Store8(wasm_encoder::MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        instrs.push(Instruction::LocalGet(idx));
+                        instrs.push(Instruction::I32Const(1));
+                        instrs.push(Instruction::I32Add);
+                        instrs.push(Instruction::LocalSet(idx));
+                        instrs.push(Instruction::Br(0));
+                        instrs.push(Instruction::End);
+                        instrs.push(Instruction::End);
+
+                        instrs.push(Instruction::LocalGet(out_ptr));
                         Ok(ValType::I32)
                     }
                     _ => Err(CclError::WasmGenerationError(

--- a/icn-ccl/tests/string_concat.rs
+++ b/icn-ccl/tests/string_concat.rs
@@ -1,0 +1,45 @@
+use icn_ccl::compile_ccl_source_to_wasm;
+use wasmtime::{Engine, Linker, Module, Store};
+
+#[test]
+fn concat_literal_strings() {
+    let src = r#"fn run() -> String { return \"foo\" + \"bar\"; }"#;
+    let (wasm, _) = compile_ccl_source_to_wasm(src).expect("compile");
+
+    let engine = Engine::default();
+    let module = Module::new(&engine, &wasm).expect("module");
+
+    let mut linker = Linker::new(&engine);
+    linker
+        .func_wrap("icn", "host_account_get_mana", || -> i64 { 0 })
+        .unwrap();
+    linker
+        .func_wrap("icn", "host_get_reputation", || -> i64 { 0 })
+        .unwrap();
+    linker
+        .func_wrap("icn", "host_submit_mesh_job", |_: i32, _: i32| {})
+        .unwrap();
+    linker
+        .func_wrap("icn", "host_anchor_receipt", |_: i32, _: i32| {})
+        .unwrap();
+
+    let mut store = Store::new(&engine, ());
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("instantiate");
+    let run = instance
+        .get_typed_func::<(), i32>(&mut store, "run")
+        .unwrap();
+    let ptr = run.call(&mut store, ()).expect("run");
+    let memory = instance.get_memory(&mut store, "memory").unwrap();
+
+    let mut len_buf = [0u8; 4];
+    memory.read(&mut store, ptr as usize, &mut len_buf).unwrap();
+    let len = u32::from_le_bytes(len_buf);
+    let mut bytes = vec![0u8; len as usize];
+    memory
+        .read(&mut store, ptr as usize + 4, &mut bytes)
+        .unwrap();
+
+    assert_eq!(std::str::from_utf8(&bytes).unwrap(), "foobar");
+}


### PR DESCRIPTION
## Summary
- implement dynamic string concatenation in CCL WASM backend
- allocate heap memory and copy both strings when using the `+` operator
- add a new test running concatenation of literal strings
- include `wasmtime` as dev dependency for tests

## Testing
- `cargo clippy -p icn-ccl --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-runtime`)*
- `cargo test -p icn-ccl` *(fails: could not compile test `integration_tests`)*
- `cargo test --all-features --workspace` *(fails: could not compile `icn-node`)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718787fa208324963a63833aecc62d