### PR TITLE
[workspace] add icn-zk crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/icn-templates",
     "tests",
     "crates/icn-sdk",
+    "crates/icn-zk",
 ]
 resolver = "2"
 


### PR DESCRIPTION
## Summary
- include `crates/icn-zk` in workspace

## Testing
- `cargo fmt --all -- --check` *(fails: produces diff)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-dag`)*
- `cargo test --all-features --workspace` *(terminated early)*
- `cargo test -p icn-ccl` *(terminated early)*
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6872fc98af6c83248b6d3df830d1595d