### PR TITLE
[economics] introduce ResourceLedger with storage backends

### DIFF
--- a/crates/icn-economics/src/ledger/rocksdb.rs
+++ b/crates/icn-economics/src/ledger/rocksdb.rs
@@ -1,5 +1,6 @@
 use icn_common::{CommonError, Did};
 use rocksdb::DB;
+use super::{ResourceLedger, TokenClass, TokenClassId};
 use std::path::PathBuf;
 
 #[derive(Debug)]
@@ -111,5 +112,113 @@ impl crate::ManaLedger for RocksdbManaLedger {
 
     fn all_accounts(&self) -> Vec<Did> {
         RocksdbManaLedger::all_accounts(self)
+    }
+}
+
+// --- RocksDB based Resource Ledger --------------------------------------------
+
+#[derive(Debug)]
+pub struct RocksdbResourceLedger {
+    db: DB,
+}
+
+impl RocksdbResourceLedger {
+    /// Initialise a RocksDB backed resource ledger at `path`.
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let db = DB::open_default(path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open rocksdb: {e}")))?;
+        Ok(Self { db })
+    }
+
+    fn class_key(id: &TokenClassId) -> String {
+        format!("class:{id}")
+    }
+
+    fn balance_key(id: &TokenClassId, did: &Did) -> String {
+        format!("bal:{id}:{}", did)
+    }
+
+    fn write_class(&self, id: &TokenClassId, class: &TokenClass) -> Result<(), CommonError> {
+        let data = bincode::serialize(class).map_err(|e| {
+            CommonError::SerializationError(format!("Failed to serialize class: {e}"))
+        })?;
+        self.db
+            .put(Self::class_key(id), data)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to store class: {e}")))?;
+        self.db.flush().map_err(|e| CommonError::DatabaseError(format!("Failed to flush ledger: {e}")))?;
+        Ok(())
+    }
+
+    fn read_class(&self, id: &TokenClassId) -> Result<Option<TokenClass>, CommonError> {
+        if let Some(val) = self
+            .db
+            .get(Self::class_key(id))
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to read class: {e}")))?
+        {
+            let class = bincode::deserialize::<TokenClass>(&val).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to decode class: {e}"))
+            })?;
+            Ok(Some(class))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn write_balance(&self, class: &TokenClassId, did: &Did, amount: u64) -> Result<(), CommonError> {
+        let encoded = bincode::serialize(&amount).map_err(|e| {
+            CommonError::SerializationError(format!("Failed to serialize balance: {e}"))
+        })?;
+        self.db
+            .put(Self::balance_key(class, did), encoded)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to store balance: {e}")))?;
+        self.db.flush().map_err(|e| CommonError::DatabaseError(format!("Failed to flush ledger: {e}")))?;
+        Ok(())
+    }
+
+    fn read_balance(&self, class: &TokenClassId, did: &Did) -> Result<u64, CommonError> {
+        if let Some(val) = self
+            .db
+            .get(Self::balance_key(class, did))
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to read balance: {e}")))?
+        {
+            let amt: u64 = bincode::deserialize(&val).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to deserialize balance: {e}"))
+            })?;
+            Ok(amt)
+        } else {
+            Ok(0)
+        }
+    }
+}
+
+impl ResourceLedger for RocksdbResourceLedger {
+    fn create_class(&self, id: &TokenClassId, class: TokenClass) -> Result<(), CommonError> {
+        self.write_class(id, &class)
+    }
+
+    fn get_class(&self, id: &TokenClassId) -> Option<TokenClass> {
+        self.read_class(id).ok().flatten()
+    }
+
+    fn mint(&self, class: &TokenClassId, owner: &Did, amount: u64) -> Result<(), CommonError> {
+        let current = self.read_balance(class, owner)?;
+        self.write_balance(class, owner, current + amount)
+    }
+
+    fn burn(&self, class: &TokenClassId, owner: &Did, amount: u64) -> Result<(), CommonError> {
+        let current = self.read_balance(class, owner)?;
+        if current < amount {
+            return Err(CommonError::PolicyDenied("Insufficient balance".into()));
+        }
+        self.write_balance(class, owner, current - amount)
+    }
+
+    fn transfer(&self, class: &TokenClassId, from: &Did, to: &Did, amount: u64) -> Result<(), CommonError> {
+        self.burn(class, from, amount)?;
+        self.mint(class, to, amount)
+    }
+
+    fn get_balance(&self, class: &TokenClassId, owner: &Did) -> u64 {
+        self.read_balance(class, owner).unwrap_or(0)
     }
 }

