### PR TITLE
Add zero-knowledge proof disclosure docs

### DIFF
--- a/docs/examples/zk_example.json
+++ b/docs/examples/zk_example.json
@@ -1,0 +1,7 @@
+{
+  "proof": "0x123456789abcdef",
+  "public_inputs": {
+    "statement": "age_over_18",
+    "verification_key": "0xdeadbeef"
+  }
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -1,0 +1,25 @@
+# Zero-Knowledge Proof Disclosure Guide
+
+This document provides a short overview of when zero-knowledge proofs (ZKPs) are useful within ICN systems, how they can be generated, and a basic example flow.
+
+---
+
+## When to Use Zero-Knowledge Proofs
+- **Selective Disclosure:** Reveal only the fact that a statement is true without exposing underlying data. Useful for credential verification (e.g., confirming age or membership).
+- **Privacy-Preserving Audits:** Allow nodes to prove compliance with network policies without revealing sensitive logs.
+- **Anonymous Voting:** Enable participants to vote without linking ballots to identities while still proving legitimacy.
+
+## Generating Proofs
+1. **Define the Statement** – Encode the claim to be proven (e.g., "age is over 18") in a circuit or constraint system.
+2. **Prepare Inputs** – Collect private inputs (such as the birth year) and any necessary public parameters.
+3. **Run the Prover** – Use a ZKP library or tool to generate the proof artifact and a corresponding public verification key.
+4. **Publish Proof** – Send the proof alongside any required public data to the verifying party.
+5. **Verify** – The verifier checks the proof using the verification key without learning the private inputs.
+
+## Example Flow: Proving Age Over 18
+1. **Holder** possesses a credential with a birthdate.
+2. **Holder** runs a proving tool to create a ZKP that asserts "birthdate + 18 years <= current date".
+3. **Holder** sends the resulting proof to a verifier (e.g., a cooperative registry).
+4. **Verifier** checks the proof. If valid, it accepts that the holder is over 18 without ever seeing the actual birthdate.
+
+See [`docs/examples/zk_example.json`](examples/zk_example.json) for a minimal JSON representation of a proof.


### PR DESCRIPTION
## Summary
- add zk_disclosure guide explaining ZKP usage and generation
- include example proof json in docs/examples

## Testing
- `just test` *(fails: could not compile `icn-economics`)*

------
https://chatgpt.com/codex/tasks/task_e_6871fa72afdc832499f8383069ffb2ce