### PR TITLE
[network] remove unused serde_json

### DIFF
--- a/crates/icn-network/Cargo.toml
+++ b/crates/icn-network/Cargo.toml
@@ -14,7 +14,6 @@ icn-identity = { path = "../icn-identity" }
 
 # Core dependencies
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 futures = "0.3"
 log = "0.4"

--- a/crates/icn-network/src/error.rs
+++ b/crates/icn-network/src/error.rs
@@ -5,9 +5,6 @@ use thiserror::Error;
 /// Errors that can occur during mesh network operations within the `icn-network` crate.
 #[derive(Debug, Error)]
 pub enum MeshNetworkError {
-    #[error("Message serialization/deserialization failed: {0}")]
-    Serialization(#[from] serde_json::Error),
-
     #[error("Failed to send message: {0}")]
     SendFailure(String),
 

--- a/icn-ccl/src/bin/generate_ccl_job_spec.rs
+++ b/icn-ccl/src/bin/generate_ccl_job_spec.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let payload = DagBlockPayload { data: wasm_bytes };
     let client = reqwest::blocking::Client::new();
     let resp = client
-        .post(format!("{}/dag/put", api_url))
+        .post(format!("{api_url}/dag/put"))
         .json(&payload)
         .send()?;
 
@@ -33,8 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let cid_str: String = resp.json()?;
-    let _cid =
-        parse_cid_from_string(&cid_str).map_err(|e| format!("Invalid CID returned: {}", e))?;
+    let _cid = parse_cid_from_string(&cid_str).map_err(|e| format!("Invalid CID returned: {e}"))?;
 
     let spec = serde_json::json!({
         "manifest_cid": cid_str,


### PR DESCRIPTION
## Summary
- drop `serde_json` dependency from `icn-network`
- clean up unused error variant
- fix clippy lint in `generate_ccl_job_spec`

## Testing
- `cargo check -p icn-network`
- `cargo fmt --all -- --check` *(fails: shows diff for many files)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to complete)*
- `cargo test -p icn-network` *(failed: 94 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871a86b9ecc83248cf225c5d2ecc6fe