### PR TITLE
Add async Sqlite reputation store

### DIFF
--- a/crates/icn-reputation/Cargo.toml
+++ b/crates/icn-reputation/Cargo.toml
@@ -11,7 +11,9 @@ icn-identity = { path = "../icn-identity" }
 serde = { version = "1.0", features = ["derive"] }
 sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
-rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
+async-trait = "0.1"
+tokio = { workspace = true, optional = true }
+sqlx = { version = "0.7", optional = true, features = ["runtime-tokio-rustls", "sqlite"] }
 rocksdb = { version = "0.21", optional = true }
 
 [dev-dependencies]
@@ -20,5 +22,6 @@ tempfile = "3"
 [features]
 default = ["persist-sled"]
 persist-sled = ["dep:sled", "dep:bincode"]
-persist-sqlite = ["dep:rusqlite"]
+persist-sqlite = ["dep:sqlx", "async"]
 persist-rocksdb = ["dep:rocksdb", "dep:bincode"]
+async = ["dep:tokio"]

--- a/crates/icn-reputation/src/sqlite_store.rs
+++ b/crates/icn-reputation/src/sqlite_store.rs
@@ -1,62 +1,111 @@
-//! SQLite-backed implementation of the `ReputationStore` trait.
-
-use crate::ReputationStore;
-use icn_common::{CommonError, Did};
-use rusqlite::{Connection, OptionalExtension};
-use std::path::PathBuf;
+//! SQLite-backed implementation of `ReputationStore` using an async connection pool.
 
 #[cfg(feature = "persist-sqlite")]
+use crate::{AsyncReputationStore, ReputationStore};
+#[cfg(all(feature = "persist-sqlite", feature = "async"))]
+use async_trait::async_trait;
+#[cfg(feature = "persist-sqlite")]
+use icn_common::{CommonError, Did};
+#[cfg(feature = "persist-sqlite")]
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+use sqlx::Row;
+#[cfg(feature = "persist-sqlite")]
+use std::path::PathBuf;
+use std::str::FromStr;
+
+#[cfg(feature = "persist-sqlite")]
+#[derive(Debug, Clone)]
 pub struct SqliteReputationStore {
-    path: PathBuf,
+    pool: SqlitePool,
 }
 
 #[cfg(feature = "persist-sqlite")]
 impl SqliteReputationStore {
-    /// Create a SQLite backed store for executor reputation.
-    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
-        let conn = Connection::open(&path)
+    pub async fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let url = format!("sqlite://{}", path.to_string_lossy());
+        let options = SqliteConnectOptions::from_str(&url)
+            .map_err(|e| CommonError::DatabaseError(format!("Invalid DB url: {e}")))?
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect_with(options)
+            .await
             .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS reputation (did TEXT PRIMARY KEY, score INTEGER)",
-            [],
-        )
-        .map_err(|e| CommonError::DatabaseError(format!("Failed to create table: {e}")))?;
-        Ok(Self { path })
+        sqlx::query("CREATE TABLE IF NOT EXISTS reputation (did TEXT PRIMARY KEY, score INTEGER)")
+            .execute(&pool)
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to create table: {e}")))?;
+        Ok(Self { pool })
     }
 
