### PR TITLE
Add resource token ledger adapter

### DIFF
--- a/crates/icn-economics/Cargo.toml
+++ b/crates/icn-economics/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 icn-common = { path = "../icn-common" }
 icn-reputation = { path = "../icn-reputation" }
 icn-eventstore = { path = "../icn-eventstore" }
+icn-dag = { path = "../icn-dag" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["sync"] } # For Mutex, RwLock if needed async
 thiserror = "2.0" # Added thiserror
@@ -27,6 +28,7 @@ rocksdb = { version = "0.21", optional = true }
 tempfile = "3.0"
 sled = { version = "0.34" }
 bincode = "1.3"
+icn-runtime = { path = "../icn-runtime" }
 
 [features]
 default = ["persist-sled"]

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -5,7 +5,11 @@
 //! It manages token models, ledger interactions, transaction logic, and incentive mechanisms,
 //! aiming for security, accuracy, and interoperability.
 
-use icn_common::{CommonError, Did, NodeInfo};
+use icn_common::{
+    compute_merkle_cid, CommonError, DagBlock, Did, NodeInfo, NodeScope, SystemTimeProvider,
+    TimeProvider,
+};
+use icn_dag::StorageService;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
 pub mod ledger;
@@ -73,6 +77,35 @@ pub trait ManaLedger: Send + Sync {
     fn all_accounts(&self) -> Vec<Did> {
         Vec::new()
     }
+}
+
+impl<T: ManaLedger + ?Sized> ManaLedger for &T {
+    fn get_balance(&self, did: &Did) -> u64 {
+        (**self).get_balance(did)
+    }
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        (**self).set_balance(did, amount)
+    }
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        (**self).spend(did, amount)
+    }
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), CommonError> {
+        (**self).credit(did, amount)
+    }
+    fn credit_all(&self, amount: u64) -> Result<(), CommonError> {
+        (**self).credit_all(amount)
+    }
+    fn all_accounts(&self) -> Vec<Did> {
+        (**self).all_accounts()
+    }
+}
+
+/// Ledger for scoped resource tokens keyed by class ID and DID.
+pub trait ResourceLedger: Send + Sync {
+    fn get_balance(&self, did: &Did, class_id: &str) -> u64;
+    fn set_balance(&self, did: &Did, class_id: &str, amount: u64) -> Result<(), CommonError>;
+    fn credit(&self, did: &Did, class_id: &str, amount: u64) -> Result<(), CommonError>;
+    fn debit(&self, did: &Did, class_id: &str, amount: u64) -> Result<(), CommonError>;
 }
 
 /// Thin wrapper exposing convenience methods over a [`ManaLedger`].