--- a/crates/icn-economics/src/ledger/sqlite.rs
+++ b/crates/icn-economics/src/ledger/sqlite.rs
@@ -1,5 +1,6 @@
 use icn_common::{CommonError, Did};
 use rusqlite::{Connection, OptionalExtension};
+use super::{ResourceLedger, TokenClass, TokenClassId};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -129,5 +130,117 @@ impl crate::ManaLedger for SqliteManaLedger {
 
     fn all_accounts(&self) -> Vec<Did> {
         SqliteManaLedger::all_accounts(self)
+    }
+}
+
+// --- SQLite based Resource Ledger --------------------------------------------
+
+#[derive(Debug)]
+pub struct SqliteResourceLedger {
+    path: PathBuf,
+}
+
+impl SqliteResourceLedger {
+    /// Create a new SQLite based resource ledger stored at `path`.
+    pub fn new(path: PathBuf) -> Result<Self, CommonError> {
+        let conn = Connection::open(&path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS token_classes (id TEXT PRIMARY KEY, data TEXT)",
+            [],
+        )
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to create classes table: {e}")))?;
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS token_balances (class_id TEXT, did TEXT, amount INTEGER, PRIMARY KEY(class_id,did))",
+            [],
+        )
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to create balances table: {e}")))?;
+        Ok(Self { path })
+    }
+
+    fn write_class(&self, id: &TokenClassId, class: &TokenClass) -> Result<(), CommonError> {
+        let conn = Connection::open(&self.path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        let data = serde_json::to_string(class)
+            .map_err(|e| CommonError::SerializationError(format!("Failed to serialize class: {e}")))?;
+        conn.execute(
+            "INSERT INTO token_classes(id, data) VALUES (?1, ?2) ON CONFLICT(id) DO UPDATE SET data=excluded.data",
+            (&id, &data),
+        )
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to write class: {e}")))?;
+        Ok(())
+    }
+
+    fn read_class(&self, id: &TokenClassId) -> Result<Option<TokenClass>, CommonError> {
+        let conn = Connection::open(&self.path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        let data: Option<String> = conn
+            .query_row("SELECT data FROM token_classes WHERE id=?1", [id], |row| row.get(0))
+            .optional()
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to read class: {e}")))?;
+        if let Some(data) = data {
+            Ok(Some(serde_json::from_str(&data).map_err(|e| {
+                CommonError::DeserializationError(format!("Failed to deserialize class: {e}"))
+            })?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn write_balance(&self, class: &TokenClassId, did: &Did, amount: u64) -> Result<(), CommonError> {
+        let conn = Connection::open(&self.path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        conn.execute(
+            "INSERT INTO token_balances(class_id, did, amount) VALUES (?1, ?2, ?3) ON CONFLICT(class_id,did) DO UPDATE SET amount=excluded.amount",
+            (&class, &did.to_string(), amount as i64),
+        )
+        .map_err(|e| CommonError::DatabaseError(format!("Failed to write balance: {e}")))?;
+        Ok(())
+    }
+
+    fn read_balance(&self, class: &TokenClassId, did: &Did) -> Result<u64, CommonError> {
+        let conn = Connection::open(&self.path)
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to open sqlite DB: {e}")))?;
+        let amt: Option<i64> = conn
+            .query_row(
+                "SELECT amount FROM token_balances WHERE class_id=?1 AND did=?2",
+                (&class, &did.to_string()),
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| CommonError::DatabaseError(format!("Failed to read balance: {e}")))?;
+        Ok(amt.unwrap_or(0) as u64)
+    }
+}
+
+impl ResourceLedger for SqliteResourceLedger {
+    fn create_class(&self, id: &TokenClassId, class: TokenClass) -> Result<(), CommonError> {
+        self.write_class(id, &class)
+    }
+
+    fn get_class(&self, id: &TokenClassId) -> Option<TokenClass> {
+        self.read_class(id).ok().flatten()
+    }
+
+    fn mint(&self, class: &TokenClassId, owner: &Did, amount: u64) -> Result<(), CommonError> {
+        let current = self.read_balance(class, owner)?;
+        self.write_balance(class, owner, current + amount)
+    }
+
+    fn burn(&self, class: &TokenClassId, owner: &Did, amount: u64) -> Result<(), CommonError> {
+        let current = self.read_balance(class, owner)?;
+        if current < amount {
+            return Err(CommonError::PolicyDenied("Insufficient balance".into()));
+        }
+        self.write_balance(class, owner, current - amount)
+    }
+
+    fn transfer(&self, class: &TokenClassId, from: &Did, to: &Did, amount: u64) -> Result<(), CommonError> {
+        self.burn(class, from, amount)?;
+        self.mint(class, to, amount)
+    }
+
+    fn get_balance(&self, class: &TokenClassId, owner: &Did) -> u64 {
+        self.read_balance(class, owner).unwrap_or(0)
     }
 }

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -10,12 +10,13 @@ use log::{debug, info};
 pub mod ledger;
 pub mod metrics;
 pub use ledger::FileManaLedger;
+pub use ledger::{FileResourceLedger, ResourceLedger};
 #[cfg(feature = "persist-rocksdb")]
-pub use ledger::RocksdbManaLedger;
+pub use ledger::{RocksdbManaLedger, RocksdbResourceLedger};
 #[cfg(feature = "persist-sled")]
-pub use ledger::SledManaLedger;
+pub use ledger::{SledManaLedger, SledResourceLedger};
 #[cfg(feature = "persist-sqlite")]
-pub use ledger::SqliteManaLedger;
+pub use ledger::{SqliteManaLedger, SqliteResourceLedger};
 
 /// Abstraction over the persistence layer storing account balances.
 pub trait ManaLedger: Send + Sync {

--- a/crates/icn-economics/tests/file_resource_ledger.rs
+++ b/crates/icn-economics/tests/file_resource_ledger.rs
@@ -1,0 +1,24 @@
+use icn_common::Did;
+use icn_economics::ledger::{FileResourceLedger, ResourceLedger, TokenClass};
+use icn_economics::ledger::TokenClassId;
+use std::str::FromStr;
+use tempfile::tempdir;
+
+#[test]
+fn file_resource_ledger_persists() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("resources.json");
+    let ledger = FileResourceLedger::new(path.clone()).unwrap();
+    let class_id: TokenClassId = "gold".to_string();
+    ledger
+        .create_class(&class_id, TokenClass { name: "Gold".into() })
+        .unwrap();
+    let alice = Did::from_str("did:example:alice").unwrap();
+    let bob = Did::from_str("did:example:bob").unwrap();
+    ledger.mint(&class_id, &alice, 50).unwrap();
+    ledger.transfer(&class_id, &alice, &bob, 20).unwrap();
+    drop(ledger);
+    let ledger2 = FileResourceLedger::new(path).unwrap();
+    assert_eq!(ledger2.get_balance(&class_id, &alice), 30);
+    assert_eq!(ledger2.get_balance(&class_id, &bob), 20);
+}

--- a/crates/icn-economics/tests/rocksdb_resource_ledger.rs
+++ b/crates/icn-economics/tests/rocksdb_resource_ledger.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "persist-rocksdb")]
+mod tests {
+    use icn_common::Did;
+    use icn_economics::ledger::{ResourceLedger, RocksdbResourceLedger, TokenClass};
+    use icn_economics::ledger::TokenClassId;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rocksdb_resource_ledger_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resources.rocks");
+        let ledger = RocksdbResourceLedger::new(path.clone()).unwrap();
+        let class_id: TokenClassId = "gold".to_string();
+        ledger
+            .create_class(&class_id, TokenClass { name: "Gold".into() })
+            .unwrap();
+        let alice = Did::from_str("did:example:alice").unwrap();
+        let bob = Did::from_str("did:example:bob").unwrap();
+        ledger.mint(&class_id, &alice, 7).unwrap();
+        ledger.transfer(&class_id, &alice, &bob, 3).unwrap();
+        drop(ledger);
+        let ledger2 = RocksdbResourceLedger::new(path).unwrap();
+        assert_eq!(ledger2.get_balance(&class_id, &alice), 4);
+        assert_eq!(ledger2.get_balance(&class_id, &bob), 3);
+    }
+}

--- a/crates/icn-economics/tests/sled_resource_ledger.rs
+++ b/crates/icn-economics/tests/sled_resource_ledger.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "persist-sled")]
+mod tests {
+    use icn_common::Did;
+    use icn_economics::ledger::{ResourceLedger, SledResourceLedger, TokenClass};
+    use icn_economics::ledger::TokenClassId;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sled_resource_ledger_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resources.sled");
+        let ledger = SledResourceLedger::new(path.clone()).unwrap();
+        let class_id: TokenClassId = "gold".to_string();
+        ledger
+            .create_class(&class_id, TokenClass { name: "Gold".into() })
+            .unwrap();
+        let alice = Did::from_str("did:example:alice").unwrap();
+        let bob = Did::from_str("did:example:bob").unwrap();
+        ledger.mint(&class_id, &alice, 10).unwrap();
+        ledger.transfer(&class_id, &alice, &bob, 5).unwrap();
+        drop(ledger);
+        let ledger2 = SledResourceLedger::new(path).unwrap();
+        assert_eq!(ledger2.get_balance(&class_id, &alice), 5);
+        assert_eq!(ledger2.get_balance(&class_id, &bob), 5);
+    }
+}

