### PR TITLE
[identity] add zero knowledge verifier

### DIFF
--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -21,8 +21,6 @@ use tokio::fs::{self, File as TokioFile, OpenOptions as TokioOpenOptions};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Helper crate for encoding/decoding root hashes
-use hex;
-
 pub mod index;
 pub mod metrics;
 #[cfg(feature = "persist-postgres")]

--- a/crates/icn-dag/src/postgres_store.rs
+++ b/crates/icn-dag/src/postgres_store.rs
@@ -1,5 +1,5 @@
 use crate::{AsyncStorageService, BlockMetadata, Cid, CommonError, DagBlock};
-use deadpool_postgres::{Config as PoolConfig, ManagerConfig, Pool, RecyclingMethod};
+use deadpool_postgres::{ManagerConfig, Pool, RecyclingMethod};
 use std::collections::HashMap;
 use tokio_postgres::NoTls;
 

--- a/crates/icn-dag/tests/root.rs
+++ b/crates/icn-dag/tests/root.rs
@@ -2,7 +2,7 @@ use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did};
 use icn_dag::compute_dag_root;
 
 fn make_block(id: &str, links: Vec<DagLink>) -> DagBlock {
-    let data = format!("{id}").into_bytes();
+    let data = id.as_bytes().to_vec();
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig = None;

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -447,6 +447,7 @@ pub fn burn_tokens<L: ResourceLedger, M: ManaLedger>(
     repo.burn(issuer, class_id, amount, owner, scope)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn transfer_tokens<L: ResourceLedger, M: ManaLedger>(
     repo: &ResourceRepositoryAdapter<L>,
     mana_ledger: &M,

--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -20,6 +20,9 @@ multibase      = "0.9"          # base-58btc ("z...") encoder/decoder
 unsigned-varint = { version = "0.8", default-features = false } 
 serde_bytes = "0.11" # For SignatureBytes serialization
 reqwest.workspace = true
+bulletproofs = "5"
+merlin = "3"
+curve25519-dalek = { version = "4", default-features = false, features = ["alloc", "digest", "rand_core", "group", "serde"] }
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -18,6 +18,8 @@ use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use unsigned_varint::encode as varint_encode;
 
+pub mod zk;
+
 // --- Core Cryptographic Operations & DID:key generation ---
 
 /// Generate an Ed25519 key-pair using the OS CSPRNG.
@@ -114,12 +116,12 @@ fn is_valid_domain(domain: &str) -> bool {
     if domain.is_empty() || domain.len() > MAX_DOMAIN_LEN {
         return false;
     }
-    
+
     // Handle domains with ports (e.g., "localhost:8080")
     let (hostname, _port) = if let Some(colon_pos) = domain.rfind(':') {
         let hostname = &domain[..colon_pos];
         let port_str = &domain[colon_pos + 1..];
-        
+
         // Validate port is numeric and in valid range
         if let Ok(port) = port_str.parse::<u16>() {
             if port == 0 {
@@ -132,12 +134,12 @@ fn is_valid_domain(domain: &str) -> bool {
     } else {
         (domain, None)
     };
-    
+
     // Validate hostname part
     if hostname.is_empty() {
         return false;
     }
-    
+
     hostname.split('.').all(|label| {
         let bytes = label.as_bytes();
         !bytes.is_empty()

--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -1,0 +1,93 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Proof data for a zero-knowledge credential.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ZkCredentialProof {
+    /// Encoded proof bytes.
+    #[serde(with = "serde_bytes")]
+    pub proof: Vec<u8>,
+    /// Compressed commitment bytes.
+    #[serde(with = "serde_bytes")]
+    pub commitment: Vec<u8>,
+    /// Bit size of the committed value.
+    pub bit_size: usize,
+}
+
+/// Errors that can occur during zero-knowledge verification.
+#[derive(Debug, Error)]
+pub enum ZkError {
+    #[error("invalid proof: {0}")]
+    InvalidProof(String),
+    #[error("verification failed: {0}")]
+    VerificationFailed(String),
+}
+
+/// Trait for verifying zero-knowledge credential proofs.
+pub trait ZkVerifier {
+    /// Verify the supplied proof, returning `true` if valid.
+    fn verify(&self, proof: &ZkCredentialProof) -> Result<bool, ZkError>;
+}
+
+/// Verifier implementation using Bulletproofs range proofs.
+pub struct BulletproofsVerifier;
+
+impl ZkVerifier for BulletproofsVerifier {
+    fn verify(&self, proof_data: &ZkCredentialProof) -> Result<bool, ZkError> {
+        use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
+        use curve25519_dalek::ristretto::CompressedRistretto;
+        use merlin::Transcript;
+
+        let proof = RangeProof::from_bytes(&proof_data.proof)
+            .map_err(|e| ZkError::InvalidProof(format!("{e:?}")))?;
+        if proof_data.commitment.len() != 32 {
+            return Err(ZkError::InvalidProof("commitment length".into()));
+        }
+        let bytes: [u8; 32] = proof_data.commitment[..]
+            .try_into()
+            .expect("length checked");
+        let commitment = CompressedRistretto(bytes);
+        let bp_gens = BulletproofGens::new(proof_data.bit_size, 1);
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"ZkCredential");
+        proof
+            .verify_single(
+                &bp_gens,
+                &pc_gens,
+                &mut transcript,
+                &commitment,
+                proof_data.bit_size,
+            )
+            .map_err(|e| ZkError::VerificationFailed(format!("{e:?}")))?;
+        Ok(true)
+    }
+}
+
+/// No-op verifier used for testing and development.
+#[derive(Default)]
+pub struct DummyVerifier;
+
+impl ZkVerifier for DummyVerifier {
+    fn verify(&self, proof: &ZkCredentialProof) -> Result<bool, ZkError> {
+        if proof.proof.is_empty() || proof.commitment.len() != 32 {
+            return Err(ZkError::InvalidProof("invalid structure".into()));
+        }
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dummy_verifier_accepts_well_formed_proof() {
+        let proof = ZkCredentialProof {
+            proof: vec![1, 2, 3],
+            commitment: vec![0; 32],
+            bit_size: 32,
+        };
+        let v = DummyVerifier;
+        assert!(v.verify(&proof).unwrap());
+    }
+}

--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -6,7 +6,6 @@
 //! InterCooperative Network (ICN) mesh network. It handles job definition, resource discovery,
 //! scheduling, execution management, and fault tolerance.
 
-use bincode;
 use icn_common::{Cid, CommonError, Did, NodeInfo};
 use icn_identity::{
     sign_message as identity_sign_message, verify_signature as identity_verify_signature,
@@ -409,7 +408,13 @@ pub fn score_bid(
     let resource_score = policy.weight_resources * resource_match;
 
     let latency_score = latency_ms
-        .and_then(|ms| if ms > 0 { Some(policy.weight_latency / ms as f64) } else { None })
+        .and_then(|ms| {
+            if ms > 0 {
+                Some(policy.weight_latency / ms as f64)
+            } else {
+                None
+            }
+        })
         .unwrap_or(0.0);
 
     let weighted = price_score + reputation_score + resource_score + latency_score;


### PR DESCRIPTION
## Summary
- add Bulletproofs-based and dummy zk verifiers
- integrate zk module into identity crate
- clean up clippy warnings in DAG, economics, mesh

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile workspace)*
- `cargo test --all-features --workspace` *(fails: build did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_6871fa70cb608324b0342087c6e7d528