@@ -213,6 +246,219 @@ pub fn credit_mana<L: ManaLedger>(ledger: L, did: &Did, amount: u64) -> Result<(
     let mana_adapter = ManaRepositoryAdapter::new(ledger);
     info!("[icn-economics] credit_mana called for DID {did:?}, amount {amount}");
     mana_adapter.credit_mana(did, amount)
+}
+
+/// Events emitted when resource token balances change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TokenEvent {
+    Mint {
+        class_id: String,
+        amount: u64,
+        issuer: Did,
+        recipient: Did,
+        scope: Option<NodeScope>,
+    },
+    Burn {
+        class_id: String,
+        amount: u64,
+        issuer: Did,
+        owner: Did,
+        scope: Option<NodeScope>,
+    },
+    Transfer {
+        class_id: String,
+        amount: u64,
+        issuer: Did,
+        from: Did,
+        to: Did,
+        scope: Option<NodeScope>,
+    },
+}
+
+/// Adapter over a [`ResourceLedger`] with optional DAG event recording.
+pub struct ResourceRepositoryAdapter<L: ResourceLedger> {
+    ledger: L,
+    issuers: std::collections::HashMap<NodeScope, std::collections::HashSet<Did>>,
+    dag_store: Option<std::sync::Mutex<Box<dyn StorageService<DagBlock>>>>,
+}
+
+impl<L: ResourceLedger> ResourceRepositoryAdapter<L> {
+    pub fn new(ledger: L) -> Self {
+        Self {
+            ledger,
+            issuers: std::collections::HashMap::new(),
+            dag_store: None,
+        }
+    }
+
+    pub fn with_dag_store(ledger: L, dag: Box<dyn StorageService<DagBlock>>) -> Self {
+        Self {
+            ledger,
+            issuers: std::collections::HashMap::new(),
+            dag_store: Some(std::sync::Mutex::new(dag)),
+        }
+    }
+
+    pub fn add_issuer(&mut self, scope: NodeScope, issuer: Did) {
+        self.issuers.entry(scope).or_default().insert(issuer);
+    }
+
+    pub fn ledger(&self) -> &L {
+        &self.ledger
+    }
+
+    fn is_authorized(&self, issuer: &Did, scope: &NodeScope) -> bool {
+        self.issuers
+            .get(scope)
+            .map(|s| s.contains(issuer))
+            .unwrap_or(false)
+    }
+
+    fn record_event(&self, event: &TokenEvent) {
+        if let Some(store) = &self.dag_store {
+            let mut store = store.lock().unwrap();
+            let data = serde_json::to_vec(event).unwrap_or_default();
+            let author = match event {
+                TokenEvent::Mint { issuer, .. } => issuer.clone(),
+                TokenEvent::Burn { issuer, .. } => issuer.clone(),
+                TokenEvent::Transfer { issuer, .. } => issuer.clone(),
+            };
+            let scope = match event {
+                TokenEvent::Mint { scope, .. }
+                | TokenEvent::Burn { scope, .. }
+                | TokenEvent::Transfer { scope, .. } => scope.clone(),
+            };
+            let ts = SystemTimeProvider.unix_seconds();
+            let cid = compute_merkle_cid(0x71, &data, &[], ts, &author, &None, &scope);
+            let block = DagBlock {
+                cid,
+                data,
+                links: vec![],
+                timestamp: ts,
+                author_did: author,
+                signature: None,
+                scope,
+            };
+            let _ = store.put(&block);
+        }
+    }
+
+    pub fn mint(
+        &self,
+        issuer: &Did,
+        class_id: &str,
+        amount: u64,
+        recipient: &Did,
+        scope: Option<NodeScope>,
+    ) -> Result<(), CommonError> {
+        if let Some(sc) = &scope {
+            if !self.is_authorized(issuer, sc) {
+                return Err(CommonError::PolicyDenied("issuer not authorized".into()));
+            }
+        }
+        self.ledger.credit(recipient, class_id, amount)?;
+        self.record_event(&TokenEvent::Mint {
+            class_id: class_id.to_string(),
+            amount,
+            issuer: issuer.clone(),
+            recipient: recipient.clone(),
+            scope,
+        });
+        Ok(())
+    }
+
+    pub fn burn(
+        &self,
+        issuer: &Did,
+        class_id: &str,
+        amount: u64,
+        owner: &Did,
+        scope: Option<NodeScope>,
+    ) -> Result<(), CommonError> {
+        if let Some(sc) = &scope {
+            if !self.is_authorized(issuer, sc) {
+                return Err(CommonError::PolicyDenied("issuer not authorized".into()));
+            }
+        }
+        self.ledger.debit(owner, class_id, amount)?;
+        self.record_event(&TokenEvent::Burn {
+            class_id: class_id.to_string(),
+            amount,
+            issuer: issuer.clone(),
+            owner: owner.clone(),
+            scope,
+        });
+        Ok(())
+    }
+
+    pub fn transfer(
+        &self,
+        issuer: &Did,
+        class_id: &str,
+        amount: u64,
+        from: &Did,
+        to: &Did,
+        scope: Option<NodeScope>,
+    ) -> Result<(), CommonError> {
+        if let Some(sc) = &scope {
+            if !self.is_authorized(issuer, sc) {
+                return Err(CommonError::PolicyDenied("issuer not authorized".into()));
+            }
+        }
+        self.ledger.debit(from, class_id, amount)?;
+        self.ledger.credit(to, class_id, amount)?;
+        self.record_event(&TokenEvent::Transfer {
+            class_id: class_id.to_string(),
+            amount,
+            issuer: issuer.clone(),
+            from: from.clone(),
+            to: to.clone(),
+            scope,
+        });
+        Ok(())
+    }
+}
+
+const TOKEN_FEE: u64 = 1;
+
+pub fn mint_tokens<L: ResourceLedger, M: ManaLedger>(
+    repo: &ResourceRepositoryAdapter<L>,
+    mana_ledger: &M,
+    issuer: &Did,
+    class_id: &str,
+    amount: u64,
+    recipient: &Did,
+    scope: Option<NodeScope>,
+) -> Result<(), CommonError> {
+    charge_mana(mana_ledger, issuer, TOKEN_FEE)?;
+    repo.mint(issuer, class_id, amount, recipient, scope)
+}
+
+pub fn burn_tokens<L: ResourceLedger, M: ManaLedger>(
+    repo: &ResourceRepositoryAdapter<L>,
+    mana_ledger: &M,
+    issuer: &Did,
+    class_id: &str,
+    amount: u64,
+    owner: &Did,
+    scope: Option<NodeScope>,
+) -> Result<(), CommonError> {
+    charge_mana(mana_ledger, issuer, TOKEN_FEE)?;
+    repo.burn(issuer, class_id, amount, owner, scope)
+}
+
+pub fn transfer_tokens<L: ResourceLedger, M: ManaLedger>(
+    repo: &ResourceRepositoryAdapter<L>,
+    mana_ledger: &M,
+    issuer: &Did,
+    class_id: &str,
+    amount: u64,
+    from: &Did,
+    to: &Did,
+    scope: Option<NodeScope>,
+) -> Result<(), CommonError> {
+    charge_mana(mana_ledger, issuer, TOKEN_FEE)?;
+    repo.transfer(issuer, class_id, amount, from, to, scope)
 }
 
 /// Credits mana to all known accounts using their reputation scores.

