### PR TITLE
[mesh] latency-aware executor selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ devnet, and expanded security guidance.
 - Introduced `icn-reputation` crate providing `ReputationStore` trait and in-memory implementation.
 - Multi-node CLI with libp2p networking and bootstrap peer discovery.
 - Cross-node mesh job execution pipeline with signed receipts anchored to the DAG.
+- Latency-aware executor selection via `LatencyStore` and updated `select_executor`.
 - HTTP gateway enabling REST job submission and status queries.
 - Containerized 3-node federation devnet with Docker and integration tests.
 - `Ed25519Signer` replaces `StubSigner` for production runtime; tests may continue using `StubSigner`.

--- a/crates/icn-mesh/benches/select_executor.rs
+++ b/crates/icn-mesh/benches/select_executor.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, BatchSize, Benchmark
 use icn_common::{Cid, Did};
 use icn_economics::ManaLedger;
 use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
-use icn_mesh::{select_executor, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy};
+use icn_mesh::{select_executor, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy, LatencyStore};
 use icn_reputation::InMemoryReputationStore;
 use std::str::FromStr;
 
@@ -11,6 +11,25 @@ use std::sync::RwLock;
 
 struct BenchLedger {
     inner: RwLock<std::collections::HashMap<Did, u64>>,
+}
+
+struct BenchLatency {
+    inner: std::sync::RwLock<std::collections::HashMap<Did, u64>>,
+}
+
+impl BenchLatency {
+    fn new() -> Self {
+        Self { inner: std::sync::RwLock::new(std::collections::HashMap::new()) }
+    }
+    fn set_latency(&self, did: Did, latency: u64) {
+        self.inner.write().unwrap().insert(did, latency);
+    }
+}
+
+impl LatencyStore for BenchLatency {
+    fn get_latency(&self, did: &Did) -> Option<u64> {
+        self.inner.read().unwrap().get(did).cloned()
+    }
 }
 impl BenchLedger {
     fn new() -> Self {
@@ -58,11 +77,13 @@ fn bench_select_executor(c: &mut Criterion) {
             let rep_store = InMemoryReputationStore::new();
             let ledger = BenchLedger::new();
             let mut bids = Vec::with_capacity(n);
+            let latency = BenchLatency::new();
             for i in 0..n {
                 let (_sk, vk) = generate_ed25519_keypair();
                 let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
                 rep_store.set_score(did.clone(), i as u64);
                 ledger.set_balance(&did, 100).unwrap();
+                latency.set_latency(did.clone(), (i % 10 + 1) as u64);
                 bids.push(MeshJobBid {
                     job_id: job_id.clone(),
                     executor_did: did,
@@ -78,7 +99,13 @@ fn bench_select_executor(c: &mut Criterion) {
                 || bids.clone(),
                 |bids_vec| {
                     black_box(select_executor(
-                        &job_id, &spec, bids_vec, &policy, &rep_store, &ledger,
+                        &job_id,
+                        &spec,
+                        bids_vec,
+                        &policy,
+                        &rep_store,
+                        &ledger,
+                        &latency,
                     ));
                 },
                 BatchSize::SmallInput,

--- a/tests/integration/reputation_persistence.rs
+++ b/tests/integration/reputation_persistence.rs
@@ -55,6 +55,9 @@ mod reputation_persistence {
             signature: SignatureBytes(Vec::new()),
         };
 
+        let latency = icn_mesh::tests::InMemoryLatencyStore::new();
+        latency.set_latency(did_a.clone(), 5);
+        latency.set_latency(did_b.clone(), 20);
         let selected = select_executor(
             &job_id,
             &JobSpec::Echo { payload: "persist".into() },
@@ -62,6 +65,7 @@ mod reputation_persistence {
             &SelectionPolicy::default(),
             &reopened,
             &ledger,
+            &latency,
         )
         .expect("executor selected");
 
@@ -195,6 +199,9 @@ mod reputation_persistence_sqlite {
             signature: SignatureBytes(Vec::new()),
         };
 
+        let latency = icn_mesh::tests::InMemoryLatencyStore::new();
+        latency.set_latency(did_a.clone(), 5);
+        latency.set_latency(did_b.clone(), 20);
         let selected = select_executor(
             &job_id,
             &JobSpec::Echo { payload: "persist".into() },
@@ -202,6 +209,7 @@ mod reputation_persistence_sqlite {
             &SelectionPolicy::default(),
             &reopened,
             &ledger,
+            &latency,
         )
         .expect("executor selected");
 
@@ -297,6 +305,9 @@ mod reputation_persistence_rocks {
             signature: SignatureBytes(Vec::new()),
         };
 
+        let latency = icn_mesh::tests::InMemoryLatencyStore::new();
+        latency.set_latency(did_a.clone(), 5);
+        latency.set_latency(did_b.clone(), 20);
         let selected = select_executor(
             &job_id,
             &JobSpec::Echo { payload: "persist".into() },
@@ -304,6 +315,7 @@ mod reputation_persistence_rocks {
             &SelectionPolicy::default(),
             &reopened,
             &ledger,
+            &latency,
         )
         .expect("executor selected");
 


### PR DESCRIPTION
## Summary
- add `LatencyStore` trait with default `NoOpLatencyStore`
- incorporate latency scoring into `select_executor`
- update runtime context and tests to supply latency data
- extend benchmarks and tests with stub latency stores
- document the new feature in CHANGELOG

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: couldn't finish due to network restrictions)*
- `cargo test --all-features --workspace` *(failed: couldn't finish due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6871a6eed9b083249b881a1325ba91f2