### PR TITLE
Improve Bulletproofs verification tests

### DIFF
--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -164,4 +164,13 @@ mod tests {
         let verifier = BulletproofsVerifier;
         assert_eq!(verifier.verify(&proof), Err(ZkError::InvalidProof));
     }
+
+    #[test]
+    fn bulletproofs_tampered_proof_fails() {
+        let mut proof = dummy_proof(ZkProofType::Bulletproofs);
+        // Flip a bit in the proof bytes to corrupt it while preserving length
+        proof.proof[0] ^= 0x01;
+        let verifier = BulletproofsVerifier;
+        assert_eq!(verifier.verify(&proof), Err(ZkError::VerificationFailed));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure Bulletproofs verifier is exercised against tampered proofs

## Testing
- `cargo test -p icn-identity --all-features`
- `cargo clippy -p icn-identity --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_6872ee70b3888324af2c1c019ae07076