### PR TITLE
Switch DAG store to async Postgres

### DIFF
--- a/crates/icn-dag/Cargo.toml
+++ b/crates/icn-dag/Cargo.toml
@@ -14,7 +14,8 @@ sled = { version = "0.34", optional = true }
 bincode = { version = "1.3", optional = true }
 rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
 rocksdb = { version = "0.21", optional = true }
-postgres = { version = "0.19", optional = true }
+tokio-postgres = { version = "0.7", optional = true }
+deadpool-postgres = { version = "0.14", optional = true }
 tokio = { workspace = true, optional = true }
 once_cell = "1.21"
 prometheus-client = "0.22"
@@ -25,7 +26,8 @@ sled = { version = "0.34", optional = false }
 bincode = { version = "1.3", optional = false }
 rusqlite = { version = "0.29", optional = false, features = ["bundled"] }
 rocksdb = { version = "0.21", optional = false }
-postgres = { version = "0.19", optional = false }
+tokio-postgres = { version = "0.7", optional = false }
+deadpool-postgres = { version = "0.14", optional = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "fs", "io-util"] }
 criterion = { version = "0.5", features = ["async"] }
 
@@ -34,5 +36,5 @@ default = ["persist-sled"]
 persist-sled = ["dep:sled", "dep:bincode"]
 persist-sqlite = ["dep:rusqlite"]
 persist-rocksdb = ["dep:rocksdb", "dep:bincode"]
-persist-postgres = ["dep:postgres"]
+persist-postgres = ["dep:tokio-postgres", "dep:deadpool-postgres"]
 async = ["dep:tokio"]

--- a/crates/icn-dag/src/postgres_store.rs
+++ b/crates/icn-dag/src/postgres_store.rs
@@ -1,19 +1,29 @@
-use crate::{BlockMetadata, Cid, CommonError, DagBlock, StorageService};
-use postgres::{Client, NoTls};
+use crate::{AsyncStorageService, BlockMetadata, Cid, CommonError, DagBlock};
+use deadpool_postgres::{Config as PoolConfig, ManagerConfig, Pool, RecyclingMethod};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use tokio_postgres::NoTls;
 
+#[derive(Debug)]
 pub struct PostgresDagStore {
-    client: Mutex<Client>,
+    pool: Pool,
     meta: HashMap<Cid, BlockMetadata>,
 }
 
 impl PostgresDagStore {
     /// Connect to Postgres using the provided connection string.
-    pub fn new(conn_str: &str) -> Result<Self, CommonError> {
-        let mut client = Client::connect(conn_str, NoTls).map_err(|e| {
-            CommonError::DatabaseError(format!("Failed to connect to postgres: {}", e))
-        })?;
+    pub async fn new(conn_str: &str) -> Result<Self, CommonError> {
+        let pg_cfg = conn_str
+            .parse::<tokio_postgres::Config>()
+            .map_err(|e| CommonError::DatabaseError(format!("Invalid connection: {e}")))?;
+        let mgr_cfg = ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
+        };
+        let manager = deadpool_postgres::Manager::from_config(pg_cfg, NoTls, mgr_cfg);
+        let pool = Pool::builder(manager).max_size(16).build().unwrap();
+        let client = pool
+            .get()
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
         client
             .batch_execute(
                 "CREATE TABLE IF NOT EXISTS blocks (
@@ -21,15 +31,16 @@ impl PostgresDagStore {
                     data BYTEA NOT NULL,
                     pinned BOOLEAN NOT NULL DEFAULT FALSE,
                     ttl BIGINT
-                )",
+                );
+                 CREATE INDEX IF NOT EXISTS idx_blocks_pinned_ttl ON blocks (pinned, ttl);",
             )
-            .map_err(|e| CommonError::DatabaseError(format!("Failed to init table: {}", e)))?;
-
-        // Load existing metadata
-        let mut meta = HashMap::new();
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to init table: {e}")))?;
         let rows = client
             .query("SELECT cid, pinned, ttl FROM blocks", &[])
-            .map_err(|e| CommonError::DatabaseError(format!("Failed to load metadata: {}", e)))?;
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to load metadata: {e}")))?;
+        let mut meta = HashMap::new();
         for row in rows {
             let cid_str: String = row.get(0);
             let pinned: bool = row.get(1);
@@ -43,33 +54,24 @@ impl PostgresDagStore {
                 },
             );
         }
-
-        Ok(Self {
-            client: Mutex::new(client),
-            meta,
-        })
+        Ok(Self { pool, meta })
     }
 }
 
