### PR TITLE
[dag] shard file store paths

### DIFF
--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -48,6 +48,17 @@ let store = TokioFileDagStore::new(PathBuf::from("./dag")).unwrap();
 let dag_store = Mutex::new(store); // implement AsyncStorageService
 ```
 
+## File Storage Layout
+
+File-based stores shard blocks into subdirectories derived from the CID string.
+Given a CID like `bafy...`, the block will be stored at:
+
+```
+<storage>/<ba>/<fy>/<cid>
+```
+
+This prevents directories from growing unbounded.
+
 ## Running Persistence Tests
 
 Integration tests for each storage backend are gated by their corresponding

--- a/crates/icn-dag/tests/sharded_file.rs
+++ b/crates/icn-dag/tests/sharded_file.rs
@@ -1,0 +1,61 @@
+use icn_common::{compute_merkle_cid, DagBlock, Did};
+use icn_dag::{AsyncStorageService, FileDagStore, StorageService, TokioFileDagStore};
+use tempfile::tempdir;
+
+fn create_block(id: &str) -> DagBlock {
+    let data = format!("data {id}").into_bytes();
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig = None;
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &sig, &None);
+    DagBlock {
+        cid,
+        data,
+        links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig,
+        scope: None,
+    }
+}
+
+#[test]
+fn file_store_sharded_layout() {
+    let dir = tempdir().unwrap();
+    let mut store = FileDagStore::new(dir.path().to_path_buf()).unwrap();
+    let block = create_block("a");
+    store.put(&block).unwrap();
+    let cid_str = block.cid.to_string();
+    let expected = dir
+        .path()
+        .join(&cid_str[0..2])
+        .join(&cid_str[2..4])
+        .join(&cid_str);
+    assert!(expected.exists());
+    assert!(store.contains(&block.cid).unwrap());
+    assert_eq!(store.get(&block.cid).unwrap().unwrap().cid, block.cid);
+    let blocks = store.list_blocks().unwrap();
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].cid, block.cid);
+}
+
+#[cfg(feature = "async")]
+#[tokio::test]
+async fn tokio_file_store_sharded_layout() {
+    let dir = tempdir().unwrap();
+    let mut store = TokioFileDagStore::new(dir.path().to_path_buf()).unwrap();
+    let block = create_block("b");
+    store.put(&block).await.unwrap();
+    let cid_str = block.cid.to_string();
+    let expected = dir
+        .path()
+        .join(&cid_str[0..2])
+        .join(&cid_str[2..4])
+        .join(&cid_str);
+    assert!(expected.exists());
+    assert!(store.contains(&block.cid).await.unwrap());
+    assert_eq!(store.get(&block.cid).await.unwrap().unwrap().cid, block.cid);
+    let blocks = store.list_blocks().await.unwrap();
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].cid, block.cid);
+}

--- a/crates/icn-eventstore/src/lib.rs
+++ b/crates/icn-eventstore/src/lib.rs
@@ -1,6 +1,5 @@
 use icn_common::CommonError;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::marker::PhantomData;
@@ -36,7 +35,7 @@ where
 
     fn query(&self, since: Option<usize>) -> Result<Vec<E>, CommonError> {
         let start = since.unwrap_or(0);
-        Ok(self.events.iter().cloned().skip(start).collect())
+        Ok(self.events.iter().skip(start).cloned().collect())
     }
 }
 


### PR DESCRIPTION
## Summary
- implement CID-based sharding for file DAG stores
- recursively list blocks from nested directories
- add helper for CLI DAG commands to traverse sharded layout
- document sharded layout in README
- cover sharded layout with new tests
- minor cleanup in eventstore

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: large-enum-variant in icn-governance)*
- `cargo test --all-features --workspace` *(fails: unresolved deps in icn-mesh)*
- `cargo test -p icn-ccl`
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871b053b6748324a2627c883e957cdc