### PR TITLE
[cli] add identity proof generator

### DIFF
--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 env_logger = "0.10"
+fastrand = "1"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/icn-cli/tests/identity_generate.rs
+++ b/crates/icn-cli/tests/identity_generate.rs
@@ -1,0 +1,36 @@
+use assert_cmd::prelude::*;
+use icn_common::{Cid, ZkCredentialProof, ZkProofType};
+use std::process::Command;
+
+#[test]
+fn identity_generate_produces_valid_json() {
+    let cid = Cid::new_v1_sha256(0x71, b"schema");
+    let cid_str = cid.to_string();
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let output = Command::new(bin)
+        .args([
+            "identity",
+            "generate-proof",
+            "--issuer",
+            "did:key:issuer",
+            "--holder",
+            "did:key:holder",
+            "--claim-type",
+            "test",
+            "--schema",
+            &cid_str,
+            "--backend",
+            "groth16",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let proof: ZkCredentialProof = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(proof.issuer.method, "key");
+    assert_eq!(proof.holder.method, "key");
+    assert_eq!(proof.claim_type, "test");
+    assert_eq!(proof.schema, cid);
+    assert_eq!(proof.backend, ZkProofType::Groth16);
+    assert!(!proof.proof.is_empty());
+}


### PR DESCRIPTION
## Summary
- add `Identity` subcommand for CLI
- implement `GenerateProof` option outputting dummy `ZkCredentialProof`
- generate random proof bytes using `fastrand`
- print proof JSON to stdout
- add integration test

## Testing
- `cargo test -p icn-cli identity_generate_produces_valid_json -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6872cf96082883249d6e71c5e5a6f8c7