### PR TITLE
Add Groth16 verifier using icn-zk circuits

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -23,6 +23,11 @@ reqwest.workspace = true
 bulletproofs = "5"
 curve25519-dalek = "4"
 merlin = "3"
+icn-zk = { path = "../icn-zk" }
+ark-groth16 = "0.4"
+ark-bn254 = "0.4"
+ark-serialize = "0.4"
+ark-std = "0.4"
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version


### PR DESCRIPTION
## Summary
- implement `Groth16Verifier` that checks Groth16 proofs using icn-zk
- add required arkworks and icn-zk dependencies
- add test covering the new verifier

## Testing
- `cargo check -p icn-identity`
- `cargo test -p icn-identity`

------
https://chatgpt.com/codex/tasks/task_e_6872f7b8e47c8324813118f738223484