-impl StorageService<DagBlock> for PostgresDagStore {
-    fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
+#[async_trait::async_trait]
+impl AsyncStorageService<DagBlock> for PostgresDagStore {
+    async fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
         icn_common::verify_block_integrity(block)?;
         let encoded = serde_json::to_vec(block).map_err(|e| {
-            CommonError::SerializationError(format!(
-                "Failed to serialize block {}: {}",
-                block.cid, e
-            ))
+            CommonError::SerializationError(format!("Failed to serialize block {}: {e}", block.cid))
         })?;
-        let meta = self
-            .meta
-            .get(&block.cid)
-            .cloned()
-            .unwrap_or_default();
-
-        self
-            .client
-            .lock()
-            .expect("mutex poisoned")
+        let meta = self.meta.get(&block.cid).cloned().unwrap_or_default();
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+        client
             .execute(
                 "INSERT INTO blocks (cid, data, pinned, ttl) VALUES ($1, $2, $3, $4)
                  ON CONFLICT (cid) DO UPDATE SET data = EXCLUDED.data, pinned = EXCLUDED.pinned, ttl = EXCLUDED.ttl",
@@ -80,28 +82,31 @@ impl StorageService<DagBlock> for PostgresDagStore {
                     &meta.ttl.map(|t| t as i64),
                 ],
             )
-            .map_err(|e| CommonError::DatabaseError(format!("Failed to store block {}: {}", block.cid, e)))?;
-
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to store block {}: {e}", block.cid)))?;
         self.meta.insert(block.cid.clone(), meta);
         Ok(())
     }
 
-    fn get(&self, cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
-        let row_opt = self
-            .client
-            .lock()
-            .expect("mutex poisoned")
+    async fn get(&self, cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+        let row_opt = client
             .query_opt(
                 "SELECT data FROM blocks WHERE cid = $1",
                 &[&cid.to_string()],
             )
-            .map_err(|e| CommonError::DatabaseError(format!("Query failed: {}", e)))?;
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Query failed: {e}")))?;
         if let Some(row) = row_opt {
             let data: Vec<u8> = row.get(0);
             let block: DagBlock = serde_json::from_slice(&data).map_err(|e| {
                 CommonError::DeserializationError(format!(
-                    "Failed to deserialize block {}: {}",
-                    cid, e
+                    "Failed to deserialize block {}: {e}",
+                    cid
                 ))
             })?;
             if &block.cid != cid {
@@ -116,68 +121,80 @@ impl StorageService<DagBlock> for PostgresDagStore {
         }
     }
 
-    fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
-        self.client
-            .lock()
-            .expect("mutex poisoned")
+    async fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+        client
             .execute("DELETE FROM blocks WHERE cid = $1", &[&cid.to_string()])
+            .await
             .map_err(|e| {
-                CommonError::DatabaseError(format!("Failed to delete block {}: {}", cid, e))
+                CommonError::DatabaseError(format!("Failed to delete block {}: {e}", cid))
             })?;
         self.meta.remove(cid);
         Ok(())
     }
 
-    fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
-        let row = self
-            .client
-            .lock()
-            .expect("mutex poisoned")
+    async fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+        let row = client
             .query_one(
                 "SELECT COUNT(1) FROM blocks WHERE cid = $1",
                 &[&cid.to_string()],
             )
+            .await
             .map_err(|e| {
-                CommonError::DatabaseError(format!("Failed to check block {}: {}", cid, e))
+                CommonError::DatabaseError(format!("Failed to check block {}: {e}", cid))
             })?;
         let count: i64 = row.get(0);
         Ok(count > 0)
     }
 
-    fn list_blocks(&self) -> Result<Vec<DagBlock>, CommonError> {
-        let rows = self
-            .client
-            .lock()
-            .expect("mutex poisoned")
+    async fn list_blocks(&self) -> Result<Vec<DagBlock>, CommonError> {
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+        let rows = client
             .query("SELECT data FROM blocks", &[])
-            .map_err(|e| CommonError::DatabaseError(format!("Query failed: {}", e)))?;
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Query failed: {e}")))?;
         let mut blocks = Vec::new();
         for row in rows {
             let data: Vec<u8> = row.get(0);
             let block: DagBlock = serde_json::from_slice(&data).map_err(|e| {
-                CommonError::DeserializationError(format!("Failed to deserialize block: {}", e))
+                CommonError::DeserializationError(format!("Failed to deserialize block: {e}"))
             })?;
             blocks.push(block);
         }
         Ok(blocks)
     }
 
-    fn pin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+    async fn pin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
         match self.meta.get_mut(cid) {
             Some(m) => {
                 m.pinned = true;
-                self
-                    .client
-                    .lock()
-                    .expect("mutex poisoned")
+                let client = self
+                    .pool
+                    .get()
+                    .await
+                    .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+                client
                     .execute(
                         "UPDATE blocks SET pinned = true WHERE cid = $1",
                         &[&cid.to_string()],
                     )
-                    .map_err(|e| CommonError::DatabaseError(format!(
-                        "Failed to pin block {}: {}",
-                        cid, e
-                    )))?;
+                    .await
+                    .map_err(|e| {
+                        CommonError::DatabaseError(format!("Failed to pin block {}: {e}", cid))
+                    })?;
                 Ok(())
             }
             None => Err(CommonError::ResourceNotFound(format!(
@@ -187,22 +204,24 @@ impl StorageService<DagBlock> for PostgresDagStore {
         }
     }
 
-    fn unpin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
+    async fn unpin_block(&mut self, cid: &Cid) -> Result<(), CommonError> {
         match self.meta.get_mut(cid) {
             Some(m) => {
                 m.pinned = false;
-                self
-                    .client
-                    .lock()
-                    .expect("mutex poisoned")
+                let client = self
+                    .pool
+                    .get()
+                    .await
+                    .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+                client
                     .execute(
                         "UPDATE blocks SET pinned = false WHERE cid = $1",
                         &[&cid.to_string()],
                     )
-                    .map_err(|e| CommonError::DatabaseError(format!(
-                        "Failed to unpin block {}: {}",
-                        cid, e
-                    )))?;
+                    .await
+                    .map_err(|e| {
+                        CommonError::DatabaseError(format!("Failed to unpin block {}: {e}", cid))
+                    })?;
                 Ok(())
             }
             None => Err(CommonError::ResourceNotFound(format!(
@@ -212,53 +231,56 @@ impl StorageService<DagBlock> for PostgresDagStore {
         }
     }
 
-    fn prune_expired(&mut self, now: u64) -> Result<Vec<Cid>, CommonError> {
+    async fn prune_expired(&mut self, now: u64) -> Result<Vec<Cid>, CommonError> {
         let mut removed = Vec::new();
-
-        let rows = self
-            .client
-            .lock()
-            .expect("mutex poisoned")
+        let client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+        let rows = client
             .query(
                 "SELECT cid FROM blocks WHERE pinned = false AND ttl IS NOT NULL AND ttl <= $1",
                 &[&(now as i64)],
             )
-            .map_err(|e| CommonError::DatabaseError(format!("GC query failed: {}", e)))?;
-
+            .await
+            .map_err(|e| CommonError::DatabaseError(format!("GC query failed: {e}")))?;
         for row in rows {
             let cid_str: String = row.get(0);
             let cid = icn_common::parse_cid_from_string(&cid_str)?;
-            self
-                .client
-                .lock()
-                .expect("mutex poisoned")
+            client
                 .execute("DELETE FROM blocks WHERE cid = $1", &[&cid_str])
+                .await
                 .map_err(|e| {
-                    CommonError::DatabaseError(format!("Failed to delete block {}: {}", cid, e))
+                    CommonError::DatabaseError(format!("Failed to delete block {}: {e}", cid))
                 })?;
             self.meta.remove(&cid);
             removed.push(cid);
         }
-
         Ok(removed)
     }
 
-    fn set_ttl(&mut self, cid: &Cid, ttl: Option<u64>) -> Result<(), CommonError> {
+    async fn set_ttl(&mut self, cid: &Cid, ttl: Option<u64>) -> Result<(), CommonError> {
         match self.meta.get_mut(cid) {
             Some(m) => {
                 m.ttl = ttl;
-                self
-                    .client
-                    .lock()
-                    .expect("mutex poisoned")
+                let client = self
+                    .pool
+                    .get()
+                    .await
+                    .map_err(|e| CommonError::DatabaseError(format!("Pool error: {e}")))?;
+                client
                     .execute(
                         "UPDATE blocks SET ttl = $1 WHERE cid = $2",
                         &[&ttl.map(|t| t as i64), &cid.to_string()],
                     )
-                    .map_err(|e| CommonError::DatabaseError(format!(
-                        "Failed to update TTL for block {}: {}",
-                        cid, e
-                    )))?;
+                    .await
+                    .map_err(|e| {
+                        CommonError::DatabaseError(format!(
+                            "Failed to update TTL for block {}: {e}",
+                            cid
+                        ))
+                    })?;
                 Ok(())
             }
             None => Err(CommonError::ResourceNotFound(format!(
@@ -268,7 +290,7 @@ impl StorageService<DagBlock> for PostgresDagStore {
         }
     }
 
-    fn get_metadata(&self, cid: &Cid) -> Result<Option<BlockMetadata>, CommonError> {
+    async fn get_metadata(&self, cid: &Cid) -> Result<Option<BlockMetadata>, CommonError> {
         Ok(self.meta.get(cid).cloned())
     }
 

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -583,6 +583,7 @@ pub async fn app_router_with_options(
     });
     let dag_store_for_rt = cfg
         .init_dag_store()
+        .await
         .expect("Failed to init DAG store for test context");
 
     #[cfg(feature = "enable-libp2p")]
@@ -994,7 +995,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
     info!("Starting {} with DID: {}", node_name, node_did);
 
     // --- Create RuntimeContext with Networking ---
-    let dag_store_for_rt = match config.init_dag_store() {
+    let dag_store_for_rt = match config.init_dag_store().await {
         Ok(store) => store,
         Err(e) => {
             error!("Failed to initialize DAG store: {}", e);


### PR DESCRIPTION
## Summary
- replace `postgres` with `tokio-postgres` and `deadpool-postgres`
- rewrite Postgres DAG store to be async and pooled
- update postgres tests for async usage
- initialize Postgres store asynchronously in node config
- await async store creation in runtime

## Testing
- `cargo test -p icn-dag --no-default-features --features persist-postgres,async --no-run` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6871b01579f483248ed61b28ed8c81ca