### PR TITLE
[sdk] add client methods for new endpoints

### DIFF
--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -412,7 +412,7 @@ impl Cid {
     /// Encode this CID to a multibase string.
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
-        use multibase::{encode, Base};
+        use multibase::{Base, encode};
         encode(Base::Base32Lower, self.to_bytes())
     }
 }
@@ -600,6 +600,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::const_is_empty)]
     fn version_is_set() {
         assert!(!ICN_CORE_VERSION.is_empty());
         assert!(ICN_CORE_VERSION.contains("0.2.0"));

--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -115,6 +115,7 @@ pub struct Vote {
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::large_enum_variant)]
 pub enum GovernanceEvent {
     ProposalSubmitted(Proposal),
     VoteCast(Vote),
@@ -233,7 +234,7 @@ impl GovernanceModule {
         })?;
 
         let proposals_tree_name = "proposals_v1".to_string(); // versioned tree name
-                                                              // sled automatically creates trees when first accessed, so no explicit creation needed here.
+        // sled automatically creates trees when first accessed, so no explicit creation needed here.
 
         Ok(GovernanceModule {
             backend: Backend::Sled {

--- a/crates/icn-sdk/src/lib.rs
+++ b/crates/icn-sdk/src/lib.rs
@@ -111,7 +111,23 @@ impl IcnClient {
         &self,
         body: &B,
     ) -> Result<serde_json::Value, reqwest::Error> {
-        self.post("/mesh/receipts", body).await
+        self.post("/mesh/receipt", body).await
+    }
+
+    /// Inject a mesh bid (stub only).
+    pub async fn mesh_stub_bid<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/mesh/stub/bid", body).await
+    }
+
+    /// Inject a mesh receipt (stub only).
+    pub async fn mesh_stub_receipt<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/mesh/stub/receipt", body).await
     }
 
     /// List governance proposals.
@@ -221,6 +237,11 @@ impl IcnClient {
         self.post("/dag/prune", body).await
     }
 
+    /// Retrieve the current DAG root CID.
+    pub async fn dag_root(&self) -> Result<String, reqwest::Error> {
+        self.get("/dag/root").await
+    }
+
     /// Return the node's peer id.
     pub async fn local_peer_id(&self) -> Result<serde_json::Value, reqwest::Error> {
         self.get("/network/local-peer-id").await
@@ -237,6 +258,23 @@ impl IcnClient {
     /// List connected peers.
     pub async fn peers(&self) -> Result<serde_json::Value, reqwest::Error> {
         self.get("/network/peers").await
+    }
+
+    /// Get mana balance for a DID.
+    pub async fn account_mana(&self, did: &str) -> Result<serde_json::Value, reqwest::Error> {
+        let path = format!("/account/{did}/mana");
+        self.get(&path).await
+    }
+
+    /// Retrieve the node DID and public key.
+    pub async fn keys(&self) -> Result<serde_json::Value, reqwest::Error> {
+        self.get("/keys").await
+    }
+
+    /// Fetch reputation score for a DID.
+    pub async fn reputation(&self, did: &str) -> Result<serde_json::Value, reqwest::Error> {
+        let path = format!("/reputation/{did}");
+        self.get(&path).await
     }
 
     /// Submit a transaction.


### PR DESCRIPTION
## Summary
- update `submit_mesh_receipt` path
- expose stub bid and receipt helpers
- expose dag root, account mana, keys and reputation helpers
- silence a couple clippy lints

## Testing
- `cargo clippy -p icn-sdk -p icn-common -p icn-governance --all-targets --all-features -- -D warnings`
- `cargo test -p icn-sdk -p icn-common -p icn-governance`


------
https://chatgpt.com/codex/tasks/task_e_6871e690d72c832483de7c6fff073059