### PR TITLE
Add icn-zk crate with simple circuits

### DIFF
--- a/crates/icn-zk/Cargo.toml
+++ b/crates/icn-zk/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "icn-zk"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+ark-std = "0.4"
+ark-relations = "0.4"
+ark-r1cs-std = "0.4"
+ark-groth16 = "0.4"
+ark-bn254 = "0.4"
+ark-snark = "0.4"
+rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+ark-std = { version = "0.4", features = ["std"] }

--- a/crates/icn-zk/src/circuits.rs
+++ b/crates/icn-zk/src/circuits.rs
@@ -1,0 +1,69 @@
+use ark_bn254::Fr;
+use ark_r1cs_std::fields::fp::FpVar;
+use ark_r1cs_std::prelude::*;
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
+
+/// Prove that `current_year >= birth_year + 18`.
+#[derive(Clone)]
+pub struct AgeOver18Circuit {
+    /// Birth year of the subject (private).
+    pub birth_year: u64,
+    /// Current year (public).
+    pub current_year: u64,
+}
+
+impl ConstraintSynthesizer<Fr> for AgeOver18Circuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let birth = FpVar::<Fr>::new_witness(cs.clone(), || Ok(Fr::from(self.birth_year)))?;
+        let current = FpVar::<Fr>::new_input(cs.clone(), || Ok(Fr::from(self.current_year)))?;
+
+        // k = current_year - birth_year - 18
+        let diff = self
+            .current_year
+            .checked_sub(self.birth_year + 18)
+            .ok_or(SynthesisError::AssignmentMissing)?;
+        let k = FpVar::<Fr>::new_witness(cs, || Ok(Fr::from(diff)))?;
+
+        let eighteen = FpVar::<Fr>::Constant(Fr::from(18u64));
+        (birth + eighteen + k).enforce_equal(&current)?;
+        Ok(())
+    }
+}
+
+/// Prove knowledge of membership boolean (must equal `true`).
+#[derive(Clone)]
+pub struct MembershipCircuit {
+    /// Whether the prover is a member (public).
+    pub is_member: bool,
+}
+
+impl ConstraintSynthesizer<Fr> for MembershipCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let member = Boolean::new_input(cs, || Ok(self.is_member))?;
+        member.enforce_equal(&Boolean::TRUE)?;
+        Ok(())
+    }
+}
+
+/// Prove that `reputation >= threshold`.
+#[derive(Clone)]
+pub struct ReputationCircuit {
+    /// Reputation score (public).
+    pub reputation: u64,
+    /// Required threshold.
+    pub threshold: u64,
+}
+
+impl ConstraintSynthesizer<Fr> for ReputationCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let rep = FpVar::<Fr>::new_input(cs.clone(), || Ok(Fr::from(self.reputation)))?;
+        let diff = self
+            .reputation
+            .checked_sub(self.threshold)
+            .ok_or(SynthesisError::AssignmentMissing)?;
+        let k = FpVar::<Fr>::new_witness(cs.clone(), || Ok(Fr::from(diff)))?;
+        let threshold = FpVar::<Fr>::Constant(Fr::from(self.threshold));
+        (threshold + k).enforce_equal(&rep)?;
+        Ok(())
+    }
+}

--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -1,0 +1,46 @@
+//! Reusable zero-knowledge circuits for ICN credential proofs.
+
+use ark_bn254::{Bn254, Fr};
+use ark_groth16::{Groth16, PreparedVerifyingKey, Proof, ProvingKey};
+use ark_relations::r1cs::{ConstraintSynthesizer, SynthesisError};
+use ark_snark::SNARK;
+use ark_std::rand::{CryptoRng, RngCore};
+
+mod circuits;
+
+pub use circuits::{AgeOver18Circuit, MembershipCircuit, ReputationCircuit};
+
+/// Generate Groth16 parameters for a given circuit.
+pub fn setup<C: ConstraintSynthesizer<Fr>, R: RngCore + CryptoRng>(
+    circuit: C,
+    rng: &mut R,
+) -> Result<ProvingKey<Bn254>, SynthesisError> {
+    let (pk, _vk) = Groth16::<Bn254>::circuit_specific_setup(circuit, rng)?;
+    Ok(pk)
+}
+
+/// Create a Groth16 proof for the provided circuit and proving key.
+pub fn prove<C: ConstraintSynthesizer<Fr>, R: RngCore + CryptoRng>(
+    pk: &ProvingKey<Bn254>,
+    circuit: C,
+    rng: &mut R,
+) -> Result<Proof<Bn254>, SynthesisError> {
+    Groth16::<Bn254>::prove(pk, circuit, rng)
+}
+
+/// Prepare the verifying key for use in verification.
+pub fn prepare_vk(pk: &ProvingKey<Bn254>) -> PreparedVerifyingKey<Bn254> {
+    Groth16::<Bn254>::process_vk(&pk.vk).unwrap()
+}
+
+/// Verify a Groth16 proof with the given verifying key and public inputs.
+pub fn verify(
+    vk: &PreparedVerifyingKey<Bn254>,
+    proof: &Proof<Bn254>,
+    public_inputs: &[Fr],
+) -> Result<bool, SynthesisError> {
+    Groth16::<Bn254>::verify_with_processed_vk(vk, public_inputs, proof)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -1,0 +1,38 @@
+use super::*;
+use ark_std::rand::{rngs::StdRng, SeedableRng};
+
+#[test]
+fn age_over_18_proof() {
+    let circuit = AgeOver18Circuit {
+        birth_year: 2000,
+        current_year: 2020,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(2020u64)]).unwrap());
+}
+
+#[test]
+fn membership_proof() {
+    let circuit = MembershipCircuit { is_member: true };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(1u64)]).unwrap());
+}
+
+#[test]
+fn reputation_threshold_proof() {
+    let circuit = ReputationCircuit {
+        reputation: 10,
+        threshold: 5,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(10u64)]).unwrap());
+}

--- a/docs/examples/zk_age_over_18.json
+++ b/docs/examples/zk_age_over_18.json
@@ -1,0 +1,7 @@
+{
+  "proof": "0xdeadbeef",
+  "public_inputs": {
+    "statement": "age_over_18",
+    "year": 2020
+  }
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -23,3 +23,12 @@ This document provides a short overview of when zero-knowledge proofs (ZKPs) are
 4. **Verifier** checks the proof. If valid, it accepts that the holder is over 18 without ever seeing the actual birthdate.
 
 See [`docs/examples/zk_example.json`](examples/zk_example.json) for a minimal JSON representation of a proof.
+
+## Available Circuits
+The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
+
+- `AgeOver18Circuit` – proves a birth year is at least 18 years in the past.
+- `MembershipCircuit` – proves the subject is a registered member.
+- `ReputationCircuit` – proves a reputation score meets a required threshold.
+
+See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.


### PR DESCRIPTION
## Summary
- create new `icn-zk` crate with Groth16 circuit helpers
- implement age, membership, and reputation circuits
- document circuits in zk_disclosure guide
- add zk age example JSON

## Testing
- `cargo test -p icn-zk --all-features`
- ❌ `cargo test --workspace --all-features` *(failed: environment limits)*
- ❌ `cargo clippy --all-targets --all-features -- -D warnings` *(failed: environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6872cfaa3f34832485a24deee3a7f44a