### PR TITLE
Add HTTP API examples

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -15,6 +15,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NodeInfo'
+              example:
+                version: "0.1.0-dev-functional"
+                name: "ICN Node"
+                status_message: "ready"
   /status:
     get:
       summary: Real-time node status
@@ -25,6 +29,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NodeStatus'
+              example:
+                is_online: true
+                peer_count: 3
+                current_block_height: 42
+                version: "0.1.0-dev-functional"
   /health:
     get:
       summary: Health check endpoint
@@ -35,6 +44,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthStatus'
+              example:
+                status: "ok"
+                timestamp: 1728000000
+                uptime_seconds: 3600
+                checks:
+                  runtime: "ok"
+                  dag_store: "ok"
+                  network: "ok"
+                  mana_ledger: "ok"
   /ready:
     get:
       summary: Readiness probe
@@ -45,6 +63,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReadinessStatus'
+              example:
+                ready: true
+                timestamp: 1728000000
+                checks:
+                  can_serve_requests: true
+                  mana_ledger_available: true
+                  dag_store_available: true
+                  network_initialized: true
   /mesh/submit:
     post:
       summary: Submit a mesh job
@@ -54,6 +80,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SubmitJobRequest'
+            example:
+              manifest_cid: "bafyjobmanifest"
+              spec_json:
+                command: "echo hello"
+              cost_mana: 10
       responses:
         '200':
           description: Job created
@@ -64,6 +95,8 @@ paths:
                 properties:
                   job_id:
                     type: string
+              example:
+                job_id: "job-123"
   /mesh/jobs:
     get:
       summary: List mesh computing jobs
@@ -79,6 +112,10 @@ paths:
                     type: array
                     items:
                       type: object
+              example:
+                jobs:
+                  - job_id: "job-123"
+                    status: "Running"
   /mesh/jobs/{job_id}:
     get:
       summary: Get specific job status
@@ -100,6 +137,9 @@ paths:
                     type: string
                   status:
                     type: string
+              example:
+                job_id: "job-123"
+                status: "Completed"
   /mesh/receipts:
     post:
       summary: Submit execution receipt
@@ -109,9 +149,22 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SubmitReceiptRequest'
+            example:
+              job_id: "job-123"
+              executor_did: "did:key:executor"
+              result_cid: "bafyresult"
+              cpu_ms: 150
+              success: true
+              signature_hex: "abcd1234"
       responses:
         '200':
           description: Receipt accepted
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                accepted: true
   /governance/proposals:
     get:
       summary: List governance proposals
@@ -124,6 +177,9 @@ paths:
                 type: array
                 items:
                   type: object
+              example:
+                - proposal_id: "prop-1"
+                  description: "Increase timeout"
   /governance/proposal/{id}:
     get:
       summary: Fetch a proposal
@@ -140,6 +196,10 @@ paths:
             application/json:
               schema:
                 type: object
+              example:
+                proposal_id: "prop-1"
+                description: "Increase timeout"
+                status: "Open"
   /governance/submit:
     post:
       summary: Submit a proposal
@@ -149,6 +209,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SubmitProposalRequest'
+            example:
+              proposer_did: "did:key:alice"
+              proposal: { "type": "ParameterChange" }
+              description: "Increase mesh timeout"
+              duration_secs: 86400
+              quorum: 3
+              threshold: 0.5
       responses:
         '200':
           description: Proposal id
@@ -156,6 +223,7 @@ paths:
             application/json:
               schema:
                 type: string
+              example: "prop-1"
   /governance/vote:
     post:
       summary: Cast a vote
@@ -165,9 +233,19 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CastVoteRequest'
+            example:
+              voter_did: "did:key:alice"
+              proposal_id: "prop-1"
+              vote_option: "Yes"
       responses:
         '200':
           description: Vote accepted
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                accepted: true
   /governance/delegate:
     post:
       summary: Delegate voting power
@@ -177,9 +255,18 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DelegateRequest'
+            example:
+              from_did: "did:key:alice"
+              to_did: "did:key:bob"
       responses:
         '200':
           description: Delegation recorded
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                delegated: true
   /governance/revoke:
     post:
       summary: Revoke a delegation
@@ -189,9 +276,17 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RevokeDelegationRequest'
+            example:
+              from_did: "did:key:alice"
       responses:
         '200':
           description: Delegation revoked
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                revoked: true
   /governance/close:
     post:
       summary: Close voting
@@ -201,9 +296,20 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ProposalIdPayload'
+            example:
+              proposal_id: "prop-1"
       responses:
         '200':
           description: Vote closed
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                status: "Accepted"
+                yes: 2
+                no: 0
+                abstain: 1
   /governance/execute:
     post:
       summary: Execute proposal
@@ -213,9 +319,17 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ProposalIdPayload'
+            example:
+              proposal_id: "prop-1"
       responses:
         '200':
           description: Execution result
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                executed: true
   /dag/put:
     post:
       summary: Store data in DAG
@@ -225,6 +339,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DagBlockPayload'
+            example:
+              data: "aGVsbG8="
       responses:
         '200':
           description: CID string
@@ -232,6 +348,7 @@ paths:
             application/json:
               schema:
                 type: string
+              example: "bafyblockcid"
   /dag/get:
     post:
       summary: Retrieve data from DAG
@@ -241,6 +358,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CidRequest'
+            example:
+              cid: "bafyblockcid"
       responses:
         '200':
           description: Data block
@@ -248,6 +367,7 @@ paths:
             application/json:
               schema:
                 type: string
