### PR TITLE
Add token endpoints to SDK

### DIFF
--- a/crates/icn-sdk/src/lib.rs
+++ b/crates/icn-sdk/src/lib.rs
@@ -285,6 +285,43 @@ impl IcnClient {
         self.post("/transaction/submit", body).await
     }
 
+    /// List available token classes.
+    pub async fn token_classes(&self) -> Result<serde_json::Value, reqwest::Error> {
+        self.get("/tokens/classes").await
+    }
+
+    /// Create a new token class.
+    pub async fn create_token_class<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/tokens/class", body).await
+    }
+
+    /// Mint resource tokens.
+    pub async fn mint_tokens<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/tokens/mint", body).await
+    }
+
+    /// Transfer resource tokens between accounts.
+    pub async fn transfer_tokens<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/tokens/transfer", body).await
+    }
+
+    /// Burn resource tokens from an account.
+    pub async fn burn_tokens<B: Serialize>(
+        &self,
+        body: &B,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        self.post("/tokens/burn", body).await
+    }
+
     /// Query data.
     pub async fn data_query<B: Serialize>(
         &self,


### PR DESCRIPTION
## Summary
- expose token class and token ledger methods in `icn-sdk`

## Testing
- `cargo test -p icn-sdk`

------
https://chatgpt.com/codex/tasks/task_e_6871efd0c3c48324a6f88fcc96116aea