### PR TITLE
Add Groth16 proof verifier

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -23,6 +23,9 @@ reqwest.workspace = true
 bulletproofs = "5"
 curve25519-dalek = "4"
 merlin = "3"
+ark-groth16 = "0.4"
+ark-bn254 = "0.4"
+ark-serialize = "0.4"
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version
@@ -36,3 +39,5 @@ rand = "0.8"
 serde_json = "1.0"
 curve25519-dalek = "4"
 merlin = "3"
+icn-zk = { path = "../icn-zk" }
+ark-std = { version = "0.4", features = ["std"] }

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -20,16 +20,11 @@ use unsigned_varint::encode as varint_encode;
 
 pub mod zk;
 pub use zk::{
-    BulletproofsProver,
-    BulletproofsVerifier,
-    DummyProver,
-    DummyVerifier,
-    ZkError,
-    ZkProver,
-    ZkVerifier,
+    BulletproofsProver, BulletproofsVerifier, DummyProver, DummyVerifier, Groth16Verifier, ZkError,
+    ZkProver, ZkVerifier,
 };
 pub mod credential;
-pub use credential::{Credential, DisclosedCredential, CredentialIssuer};
+pub use credential::{Credential, CredentialIssuer, DisclosedCredential};
 
 // --- Core Cryptographic Operations & DID:key generation ---
 


### PR DESCRIPTION
## Summary
- add arkworks dependencies for Groth16
- expose Groth16Verifier in public API
- implement Groth16 verification logic
- test Groth16 proofs via icn-zk circuits

## Testing
- `cargo clippy -p icn-identity --all-targets --all-features -- -D warnings`
- `cargo test -p icn-identity --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6872fc94b588832494d440bbb2e4d672