+              example: "aGVsbG8="
   /dag/meta:
     post:
       summary: Retrieve DAG metadata
@@ -257,6 +377,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CidRequest'
+            example:
+              cid: "bafyblockcid"
       responses:
         '200':
           description: Metadata
@@ -264,6 +386,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DagBlockMetadata'
+              example:
+                size: 1024
+                timestamp: 1728000000
+                author_did: "did:key:alice"
+                links: []
   /dag/pin:
     post:
       summary: Pin a DAG block
@@ -273,6 +400,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PinRequest'
+            example:
+              cid: "bafyblockcid"
+              ttl: 3600
       responses:
         '200':
           description: Pinned
@@ -280,6 +410,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Cid'
+              example:
+                version: 1
+                codec: 0
+                hash_alg: 1
+                hash_bytes: "AAEC"
   /dag/unpin:
     post:
       summary: Unpin a DAG block
@@ -289,6 +424,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CidRequest'
+            example:
+              cid: "bafyblockcid"
       responses:
         '200':
           description: Unpinned
@@ -296,6 +433,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Cid'
+              example:
+                version: 1
+                codec: 0
+                hash_alg: 1
+                hash_bytes: "AAEC"
   /dag/prune:
     post:
       summary: Prune unpinned blocks
@@ -305,9 +447,16 @@ paths:
           application/json:
             schema:
               type: object
+            example: {}
       responses:
         '200':
           description: Pruned
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                pruned: true
   /network/local-peer-id:
     get:
       summary: Show local peer ID
@@ -321,6 +470,8 @@ paths:
                 properties:
                   peer_id:
                     type: string
+              example:
+                peer_id: "12D3KooW..."
   /network/connect:
     post:
       summary: Connect to a peer
@@ -330,9 +481,17 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PeerPayload'
+            example:
+              peer: "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW..."
       responses:
         '200':
           description: Connection result
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                connected: true
   /network/peers:
     get:
       summary: List network peers
@@ -345,6 +504,9 @@ paths:
                 type: array
                 items:
                   type: string
+              example:
+                - "12D3KooWpeer1"
+                - "12D3KooWpeer2"
   /transaction/submit:
     post:
       summary: Submit a transaction
@@ -354,6 +516,16 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Transaction'
+            example:
+              id: "tx-1"
+              timestamp: 1728000000
+              sender_did: "did:key:alice"
+              recipient_did: "did:key:bob"
+              payload_type: "Transfer"
+              payload: "AAEC"
+              nonce: 1
+              mana_limit: 100
+              mana_price: 1
       responses:
         '200':
           description: Transaction id
@@ -361,6 +533,7 @@ paths:
             application/json:
               schema:
                 type: string
+              example: "tx-1"
   /data/query:
     post:
       summary: Query data
@@ -370,6 +543,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CidRequest'
+            example:
+              cid: "bafyblockcid"
       responses:
         '200':
           description: Query results
@@ -377,6 +552,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DagBlock'
+              example:
+                cid:
+                  version: 1
+                  codec: 0
+                  hash_alg: 1
+                  hash_bytes: "AAEC"
+                data: "aGVsbG8="
   /contracts:
     post:
       summary: Upload WASM contract
@@ -386,6 +568,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ContractSourcePayload'
+            example:
+              source: "(module ...)"
       responses:
         '200':
           description: Upload result
@@ -396,6 +580,8 @@ paths:
                 properties:
                   manifest_cid:
                     type: string
+              example:
+                manifest_cid: "bafycontractmanifest"
   /federation/peers:
     get:
       summary: List federation peers
@@ -408,6 +594,9 @@ paths:
                 type: array
                 items:
                   type: string
+              example:
+                - "12D3KooWpeer1"
+                - "12D3KooWpeer2"
     post:
       summary: Add federation peer
       requestBody:
@@ -416,6 +605,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/AddPeerPayload'
+            example:
+              peer: "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW..."
       responses:
         '200':
           description: Added
@@ -426,6 +617,8 @@ paths:
                 properties:
                   peer:
                     type: string
+              example:
+                peer: "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW..."
   /federation/join:
     post:
       summary: Join a federation
@@ -435,6 +628,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PeerPayload'
+            example:
+              peer: "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW..."
       responses:
         '200':
           description: Joined
@@ -445,6 +640,8 @@ paths:
                 properties:
                   joined:
                     type: string
+              example:
+                joined: "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW..."
   /federation/leave:
     post:
       summary: Leave the federation
@@ -454,6 +651,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PeerPayload'
+            example:
+              peer: "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW..."
       responses:
         '200':
           description: Left
@@ -464,6 +663,8 @@ paths:
                 properties:
                   left:
                     type: string
+              example:
+                left: "/ip4/127.0.0.1/tcp/4001/p2p/12D3KooW..."
   /federation/status:
     get:
       summary: Current federation status
@@ -474,6 +675,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FederationStatus'
+              example:
+                peer_count: 3
+                peers:
+                  - "12D3KooWpeer1"
+                  - "12D3KooWpeer2"
+                  - "12D3KooWpeer3"
   /metrics:
     get:
       summary: Prometheus metrics
@@ -484,6 +691,9 @@ paths:
             text/plain:
               schema:
                 type: string
+              example: |
+                # HELP icn_requests_total Total HTTP requests
+                icn_requests_total{path="/info"} 5
 components:
   schemas:
     NodeInfo:


### PR DESCRIPTION
## Summary
- add request/response examples for every endpoint in `docs/API.md`
- embed example payloads in `docs/openapi.yaml`

## Testing
- `just validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68719d70c85c8324ba42691aefadf341