### PR TITLE
[common] add verifying key cid field

### DIFF
--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -7,6 +7,7 @@
 use base64::{self, Engine};
 use bincode;
 use clap::{Parser, Subcommand};
+use fastrand;
 use icn_common::CommonError;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -14,13 +15,10 @@ use serde_json::Value as JsonValue; // For generic JSON data if needed
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::exit; // Added for reading from stdin
-use fastrand;
 
 // Types from our ICN crates that CLI will interact with (serialize/deserialize)
 // These types are expected to be sent to/received from the icn-node HTTP API.
-use icn_common::{
-    Cid, DagBlock, Did, NodeInfo, NodeStatus, ZkCredentialProof, ZkProofType,
-};
+use icn_common::{Cid, DagBlock, Did, NodeInfo, NodeStatus, ZkCredentialProof, ZkProofType};
 // Using aliased request structs from icn-api for clarity, these are what the node expects
 use icn_api::governance_trait::{
     CastVoteRequest as ApiCastVoteRequest, SubmitProposalRequest as ApiSubmitProposalRequest,
@@ -406,9 +404,9 @@ async fn run_command(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
             ReputationCommands::Get { did } => handle_reputation_get(cli, client, did).await?,
         },
         Commands::Identity { command } => match command {
-            IdentityCommands::VerifyProof { proof_json_or_stdin } => {
-                handle_identity_verify(cli, client, proof_json_or_stdin).await?
-            }
+            IdentityCommands::VerifyProof {
+                proof_json_or_stdin,
+            } => handle_identity_verify(cli, client, proof_json_or_stdin).await?,
             IdentityCommands::GenerateProof {
                 issuer,
                 holder,
@@ -1033,6 +1031,7 @@ fn handle_identity_generate(
         claim_type: claim_type.to_string(),
         proof: proof_bytes,
         schema: schema_cid,
+        vk_cid: None,
         disclosed_fields: Vec::new(),
         challenge: None,
         backend: backend_parsed,

--- a/crates/icn-cli/tests/identity_generate.rs
+++ b/crates/icn-cli/tests/identity_generate.rs
@@ -42,6 +42,7 @@ async fn identity_generate_command() {
     assert_eq!(proof.holder, holder);
     assert_eq!(proof.claim_type, "test");
     assert_eq!(proof.schema, schema_cid);
+    assert!(proof.vk_cid.is_none());
     assert_eq!(proof.backend, ZkProofType::Groth16);
     assert!(!proof.proof.is_empty());
 }

--- a/crates/icn-cli/tests/identity_verify.rs
+++ b/crates/icn-cli/tests/identity_verify.rs
@@ -22,6 +22,7 @@ async fn identity_verify_command() {
         claim_type: "test".to_string(),
         proof: vec![1, 2, 3],
         schema: Cid::new_v1_sha256(0x55, b"schema"),
+        vk_cid: None,
         disclosed_fields: Vec::new(),
         challenge: None,
         backend: ZkProofType::Groth16,

--- a/crates/icn-common/src/zk.rs
+++ b/crates/icn-common/src/zk.rs
@@ -27,6 +27,8 @@ pub struct ZkCredentialProof {
     pub proof: Vec<u8>,
     /// CID of the credential schema this proof adheres to.
     pub schema: Cid,
+    /// Optional CID referencing the verifying key for this proof.
+    pub vk_cid: Option<Cid>,
     /// Fields from the credential that were disclosed in plain text.
     pub disclosed_fields: Vec<String>,
     /// Optional challenge used in the proof generation.

--- a/tests/integration/zk_proof_verification.rs
+++ b/tests/integration/zk_proof_verification.rs
@@ -38,6 +38,7 @@ async fn zk_proof_verification_route() {
         claim_type: "test".to_string(),
         proof: vec![1, 2, 3],
         schema: Cid::new_v1_sha256(0x55, b"schema"),
+        vk_cid: None,
         disclosed_fields: Vec::new(),
         challenge: None,
         backend: ZkProofType::Groth16,


### PR DESCRIPTION
## Summary
- extend `ZkCredentialProof` with optional `vk_cid`
- update CLI and tests for new field
- update identity zk module and integration test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p icn-cli identity_generate_command -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_6872fc99878083248e16e77d111cb463