--- a/crates/icn-economics/tests/resource_tokens.rs
+++ b/crates/icn-economics/tests/resource_tokens.rs
@@ -1,0 +1,130 @@
+use icn_common::{Did, NodeScope};
+use icn_economics::{
+    burn_tokens, mint_tokens, transfer_tokens, ManaLedger, ResourceLedger,
+    ResourceRepositoryAdapter,
+};
+use icn_runtime::context::StubDagStore;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct InMemoryManaLedger {
+    balances: Mutex<HashMap<Did, u64>>,
+}
+
+impl ManaLedger for InMemoryManaLedger {
+    fn get_balance(&self, did: &Did) -> u64 {
+        *self.balances.lock().unwrap().get(did).unwrap_or(&0)
+    }
+    fn set_balance(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        self.balances.lock().unwrap().insert(did.clone(), amount);
+        Ok(())
+    }
+    fn spend(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let bal = map.entry(did.clone()).or_insert(0);
+        if *bal < amount {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= amount;
+        Ok(())
+    }
+    fn credit(&self, did: &Did, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let entry = map.entry(did.clone()).or_insert(0);
+        *entry += amount;
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct InMemoryResourceLedger {
+    balances: Mutex<HashMap<(Did, String), u64>>,
+}
+
+impl ResourceLedger for InMemoryResourceLedger {
+    fn get_balance(&self, did: &Did, class_id: &str) -> u64 {
+        *self
+            .balances
+            .lock()
+            .unwrap()
+            .get(&(did.clone(), class_id.to_string()))
+            .unwrap_or(&0)
+    }
+    fn set_balance(
+        &self,
+        did: &Did,
+        class_id: &str,
+        amount: u64,
+    ) -> Result<(), icn_common::CommonError> {
+        self.balances
+            .lock()
+            .unwrap()
+            .insert((did.clone(), class_id.to_string()), amount);
+        Ok(())
+    }
+    fn credit(
+        &self,
+        did: &Did,
+        class_id: &str,
+        amount: u64,
+    ) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let entry = map.entry((did.clone(), class_id.to_string())).or_insert(0);
+        *entry += amount;
+        Ok(())
+    }
+    fn debit(&self, did: &Did, class_id: &str, amount: u64) -> Result<(), icn_common::CommonError> {
+        let mut map = self.balances.lock().unwrap();
+        let bal = map.entry((did.clone(), class_id.to_string())).or_insert(0);
+        if *bal < amount {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= amount;
+        Ok(())
+    }
+}
+
+#[test]
+fn mint_transfer_burn_flow() {
+    let mana = InMemoryManaLedger::default();
+    mana.set_balance(&Did::from_str("did:example:issuer").unwrap(), 10)
+        .unwrap();
+    let ledger = InMemoryResourceLedger::default();
+    let mut repo = ResourceRepositoryAdapter::with_dag_store(ledger, Box::new(StubDagStore::new()));
+    let scope = NodeScope("scope".into());
+    let issuer = Did::from_str("did:example:issuer").unwrap();
+    repo.add_issuer(scope.clone(), issuer.clone());
+    let recipient = Did::from_str("did:example:bob").unwrap();
+
+    mint_tokens(
+        &repo,
+        &mana,
+        &issuer,
+        "token",
+        5,
+        &recipient,
+        Some(scope.clone()),
+    )
+    .unwrap();
+    assert_eq!(repo.ledger().get_balance(&recipient, "token"), 5);
+
+    let other = Did::from_str("did:example:alice").unwrap();
+    transfer_tokens(
+        &repo,
+        &mana,
+        &issuer,
+        "token",
+        3,
+        &recipient,
+        &other,
+        Some(scope.clone()),
+    )
+    .unwrap();
+    assert_eq!(repo.ledger().get_balance(&recipient, "token"), 2);
+    assert_eq!(repo.ledger().get_balance(&other, "token"), 3);
+
+    burn_tokens(&repo, &mana, &issuer, "token", 2, &other, Some(scope)).unwrap();
+    assert_eq!(repo.ledger().get_balance(&other, "token"), 1);
+}


### PR DESCRIPTION
## Summary
- expose ResourceLedger trait and repository adapter
- add token mint, burn and transfer helpers with mana fees
- log token events to the DAG
- add resource token integration test

## Testing
- `cargo test -p icn-economics --tests`

------
https://chatgpt.com/codex/tasks/task_e_6871e85499308324a4f06c34fee48864