-    fn read_score(&self, did: &Did) -> u64 {
-        let conn = Connection::open(&self.path).expect("open sqlite");
-        conn.query_row(
-            "SELECT score FROM reputation WHERE did=?1",
-            [&did.to_string()],
-            |row| row.get::<_, i64>(0),
-        )
-        .optional()
-        .unwrap_or(None)
-        .unwrap_or(0) as u64
+    async fn read_score(&self, did: &Did) -> Result<u64, CommonError> {
+        let row = sqlx::query("SELECT score FROM reputation WHERE did=?")
+            .bind(did.to_string())
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to read score: {e}")))?;
+        Ok(row.map(|r| r.get::<i64, _>(0) as u64).unwrap_or(0))
     }
 
-    fn write_score(&self, did: &Did, score: u64) {
-        let conn = Connection::open(&self.path).expect("open sqlite");
-        let _ = conn.execute(
-            "INSERT INTO reputation(did, score) VALUES(?1, ?2) \n             ON CONFLICT(did) DO UPDATE SET score=excluded.score",
-            (&did.to_string(), score as i64),
-        );
+    async fn write_score(&self, did: &Did, score: u64) -> Result<(), CommonError> {
+        sqlx::query(
+            "INSERT INTO reputation(did, score) VALUES(?, ?) \
+             ON CONFLICT(did) DO UPDATE SET score=excluded.score",
+        )
+        .bind(did.to_string())
+        .bind(score as i64)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to write score: {e}")))?;
+        Ok(())
     }
 }
 
 #[cfg(feature = "persist-sqlite")]
 impl ReputationStore for SqliteReputationStore {
     fn get_reputation(&self, did: &Did) -> u64 {
-        self.read_score(did)
+        tokio::runtime::Handle::try_current()
+            .map(|h| h.block_on(self.read_score(did)))
+            .unwrap_or_else(|_| {
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(self.read_score(did))
+            })
+            .unwrap_or(0)
     }
 
     fn record_execution(&self, executor: &Did, success: bool, cpu_ms: u64) {
-        let current = self.read_score(executor);
+        let fut = async {
+            let current = self.read_score(executor).await.unwrap_or(0);
+            let base: i64 = if success { 1 } else { -1 };
+            let delta: i64 = base + (cpu_ms / 1000) as i64;
+            let updated = (current as i64) + delta;
+            let new_score = if updated < 0 { 0 } else { updated as u64 };
+            let _ = self.write_score(executor, new_score).await;
+        };
+        match tokio::runtime::Handle::try_current() {
+            Ok(h) => h.block_on(fut),
+            Err(_) => {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                rt.block_on(fut);
+            }
+        }
+    }
+}
+
+#[cfg(all(feature = "persist-sqlite", feature = "async"))]
+#[async_trait]
+impl AsyncReputationStore for SqliteReputationStore {
+    async fn get_reputation(&self, did: &Did) -> u64 {
+        self.read_score(did).await.unwrap_or(0)
+    }
+
+    async fn record_execution(&self, executor: &Did, success: bool, cpu_ms: u64) {
+        let current = self.read_score(executor).await.unwrap_or(0);
         let base: i64 = if success { 1 } else { -1 };
         let delta: i64 = base + (cpu_ms / 1000) as i64;
         let updated = (current as i64) + delta;
         let new_score = if updated < 0 { 0 } else { updated as u64 };
-        self.write_score(executor, new_score);
+        let _ = self.write_score(executor, new_score).await;
     }
 }

--- a/crates/icn-reputation/tests/sqlite.rs
+++ b/crates/icn-reputation/tests/sqlite.rs
@@ -3,25 +3,25 @@ mod tests {
     use icn_common::Did;
     use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair};
     use icn_reputation::sqlite_store::SqliteReputationStore;
-    use icn_reputation::ReputationStore;
+    use icn_reputation::AsyncReputationStore;
     use std::path::PathBuf;
     use std::str::FromStr;
     use tempfile::tempdir;
 
-    #[test]
-    fn sqlite_round_trip() {
+    #[tokio::test]
+    async fn sqlite_round_trip() {
         let dir = tempdir().unwrap();
         let path: PathBuf = dir.path().join("rep.sqlite");
-        let store = SqliteReputationStore::new(path.clone()).unwrap();
+        let store = SqliteReputationStore::new(path.clone()).await.unwrap();
 
         let (_sk, vk) = generate_ed25519_keypair();
         let did = Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
 
-        store.record_execution(&did, true, 1000);
-        assert_eq!(store.get_reputation(&did), 2);
+        store.record_execution(&did, true, 1000).await;
+        assert_eq!(store.get_reputation(&did).await, 2);
 
         drop(store);
-        let reopened = SqliteReputationStore::new(path).unwrap();
-        assert_eq!(reopened.get_reputation(&did), 2);
+        let reopened = SqliteReputationStore::new(path).await.unwrap();
+        assert_eq!(reopened.get_reputation(&did).await, 2);
     }
 }


### PR DESCRIPTION
## Summary
- implement async SqliteReputationStore using sqlx pool
- add AsyncReputationStore trait and compatibility wrapper
- update tests for async sqlite backend

## Testing
- `cargo test -p icn-reputation --features persist-sqlite,async --quiet`
- `cargo check -p icn-reputation --features persist-sqlite,async --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6871b01385bc8324bd8022b8ca557fb4