### PR TITLE
[icn-common] add ZK credential proof types

### DIFF
--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -13,6 +13,8 @@ pub use retry::retry_with_backoff;
 pub mod resilience;
 pub use resilience::{CircuitBreaker, CircuitBreakerError, CircuitState};
 pub mod resource_token;
+pub mod zk;
+pub use zk::{ZkCredentialProof, ZkProofType};
 
 pub const ICN_CORE_VERSION: &str = "0.2.0-beta";
 
@@ -413,7 +415,7 @@ impl Cid {
     /// Encode this CID to a multibase string.
     #[allow(clippy::inherent_to_string_shadow_display)]
     pub fn to_string(&self) -> String {
-        use multibase::{Base, encode};
+        use multibase::{encode, Base};
         encode(Base::Base32Lower, self.to_bytes())
     }
 }

--- a/crates/icn-common/src/zk.rs
+++ b/crates/icn-common/src/zk.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Cid, Did};
+
+/// Supported zero-knowledge proof backends.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ZkProofType {
+    /// Groth16 zk-SNARK proofs
+    Groth16,
+    /// Bulletproofs proving system
+    Bulletproofs,
+    /// Catch-all for custom or future proof systems
+    Other(String),
+}
+
+/// A verifiable credential proof generated via a zero-knowledge protocol.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkCredentialProof {
+    /// DID of the credential issuer.
+    pub issuer: Did,
+    /// DID of the credential holder.
+    pub holder: Did,
+    /// Type or semantic tag of the claim being proven.
+    pub claim_type: String,
+    /// Raw bytes of the zero-knowledge proof.
+    #[serde(with = "serde_bytes")]
+    pub proof: Vec<u8>,
+    /// CID of the credential schema this proof adheres to.
+    pub schema: Cid,
+    /// Fields from the credential that were disclosed in plain text.
+    pub disclosed_fields: Vec<String>,
+    /// Optional challenge used in the proof generation.
+    pub challenge: Option<String>,
+    /// Backend proving system used for this proof.
+    pub backend: ZkProofType,
+}


### PR DESCRIPTION
## Summary
- add zero-knowledge proof structures
- re-export zk module in `icn-common`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: single_component_path_imports in icn-dag, unused imports, etc.)*
- `cargo test --all-features --workspace` *(fails: could not compile `icn-economics` and `icn-node`)*

------
https://chatgpt.com/codex/tasks/task_e_6871fa70c89c8324893f4229d6850eee