--- a/crates/icn-economics/tests/sqlite_resource_ledger.rs
+++ b/crates/icn-economics/tests/sqlite_resource_ledger.rs
@@ -1,0 +1,27 @@
+#[cfg(feature = "persist-sqlite")]
+mod tests {
+    use icn_common::Did;
+    use icn_economics::ledger::{ResourceLedger, SqliteResourceLedger, TokenClass};
+    use icn_economics::ledger::TokenClassId;
+    use std::str::FromStr;
+    use tempfile::tempdir;
+
+    #[test]
+    fn sqlite_resource_ledger_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("resources.sqlite");
+        let ledger = SqliteResourceLedger::new(path.clone()).unwrap();
+        let class_id: TokenClassId = "gold".to_string();
+        ledger
+            .create_class(&class_id, TokenClass { name: "Gold".into() })
+            .unwrap();
+        let alice = Did::from_str("did:example:alice").unwrap();
+        let bob = Did::from_str("did:example:bob").unwrap();
+        ledger.mint(&class_id, &alice, 20).unwrap();
+        ledger.transfer(&class_id, &alice, &bob, 8).unwrap();
+        drop(ledger);
+        let ledger2 = SqliteResourceLedger::new(path).unwrap();
+        assert_eq!(ledger2.get_balance(&class_id, &alice), 12);
+        assert_eq!(ledger2.get_balance(&class_id, &bob), 8);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ResourceLedger` trait and token class types
- implement `FileResourceLedger` with JSON persistence
- provide sqlite, sled and rocksdb ledger implementations
- expose new APIs through `icn-economics`
- test persistence across all ledgers

## Testing
- `cargo fmt --all -- --check` *(fails: encountered diff marker)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to complete)*
- `cargo test --all-features --workspace` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_6871e0ee93808324a80a72839b9981a4