### PR TITLE
[icn-sdk] add new endpoint methods

### DIFF
--- a/crates/icn-sdk/src/lib.rs
+++ b/crates/icn-sdk/src/lib.rs
@@ -111,7 +111,23 @@ impl IcnClient {
         &self,
         body: &B,
     ) -> Result<serde_json::Value, reqwest::Error> {
-        self.post("/mesh/receipts", body).await
+        self.post("/mesh/receipt", body).await
+    }
+
+    /// Inject a mesh bid (testing stub).
+    pub async fn mesh_stub_bid<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/mesh/stub/bid", body).await
+    }
+
+    /// Inject a mesh receipt (testing stub).
+    pub async fn mesh_stub_receipt<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/mesh/stub/receipt", body).await
     }
 
     /// List governance proposals.
@@ -237,6 +253,23 @@ impl IcnClient {
     /// List connected peers.
     pub async fn peers(&self) -> Result<serde_json::Value, reqwest::Error> {
         self.get("/network/peers").await
+    }
+
+    /// Get the mana balance for an account.
+    pub async fn account_mana(&self, did: &str) -> Result<serde_json::Value, reqwest::Error> {
+        let path = format!("/account/{did}/mana");
+        self.get(&path).await
+    }
+
+    /// Retrieve the node DID and public key.
+    pub async fn keys(&self) -> Result<serde_json::Value, reqwest::Error> {
+        self.get("/keys").await
+    }
+
+    /// Fetch reputation score for a DID.
+    pub async fn reputation(&self, did: &str) -> Result<serde_json::Value, reqwest::Error> {
+        let path = format!("/reputation/{did}");
+        self.get(&path).await
     }
 
     /// Submit a transaction.

--- a/tests/integration/network_resilience.rs
+++ b/tests/integration/network_resilience.rs
@@ -262,9 +262,6 @@ async fn test_long_partition_circuit_breaker() {
         assert!(interval2 >= interval1);
     }
 }
-<<<<<<< HEAD
-=======
-
 #[tokio::test]
 async fn test_stub_network_breaker_open_close() {
     use icn_common::Did;
@@ -309,4 +306,3 @@ async fn test_stub_network_breaker_open_close() {
         .expect_err("expected send failure");
     assert!(!matches!(err2, icn_network::MeshNetworkError::Timeout(_)));
 }
->>>>>>> develop


### PR DESCRIPTION
## Summary
- expand `IcnClient` with helpers for new HTTP endpoints
- fix merge conflict markers in network resilience test

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: Codex couldn't complete command due to environment constraints)*
- `cargo test --all-features --workspace` *(fails: Codex couldn't complete command due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6871e0f045148324b72c4bbd8539f354