### PR TITLE
Update bincode error variant in icn-network

### DIFF
--- a/crates/icn-network/Cargo.toml
+++ b/crates/icn-network/Cargo.toml
@@ -14,7 +14,6 @@ icn-identity = { path = "../icn-identity" }
 
 # Core dependencies
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 futures = "0.3"
 log = "0.4"

--- a/crates/icn-network/src/error.rs
+++ b/crates/icn-network/src/error.rs
@@ -1,12 +1,13 @@
 // crates/icn-network/src/error.rs
 
 use thiserror::Error;
+use bincode::Error as BincodeError;
 
 /// Errors that can occur during mesh network operations within the `icn-network` crate.
 #[derive(Debug, Error)]
 pub enum MeshNetworkError {
     #[error("Message serialization/deserialization failed: {0}")]
-    Serialization(#[from] serde_json::Error),
+    Serialization(#[from] BincodeError),
 
     #[error("Failed to send message: {0}")]
     SendFailure(String),


### PR DESCRIPTION
## Summary
- switch network serialization error to use `bincode::Error`
- drop unused `serde_json` dependency

## Testing
- `cargo check -p icn-network`
- `cargo test -p icn-network --lib`


------
https://chatgpt.com/codex/tasks/task_e_6871a86d35348324a0e6aed976f167ef