### PR TITLE
[dag] add root hash tracking

### DIFF
--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -18,6 +18,8 @@ postgres = { version = "0.19", optional = true }
 tokio = { workspace = true, optional = true }
 once_cell = "1.21"
 prometheus-client = "0.22"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -20,6 +20,10 @@ This forms a foundational layer for data representation and exchange within the 
 
 Every block stored in a DAG backend can have associated metadata indicating whether it is pinned and an optional TTL (expiration timestamp). Pinned blocks are preserved during pruning even if their TTL has passed. TTL values are expressed as seconds since the Unix epoch and may be updated after a block is stored. Implementations provide `pin_block`, `unpin_block`, and `prune_expired` to manage this metadata and remove stale content.
 
+## Synchronization Root
+
+Whenever blocks are added or removed, file‑based stores compute a Merkle root hash from the set of top‑level CIDs and persist it in `dag.root` inside the DAG directory. This snapshot root can be read via `current_root()` to verify two nodes are synchronized.
+
 ## Public API Style
 
 The API style prioritizes:

--- a/crates/icn-dag/tests/root.rs
+++ b/crates/icn-dag/tests/root.rs
@@ -1,0 +1,33 @@
+use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did};
+use icn_dag::compute_dag_root;
+
+fn make_block(id: &str, links: Vec<DagLink>) -> DagBlock {
+    let data = format!("{id}").into_bytes();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig = None;
+    let cid = compute_merkle_cid(0x71, &data, &links, ts, &author, &sig, &None);
+    DagBlock {
+        cid,
+        data,
+        links,
+        timestamp: ts,
+        author_did: author,
+        signature: sig,
+        scope: None,
+    }
+}
+
+#[test]
+fn root_deterministic() {
+    let child = make_block("child", vec![]);
+    let link = DagLink {
+        cid: child.cid.clone(),
+        name: "child".into(),
+        size: 0,
+    };
+    let parent = make_block("parent", vec![link]);
+    let root1 = compute_dag_root(&[parent.cid.clone()]);
+    let root2 = compute_dag_root(&[parent.cid.clone()]);
+    assert_eq!(root1, root2);
+}


### PR DESCRIPTION
## Summary
- add `compute_dag_root` utility
- write updated root hash to `dag.root`
- expose `current_root()` for file stores
- document synchronization root usage
- unit test for deterministic root computation

## Testing
- `cargo fmt --all -- --check`
- *attempted* `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build too resource intensive)*
- *attempted* `cargo test --all-features --workspace` *(failed: build too resource intensive)*

------
https://chatgpt.com/codex/tasks/task_e_6871a878d1008324a33b6df0ef6cc76c