### PR TITLE
Add credential ZK prover integration

### DIFF
--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -19,9 +19,17 @@ use std::str::FromStr;
 use unsigned_varint::encode as varint_encode;
 
 pub mod zk;
-pub use zk::{BulletproofsVerifier, DummyVerifier, ZkError, ZkVerifier};
+pub use zk::{
+    BulletproofsProver,
+    BulletproofsVerifier,
+    DummyProver,
+    DummyVerifier,
+    ZkError,
+    ZkProver,
+    ZkVerifier,
+};
 pub mod credential;
-pub use credential::{Credential, DisclosedCredential};
+pub use credential::{Credential, DisclosedCredential, CredentialIssuer};
 
 // --- Core Cryptographic Operations & DID:key generation ---
 


### PR DESCRIPTION
## Summary
- add `ZkProver` trait with `DummyProver` and `BulletproofsProver`
- integrate `CredentialIssuer` to generate proofs
- test proof generation and verification

## Testing
- `cargo test -p icn-identity --lib -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6872ee4ba5948324ba8d8dc44c3b8455