### PR TITLE
[identity] integrate bulletproofs verifier

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -11,6 +11,10 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 icn-common = { path = "../icn-common" }
 
+bulletproofs = "5.0"
+curve25519-dalek = "4.2"
+merlin = "3.0"
+
 # --- crypto ---
 ed25519-dalek = { version = "2.0.0-pre.3", features = ["rand_core"] }
 rand_core      = { version = "0.6", features = ["getrandom"] } # used by dalek's OsRng

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -83,3 +83,6 @@ icn-common = { path = "../crates/icn-common" }
 icn-protocol = { path = "../crates/icn-protocol" }
 icn-identity = { path = "../crates/icn-identity" }
 icn-network = { path = "../crates/icn-network" }
+bulletproofs = "5.0"
+curve25519-dalek = "4.2"
+merlin = "3.0"

--- a/tests/integration/zk_proof_verification.rs
+++ b/tests/integration/zk_proof_verification.rs
@@ -1,8 +1,27 @@
+use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
+use curve25519_dalek::scalar::Scalar;
 use icn_common::{Cid, Did, ZkCredentialProof, ZkProofType};
 use icn_node::app_router_with_options;
+use merlin::Transcript;
 use reqwest::Client;
 use tokio::task;
 use tokio::time::{sleep, Duration};
+
+fn make_bulletproof(value: u64) -> Vec<u8> {
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(64, 1);
+    let mut transcript = Transcript::new(b"icn-bulletproof");
+    let (proof, _) = RangeProof::prove_single(
+        &bp_gens,
+        &pc_gens,
+        &mut transcript,
+        value,
+        &Scalar::ZERO,
+        64,
+    )
+    .unwrap();
+    proof.to_bytes()
+}
 
 #[tokio::test]
 async fn zk_proof_verification_route() {
@@ -36,17 +55,62 @@ async fn zk_proof_verification_route() {
         issuer: Did::new("key", "issuer"),
         holder: Did::new("key", "holder"),
         claim_type: "test".to_string(),
-        proof: vec![1, 2, 3],
+        proof: make_bulletproof(42),
         schema: Cid::new_v1_sha256(0x55, b"schema"),
         disclosed_fields: Vec::new(),
         challenge: None,
-        backend: ZkProofType::Groth16,
+        backend: ZkProofType::Bulletproofs,
     };
 
     let resp = client.post(url).json(&proof).send().await.unwrap();
     assert!(resp.status().is_success());
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["verified"], true);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn zk_proof_verification_invalid() {
+    std::fs::write("fixtures/mana_ledger.tmp", "{\"balances\":{}}").unwrap();
+    let (router, _ctx) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(std::path::PathBuf::from("fixtures/mana_ledger.tmp")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    sleep(Duration::from_millis(100)).await;
+    let client = Client::new();
+    let url = format!("http://{}/identity/verify", addr);
+
+    let proof = ZkCredentialProof {
+        issuer: Did::new("key", "issuer"),
+        holder: Did::new("key", "holder"),
+        claim_type: "test".to_string(),
+        proof: make_bulletproof(7),
+        schema: Cid::new_v1_sha256(0x55, b"schema"),
+        disclosed_fields: Vec::new(),
+        challenge: None,
+        backend: ZkProofType::Bulletproofs,
+    };
+
+    let resp = client.post(url).json(&proof).send().await.unwrap();
+    assert_eq!(resp.status(), 400);
 
     server.abort();
 }


### PR DESCRIPTION
## Summary
- add bulletproofs, curve25519-dalek and merlin crates
- verify Bulletproofs range proofs in `BulletproofsVerifier`
- create helper for generating test proofs
- add failing and passing Bulletproofs tests

## Testing
- `cargo clippy -p icn-identity -- -D warnings`
- `cargo test -p icn-identity --all-features`
- `cargo test --test zk_proof_verification`


------
https://chatgpt.com/codex/tasks/task_e_6872cf8d84388324b32c2e573aa30e44