### PR TITLE
Groth16 proof generation for CLI

### DIFF
--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 icn-common = { path = "../icn-common" }
 icn-api = { path = "../icn-api" }
+icn-identity = { path = "../icn-identity" }
 icn-governance = { path = "../icn-governance" }
 icn-network = { path = "../icn-network" }
 icn-mesh = { path = "../icn-mesh" }

--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -23,6 +23,9 @@ reqwest.workspace = true
 bulletproofs = "5"
 curve25519-dalek = "4"
 merlin = "3"
+ark-serialize = "0.4"
+icn-zk = { path = "../icn-zk" }
+ark-std = "0.4"
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -20,16 +20,11 @@ use unsigned_varint::encode as varint_encode;
 
 pub mod zk;
 pub use zk::{
-    BulletproofsProver,
-    BulletproofsVerifier,
-    DummyProver,
-    DummyVerifier,
-    ZkError,
-    ZkProver,
-    ZkVerifier,
+    BulletproofsProver, BulletproofsVerifier, DummyProver, DummyVerifier, Groth16Prover, ZkError,
+    ZkProver, ZkVerifier,
 };
 pub mod credential;
-pub use credential::{Credential, DisclosedCredential, CredentialIssuer};
+pub use credential::{Credential, CredentialIssuer, DisclosedCredential};
 
 // --- Core Cryptographic Operations & DID:key generation ---
 


### PR DESCRIPTION
## Summary
- use Groth16Prover from `icn-identity` to produce proofs
- add `--age-over-18` option to pick the age circuit
- return verifying key alongside proof

## Testing
- `cargo test -p icn-cli identity_generate`

------
https://chatgpt.com/codex/tasks/task_e_6872fc9ad99083249bdf25fc90a27cb5