### PR TITLE
Add generate_ccl_job_spec utility

### DIFF
--- a/icn-ccl/Cargo.toml
+++ b/icn-ccl/Cargo.toml
@@ -38,6 +38,10 @@ path = "test_cooperative_contracts.rs"
 name = "test_individual_contracts"
 path = "test_individual_contracts.rs"
 
+[[bin]]
+name = "generate_ccl_job_spec"
+path = "src/bin/generate_ccl_job_spec.rs"
+
 
 [dependencies]
 pest = "2.7" # Or the version you intend to use
@@ -53,6 +57,8 @@ sha2 = "0.10"
 # WASM generation
 wasm-encoder = "0.233"
 wasmparser = "0.121"
+# HTTP client for job spec generator
+reqwest = { workspace = true, features = ["blocking"] }
 # wasm-tools = "1.208"  # Example, for WASM manipulation/validation
 
 # Dependency for icn-common if metadata uses Did, Cid etc.

--- a/icn-ccl/README.md
+++ b/icn-ccl/README.md
@@ -69,6 +69,18 @@ cargo run -p icn-cli -- --api-url http://localhost:7845 submit-job \
   '{"manifest_cid":"CID_FROM_UPLOAD","spec_json":{},"cost_mana":0}'
 ```
 
+### Utility: `generate_ccl_job_spec`
+
+For quick testing you can upload a compiled `.wasm` file and produce a
+`ccl_job_spec.json` in one step:
+
+```bash
+cargo run -p icn-ccl --bin generate_ccl_job_spec -- path/to/policy.wasm http://localhost:7845
+```
+
+The file will contain a job specification referencing the returned CID and
+requesting minimal resources.
+
 ### Included Governance Examples
 
 Several example contracts live in `examples/`:

--- a/icn-ccl/src/bin/generate_ccl_job_spec.rs
+++ b/icn-ccl/src/bin/generate_ccl_job_spec.rs
@@ -1,0 +1,54 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+use icn_common::parse_cid_from_string;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct DagBlockPayload {
+    data: Vec<u8>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        eprintln!("Usage: {} <wasm-file> <node-api-url>", args[0]);
+        std::process::exit(1);
+    }
+    let wasm_path = PathBuf::from(&args[1]);
+    let api_url = args[2].trim_end_matches('/');
+
+    let wasm_bytes = std::fs::read(&wasm_path)?;
+    let payload = DagBlockPayload { data: wasm_bytes };
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(format!("{}/dag/put", api_url))
+        .json(&payload)
+        .send()?;
+
+    if !resp.status().is_success() {
+        return Err(format!("dag/put failed: {}", resp.status()).into());
+    }
+
+    let cid_str: String = resp.json()?;
+    let _cid =
+        parse_cid_from_string(&cid_str).map_err(|e| format!("Invalid CID returned: {}", e))?;
+
+    let spec = serde_json::json!({
+        "manifest_cid": cid_str,
+        "spec_json": {
+            "kind": "CclWasm",
+            "inputs": [],
+            "outputs": [],
+            "required_resources": {"cpu_cores": 1, "memory_mb": 64}
+        },
+        "cost_mana": 0
+    });
+
+    let mut file = File::create("ccl_job_spec.json")?;
+    file.write_all(serde_json::to_string_pretty(&spec)?.as_bytes())?;
+    println!("Generated ccl_job_spec.json");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a small utility that uploads a WASM file and produces a default job spec
- register the binary in Cargo.toml
- document usage of `generate_ccl_job_spec` in the icn-ccl README

## Testing
- `cargo test -p icn-ccl --lib --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68719eb9692c8324b5922b69c0b5364a