### PR TITLE
[icn-common] add resource token types

### DIFF
--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod retry;
 pub use retry::retry_with_backoff;
 pub mod resilience;
 pub use resilience::{CircuitBreaker, CircuitBreakerError, CircuitState};
+pub mod resource_token;
 
 pub const ICN_CORE_VERSION: &str = "0.2.0-beta";
 

--- a/crates/icn-common/src/resource_token.rs
+++ b/crates/icn-common/src/resource_token.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Did, NodeScope};
+
+/// Unique identifier for a resource token class.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TokenClassId(pub String);
+
+/// Balance of tokens held in an account.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TokenBalance {
+    /// Amount of tokens.
+    pub amount: u64,
+}
+
+/// Metadata describing a class of tokens.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenClassMetadata {
+    /// Optional scope that owns or governs this token class.
+    pub scope: Option<NodeScope>,
+    /// DID of the entity that issued the token class.
+    pub issuer: Did,
+    /// Display unit or symbol for the token.
+    pub unit: String,
+    /// Whether tokens can be freely transferred between accounts.
+    pub is_transferable: bool,
+    /// Indicates if the token is fungible or non-fungible.
+    pub fungible: bool,
+    /// Human readable name for the token class.
+    pub name: String,
+    /// Optional longer description.
+    pub description: Option<String>,
+}

--- a/tests/integration/network_resilience.rs
+++ b/tests/integration/network_resilience.rs
@@ -262,9 +262,6 @@ async fn test_long_partition_circuit_breaker() {
         assert!(interval2 >= interval1);
     }
 }
-<<<<<<< HEAD
-=======
-
 #[tokio::test]
 async fn test_stub_network_breaker_open_close() {
     use icn_common::Did;
@@ -309,4 +306,3 @@ async fn test_stub_network_breaker_open_close() {
         .expect_err("expected send failure");
     assert!(!matches!(err2, icn_network::MeshNetworkError::Timeout(_)));
 }
->>>>>>> develop


### PR DESCRIPTION
## Summary
- add TokenClassId, TokenBalance and TokenClassMetadata types
- expose new module from icn-common
- fix merge markers in `network_resilience` test

## Testing
- `cargo fmt --all -- --check` *(fails: async fn not permitted in Rust 2015)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to complete)*
- `cargo test --all-features --workspace` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_6871e0ee36e083249e775091957e2ced