### PR TITLE
Add DAG root API endpoint

### DIFF
--- a/crates/icn-api/src/dag_trait.rs
+++ b/crates/icn-api/src/dag_trait.rs
@@ -1,0 +1,12 @@
+use async_trait::async_trait;
+use icn_common::{Cid, CommonError};
+
+/// API surface for DAG operations.
+#[async_trait]
+pub trait DagApi {
+    /// Return the current root CID of the node's DAG.
+    ///
+    /// Clients can poll this value to detect when a peer has new history and
+    /// needs state synchronization.
+    async fn get_dag_root(&self) -> Result<Option<Cid>, CommonError>;
+}

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -747,6 +747,7 @@ pub async fn app_router_with_options(
             .route("/dag/put", post(dag_put_handler)) // These will use RT context's DAG store
             .route("/dag/get", post(dag_get_handler)) // These will use RT context's DAG store
             .route("/dag/meta", post(dag_meta_handler))
+            .route("/dag/root", get(dag_root_handler))
             .route("/dag/pin", post(dag_pin_handler))
             .route("/dag/unpin", post(dag_unpin_handler))
             .route("/dag/prune", post(dag_prune_handler))
@@ -871,6 +872,7 @@ pub async fn app_router_from_context(
         .route("/dag/put", post(dag_put_handler))
         .route("/dag/get", post(dag_get_handler))
         .route("/dag/meta", post(dag_meta_handler))
+        .route("/dag/root", get(dag_root_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1137,6 +1139,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         .route("/dag/put", post(dag_put_handler))
         .route("/dag/get", post(dag_get_handler))
         .route("/dag/meta", post(dag_meta_handler))
+        .route("/dag/root", get(dag_root_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1560,6 +1563,21 @@ async fn dag_meta_handler(
             .into_response(),
         Err(e) => map_rust_error_to_json_response(
             format!("DAG meta error: {e}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .into_response(),
+    }
+}
+
+/// GET /dag/root – Retrieve the current DAG root CID.
+/// Clients can compare this value across peers for synchronization.
+async fn dag_root_handler(State(state): State<AppState>) -> impl IntoResponse {
+    let store = state.runtime_context.dag_store.lock().await;
+    match icn_dag::current_root(&*store).await {
+        Ok(Some(cid)) => (StatusCode::OK, Json(cid.to_string())).into_response(),
+        Ok(None) => (StatusCode::OK, Json(String::new())).into_response(),
+        Err(e) => map_rust_error_to_json_response(
+            format!("DAG root error: {e}"),
             StatusCode::INTERNAL_SERVER_ERROR,
         )
         .into_response(),

--- a/crates/icn-node/tests/dag_root.rs
+++ b/crates/icn-node/tests/dag_root.rs
@@ -1,0 +1,55 @@
+use icn_common::parse_cid_from_string;
+use icn_node::app_router;
+use reqwest::Client;
+use tokio::task;
+
+#[tokio::test]
+async fn dag_root_matches_across_nodes() {
+    let listener1 = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr1 = listener1.local_addr().unwrap();
+    let server1 = task::spawn(async move {
+        axum::serve(listener1, app_router().await).await.unwrap();
+    });
+
+    let listener2 = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr2 = listener2.local_addr().unwrap();
+    let server2 = task::spawn(async move {
+        axum::serve(listener2, app_router().await).await.unwrap();
+    });
+
+    let client = Client::new();
+    for addr in &[addr1, addr2] {
+        let resp = client
+            .post(format!("http://{addr}/dag/put"))
+            .json(&serde_json::json!({ "data": [1, 2, 3] }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), reqwest::StatusCode::CREATED);
+    }
+
+    let root1: String = client
+        .get(format!("http://{addr1}/dag/root"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let root2: String = client
+        .get(format!("http://{addr2}/dag/root"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        parse_cid_from_string(&root1).unwrap(),
+        parse_cid_from_string(&root2).unwrap()
+    );
+
+    server1.abort();
+    server2.abort();
+}


### PR DESCRIPTION
## Summary
- expose `current_root` helper in `icn-dag`
- add `DagApi` trait and `DagApiImpl` in `icn-api`
- implement `/dag/root` handler in `icn-node`
- test DAG root equality across nodes

## Testing
- `cargo check -p icn-api`
- `cargo check -p icn-node` *(fails: no field `enable_p2p` on type `&NodeConfig`)*

------
https://chatgpt.com/codex/tasks/task_e_6871a87b45088324a34fd29a308654aa