### PR TITLE
Add resource token docs and API

### DIFF
--- a/ICN_API_REFERENCE.md
+++ b/ICN_API_REFERENCE.md
@@ -36,6 +36,11 @@
 | `/network/connect` | POST | Connect to a peer | ✅ Working |
 | `/network/peers` | GET | List network peers | ✅ Working |
 | `/transaction/submit` | POST | Submit a transaction | ✅ Working |
+| `/tokens/classes` | GET | List token classes | 🚧 Experimental |
+| `/tokens/class` | POST | Create a token class | 🚧 Experimental |
+| `/tokens/mint` | POST | Mint resource tokens | 🚧 Experimental |
+| `/tokens/transfer` | POST | Transfer resource tokens | 🚧 Experimental |
+| `/tokens/burn` | POST | Burn resource tokens | 🚧 Experimental |
 | `/data/query` | POST | Query data | ✅ Working |
 | `/contracts` | POST | Upload WASM contract | ✅ Working |
 | `/federation/peers` | GET | List federation peers | ✅ Working |

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ More detailed information can be found in the `README.md` file within each crate
 * [RFC Index](icn-docs/rfcs/README.md) – design proposals and specifications
 * [RFC 0010: ICN Governance Core](icn-docs/rfcs/0010-governance-core.md) – governance framework
 * [Mana Policies](docs/mana_policies.md) – economic policy examples
+* [Resource Tokens](docs/resource_tokens.md) – token classes and mana integration
 * [CCL Language Reference](docs/CCL_LANGUAGE_REFERENCE.md) – full syntax guide
 * [CCL Examples](icn-ccl/examples/) – governance contract templates
 * [Contract Creation Guide](docs/howto-create-contract.md) – compile and submit CCL jobs

--- a/docs/API.md
+++ b/docs/API.md
@@ -84,6 +84,16 @@ curl -X POST https://localhost:8080/dag/unpin \
 |--------|------|-------------|---------------|
 | POST | `/transaction/submit` | Submit a signed transaction to the runtime | Yes |
 
+## Resource Token Endpoints
+
+| Method | Path | Description | Auth Required |
+|--------|------|-------------|---------------|
+| GET | `/tokens/classes` | List available token classes | Yes |
+| POST | `/tokens/class` | Create a new token class | Yes |
+| POST | `/tokens/mint` | Mint resource tokens | Yes |
+| POST | `/tokens/transfer` | Transfer resource tokens | Yes |
+| POST | `/tokens/burn` | Burn resource tokens | Yes |
+
 ## Governance Endpoints
 
 | Method | Path | Description | Auth Required |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -401,7 +401,7 @@ and set `storage_backend = "rocksdb"` in your configuration.
     *   **`icn-reputation`**: Reputation scoring and validation for network participants.
     *   **`icn-node`**: The main binary executable that runs a persistent HTTP server with P2P networking.
     *   **`icn-cli`**: The command-line interface client that interacts with `icn-node` via HTTP API.
-*   **`docs/` directory:** Contains this onboarding guide and potentially other architectural documents.
+*   **`docs/` directory:** Contains this onboarding guide and other references such as [resource_tokens.md](resource_tokens.md) explaining the token system.
 *   **`.github/` directory:** CI workflows, issue templates, Dependabot configuration.
 
 ### Error Handling Approach

--- a/docs/beginner/README.md
+++ b/docs/beginner/README.md
@@ -25,3 +25,4 @@ just validate                 # format, lint and test
 - [Developer Onboarding Guide](../ONBOARDING.md)
 - [ICN Feature Overview](../ICN_FEATURE_OVERVIEW.md)
 - [Project Context](../../CONTEXT.md)
+- [Resource Tokens](../resource_tokens.md)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -533,6 +533,109 @@ paths:
               schema:
                 type: string
               example: "tx-1"
+  /tokens/classes:
+    get:
+      summary: List token classes
+      responses:
+        '200':
+          description: Token classes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TokenClass'
+              example:
+                - id: "pantry-credit"
+                  transferable: true
+  /tokens/class:
+    post:
+      summary: Create a token class
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTokenClassRequest'
+            example:
+              id: "pantry-credit"
+              description: "Food pantry credit"
+              transferable: true
+      responses:
+        '200':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: string
+              example: "pantry-credit"
+  /tokens/mint:
+    post:
+      summary: Mint resource tokens
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MintTokensRequest'
+            example:
+              class_id: "pantry-credit"
+              amount: 10
+              recipient_did: "did:key:alice"
+      responses:
+        '200':
+          description: Minted
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                minted: true
+  /tokens/transfer:
+    post:
+      summary: Transfer resource tokens
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferTokensRequest'
+            example:
+              class_id: "pantry-credit"
+              amount: 5
+              from_did: "did:key:alice"
+              to_did: "did:key:bob"
+      responses:
+        '200':
+          description: Transferred
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                transferred: true
+  /tokens/burn:
+    post:
+      summary: Burn resource tokens
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BurnTokensRequest'
+            example:
+              class_id: "pantry-credit"
+              amount: 3
+              owner_did: "did:key:alice"
+      responses:
+        '200':
+          description: Burned
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                burned: true
   /data/query:
     post:
       summary: Query data
