### PR TITLE
Add icn-zk to workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/icn-templates",
     "tests",
     "crates/icn-sdk",
+    "crates/icn-zk",
 ]
 resolver = "2"
 


### PR DESCRIPTION
## Summary
- include `crates/icn-zk` crate in the workspace

## Testing
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_6872f7b550b483248735b7844e778853