### PR TITLE
Add token API traits and docs

### DIFF
--- a/ICN_API_REFERENCE.md
+++ b/ICN_API_REFERENCE.md
@@ -2,6 +2,7 @@
 
 **Base URL:** `http://127.0.0.1:7845`
 **Version:** 0.1.0-dev-functional
+**Base Path:** `/api/v1`
 **Content-Type:** `application/json`
 
 ---

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -51,6 +51,82 @@ use crate::governance_trait::{
     SubmitProposalRequest as GovernanceSubmitProposalRequest, // Renamed to avoid conflict
 };
 
+// -----------------------------------------------------------------------------
+// Token & Balance DTOs and Service Traits
+// -----------------------------------------------------------------------------
+use serde::{Deserialize, Serialize};
+
+/// Request body for creating a new token class.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateTokenClassRequest {
+    pub id: String,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+/// Representation of a token class.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenClass {
+    pub id: String,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+/// Request to mint new tokens.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MintTokensRequest {
+    pub class_id: String,
+    pub to_did: String,
+    pub amount: u64,
+}
+
+/// Request to burn tokens from an account.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BurnTokensRequest {
+    pub class_id: String,
+    pub from_did: String,
+    pub amount: u64,
+}
+
+/// Request to transfer tokens between accounts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransferTokensRequest {
+    pub class_id: String,
+    pub from_did: String,
+    pub to_did: String,
+    pub amount: u64,
+}
+
+/// Balance information for a single token class.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenBalance {
+    pub class_id: String,
+    pub amount: u64,
+}
+
+/// API surface for token management and balance queries.
+pub trait TokensApi {
+    /// Create a new token class.
+    fn create_class(&self, request: CreateTokenClassRequest) -> Result<TokenClass, CommonError>;
+
+    /// Fetch details about a specific token class by ID.
+    fn get_class(&self, id: String) -> Result<Option<TokenClass>, CommonError>;
+
+    /// Mint tokens to the given DID account.
+    fn mint(&self, request: MintTokensRequest) -> Result<(), CommonError>;
+
+    /// Burn tokens from the given DID account.
+    fn burn(&self, request: BurnTokensRequest) -> Result<(), CommonError>;
+
+    /// Transfer tokens between accounts.
+    fn transfer(&self, request: TransferTokensRequest) -> Result<(), CommonError>;
+
+    /// List token balances for the specified DID.
+    fn list_balances(&self, did: String) -> Result<Vec<TokenBalance>, CommonError>;
+}
+
 /// Planned: Define a trait for the ICN API service for RPC implementation.
 // pub trait IcnApiService {
 //    async fn get_node_info(&self) -> Result<NodeInfo, CommonError>;

--- a/docs/API.md
+++ b/docs/API.md
@@ -23,6 +23,12 @@ curl -X GET https://localhost:8080/info \
   -H "Authorization: Bearer your-auth-token"
 ```
 
+### API Versioning
+
+All endpoints use a versioned base path. The current prefix is `/api/v1`. When
+breaking changes are introduced, a new prefix will be added (e.g. `/api/v2`).
+Clients should include this prefix when making requests.
+
 ## Core Node Endpoints
 
 | Method | Path | Description | Auth Required |

--- a/tests/integration/network_resilience.rs
+++ b/tests/integration/network_resilience.rs
@@ -262,8 +262,6 @@ async fn test_long_partition_circuit_breaker() {
         assert!(interval2 >= interval1);
     }
 }
-<<<<<<< HEAD
-=======
 
 #[tokio::test]
 async fn test_stub_network_breaker_open_close() {
@@ -309,4 +307,3 @@ async fn test_stub_network_breaker_open_close() {
         .expect_err("expected send failure");
     assert!(!matches!(err2, icn_network::MeshNetworkError::Timeout(_)));
 }
->>>>>>> develop


### PR DESCRIPTION
## Summary
- define DTOs and `TokensApi` trait for token classes, mint/burn/transfer, and balance queries
- mention `/api/v1` base path in API docs
- fix leftover conflict markers in `network_resilience` test

## Testing
- `cargo test -p icn-api --lib --quiet` *(fails: test_cast_vote_api, test_submit_and_retrieve_dag_block_api)*

------
https://chatgpt.com/codex/tasks/task_e_6871e0ef3c2c8324a7fee363669c3096