### PR TITLE
Add placeholder tests for economics and node

### DIFF
--- a/crates/icn-economics/tests/policy.rs
+++ b/crates/icn-economics/tests/policy.rs
@@ -1,0 +1,64 @@
+use icn_common::{CommonError, Did};
+use icn_economics::{ledger::FileManaLedger, ManaRepositoryAdapter, ResourcePolicyEnforcer};
+use std::str::FromStr;
+use tempfile::tempdir;
+
+#[test]
+fn file_ledger_basic_ops() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("mana.json");
+    let ledger = FileManaLedger::new(path.clone()).unwrap();
+    let alice = Did::from_str("did:example:alice").unwrap();
+
+    ledger.set_balance(&alice, 50).unwrap();
+    ledger.credit(&alice, 10).unwrap();
+    ledger.spend(&alice, 20).unwrap();
+
+    drop(ledger);
+    let ledger2 = FileManaLedger::new(path).unwrap();
+    assert_eq!(ledger2.get_balance(&alice), 40);
+}
+
+#[test]
+fn policy_enforcer_spend_success() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("mana.json");
+    let ledger = FileManaLedger::new(path).unwrap();
+    let did = Did::from_str("did:example:alice").unwrap();
+    ledger.set_balance(&did, 150).unwrap();
+
+    let adapter = ManaRepositoryAdapter::new(ledger);
+    let enforcer = ResourcePolicyEnforcer::new(adapter);
+    let result = enforcer.spend_mana(&did, 100);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn policy_enforcer_insufficient_balance() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("mana.json");
+    let ledger = FileManaLedger::new(path).unwrap();
+    let did = Did::from_str("did:example:bob").unwrap();
+    ledger.set_balance(&did, 20).unwrap();
+
+    let adapter = ManaRepositoryAdapter::new(ledger);
+    let enforcer = ResourcePolicyEnforcer::new(adapter);
+    let result = enforcer.spend_mana(&did, 30);
+    assert!(matches!(result, Err(CommonError::PolicyDenied(_))));
+}
+
+#[test]
+fn policy_enforcer_exceeds_limit() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("mana.json");
+    let ledger = FileManaLedger::new(path).unwrap();
+    let did = Did::from_str("did:example:carol").unwrap();
+    ledger.set_balance(&did, 5000).unwrap();
+
+    let adapter = ManaRepositoryAdapter::new(ledger);
+    let enforcer = ResourcePolicyEnforcer::new(adapter);
+    let over_limit = ResourcePolicyEnforcer::<FileManaLedger>::MAX_SPEND_LIMIT + 1;
+    let result = enforcer.spend_mana(&did, over_limit);
+    assert!(matches!(result, Err(CommonError::PolicyDenied(_))));
+}
+

--- a/crates/icn-node/tests/asset_flow.rs
+++ b/crates/icn-node/tests/asset_flow.rs
@@ -1,0 +1,67 @@
+use icn_node::app_router_with_options;
+use reqwest::Client;
+use serde_json::json;
+use tokio::task;
+
+#[tokio::test]
+async fn asset_class_lifecycle_unimplemented() {
+    let (router, _ctx) = app_router_with_options(
+        None, None, None, None, None, None, None, None, None, None,
+    )
+    .await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("http://{}/assets/classes", addr))
+        .json(&json!({"name": "test"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let resp = client
+        .post(format!("http://{}/assets/mint", addr))
+        .json(&json!({"class_id": "test", "to": "did:example:alice", "amount": 1}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let resp = client
+        .post(format!("http://{}/assets/transfer", addr))
+        .json(&json!({
+            "class_id": "test",
+            "from": "did:example:alice",
+            "to": "did:example:bob",
+            "amount": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let resp = client
+        .post(format!("http://{}/assets/burn", addr))
+        .json(&json!({"class_id": "test", "from": "did:example:bob", "amount": 1}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    let resp = client
+        .get(format!("http://{}/dag/events", addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::NOT_FOUND);
+
+    server.abort();
+}
+

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -47,6 +47,10 @@ path = "../icn-ccl/tests/operator_precedence.rs"
 name = "ten_node_scale"
 path = "integration/ten_node_scale.rs"
 
+[[test]]
+name = "full_workflow"
+path = "integration/full_workflow.rs"
+
 [dependencies]
 reqwest.workspace = true
 serde_json.workspace = true
@@ -54,7 +58,7 @@ tokio.workspace = true
 once_cell = "1"
 assert_cmd = "2.0"
 predicates = "3.1"
-axum = { version = "0.7", features = ["json"] }
+axum = { version = "0.8", features = ["json"] }
 icn-node = { path = "../crates/icn-node", features = ["with-libp2p"] }
 icn-runtime = { path = "../crates/icn-runtime", features = ["async"] }
 icn-governance = { path = "../crates/icn-governance" }

--- a/tests/integration/full_workflow.rs
+++ b/tests/integration/full_workflow.rs
@@ -1,0 +1,73 @@
+use icn_node::app_router_with_options;
+use reqwest::Client;
+use serde_json::json;
+use tokio::task;
+
+#[tokio::test]
+async fn workflow_via_router() {
+    let (router, _ctx) = app_router_with_options(
+        None, None, None, None, None, None, None, None, None, None,
+    )
+    .await;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    let client = Client::new();
+    let base = format!("http://{}", addr);
+
+    let job_response = client
+        .post(format!("{}/mesh/submit", base))
+        .json(&json!({
+            "manifest_cid": "bafybeigdyrztktx5b5m2y4sogf2hf5uq3k5knv5c5k2pvx7aq5w3sh7g5e",
+            "spec_json": {
+                "kind": { "Echo": { "payload": "testing" } },
+                "inputs": [],
+                "outputs": ["result"],
+                "required_resources": { "cpu_cores": 1, "memory_mb": 128 }
+            },
+            "cost_mana": 10
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(job_response.status().is_success());
+    let job_data: serde_json::Value = job_response.json().await.unwrap();
+    let job_id = job_data.get("job_id").and_then(|v| v.as_str()).unwrap();
+
+    let resp = client
+        .post(format!("{}/mesh/stub/bid", base))
+        .json(&json!({"job_id": job_id, "executor_id": "did:example:exec", "estimated_cost": 5}))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    let resp = client
+        .post(format!("{}/mesh/stub/receipt", base))
+        .json(&json!({
+            "job_id": job_id,
+            "executor_id": "did:example:exec",
+            "result": {"status": "Success", "outputs": {"result": "ok"}}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+    let status_resp = client
+        .get(format!("{}/mesh/jobs/{}", base, job_id))
+        .send()
+        .await
+        .unwrap();
+    assert!(status_resp.status().is_success());
+
+    server.abort();
+}
+


### PR DESCRIPTION
## Summary
- add policy enforcement unit tests for economics ledger
- stub asset lifecycle integration test in icn-node
- add end-to-end workflow test and register it in integration test crate

## Testing
- `cargo test -p icn-economics`
- `cargo test -p icn-node --tests` *(fails: multiple `as_any` items in scope)*
- `cargo test --test full_workflow` *(fails: job submission returned error)*

------
https://chatgpt.com/codex/tasks/task_e_6871e0f0ced08324afe8ac8b701d9efc