@@ -945,3 +1048,51 @@ components:
           type: string
           format: byte
           nullable: true
+    TokenClass:
+      type: object
+      properties:
+        id:
+          type: string
+        description:
+          type: string
+          nullable: true
+        transferable:
+          type: boolean
+    CreateTokenClassRequest:
+      type: object
+      properties:
+        id:
+          type: string
+        description:
+          type: string
+        transferable:
+          type: boolean
+    MintTokensRequest:
+      type: object
+      properties:
+        class_id:
+          type: string
+        amount:
+          type: integer
+        recipient_did:
+          type: string
+    TransferTokensRequest:
+      type: object
+      properties:
+        class_id:
+          type: string
+        amount:
+          type: integer
+        from_did:
+          type: string
+        to_did:
+          type: string
+    BurnTokensRequest:
+      type: object
+      properties:
+        class_id:
+          type: string
+        amount:
+          type: integer
+        owner_did:
+          type: string

--- a/docs/resource_tokens.md
+++ b/docs/resource_tokens.md
@@ -1,0 +1,38 @@
+# ICN Resource Tokens
+
+Resource tokens are purpose-bound digital assets used within the InterCooperative Network. They represent rights to specific resources or services and are tightly coupled with the mana system.
+
+## Design Goals
+- **Non-Speculative:** Tokens cannot be freely traded on secondary markets.
+- **Capability Bound:** Each token grants access only to a defined resource or service.
+- **Transparent Creation:** Token classes are created through governance or trusted contracts.
+- **Mana Integration:** Mana is consumed when tokens are minted or transferred, preventing abuse.
+
+## Token Class Creation
+A token *class* defines the properties of a resource token. Fields include:
+- `id` – unique identifier (e.g. `pantry-credit`)
+- `description` – human readable purpose
+- `transferable` – if `false`, the token is soul‑bound to the owner
+
+New classes are created via the `/tokens/class` endpoint or a CCL contract. The creator pays a mana cost and specifies whether the tokens are transferable.
+
+## Mint Flow
+1. Call `/tokens/mint` with the class id, amount, and recipient DID.
+2. Mana is debited from the caller according to the mint cost policy.
+3. The ledger records the new balance for the recipient.
+
+## Transfer Flow
+1. Call `/tokens/transfer` with class id, amount, sender DID, and recipient DID.
+2. If the class is `transferable`, balances are updated and mana fees applied.
+3. Soul‑bound tokens (`transferable = false`) will be rejected.
+
+## Burn Flow
+1. Call `/tokens/burn` with the class id, amount, and owner DID.
+2. Tokens are removed from the owner's balance.
+3. Optionally mana can be refunded based on policy.
+
+## Mana Interaction
+Mana represents regenerative cooperative capacity. Token operations charge or refund mana so that resource allocation stays fair. A typical policy might charge a small amount of mana when minting or transferring to limit spam but refund a portion when tokens are burned.
+
+## Example
+See `icn-ccl/examples/pantry_credit.ccl` for a simple contract that mints a soul‑bound volunteer badge and a transferable pantry credit token.

--- a/icn-ccl/examples/pantry_credit.ccl
+++ b/icn-ccl/examples/pantry_credit.ccl
@@ -1,0 +1,22 @@
+// Pantry Credit Token Example
+// Demonstrates soul-bound and transferable tokens
+
+// Define a transferable token for trading pantry credits
+class PantryCredit {
+    transferable: true
+}
+
+// Define a soul-bound badge for volunteers
+class VolunteerBadge {
+    transferable: false
+}
+
+fn run() -> Integer {
+    // In a real contract these functions would interact with the runtime
+    // Here we simply illustrate the intended flows
+    mint("PantryCredit", 10, caller());
+    mint("VolunteerBadge", 1, caller());
+    transfer("PantryCredit", caller(), "did:key:bob", 5);
+    burn("PantryCredit", caller(), 2);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- document resource tokens and token flows
- update API docs and OpenAPI spec with token endpoints
- add pantry_credit.ccl demo contract
- reference resource token docs from onboarding materials

## Testing
- `cargo fmt --all`
- `just validate` *(fails: large_enum_variant clippy lint)*

------
https://chatgpt.com/codex/tasks/task_e_6871d1b6e9b08324b76594da7d0ab258