### PR TITLE
[identity] add Groth16 prover

### DIFF
--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::single_component_path_imports)]
 
 //! # ICN DAG Crate
 //! This crate implements or defines interfaces for content-addressed Directed Acyclic Graph (DAG)

--- a/crates/icn-dag/tests/root.rs
+++ b/crates/icn-dag/tests/root.rs
@@ -2,7 +2,7 @@ use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did};
 use icn_dag::compute_dag_root;
 
 fn make_block(id: &str, links: Vec<DagLink>) -> DagBlock {
-    let data = format!("{id}").into_bytes();
+    let data = id.as_bytes().to_vec();
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig = None;

--- a/crates/icn-economics/src/ledger/rocksdb.rs
+++ b/crates/icn-economics/src/ledger/rocksdb.rs
@@ -43,7 +43,7 @@ impl RocksdbManaLedger {
     /// Flush pending batched writes to disk.
     pub fn flush(&self) -> Result<(), CommonError> {
         let mut batch = self.batch.lock().unwrap();
-        if batch.len() > 0 {
+        if !batch.is_empty() {
             let write_batch = std::mem::take(&mut *batch);
             self.db
                 .write(write_batch)

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -447,6 +447,7 @@ pub fn burn_tokens<L: ResourceLedger, M: ManaLedger>(
     repo.burn(issuer, class_id, amount, owner, scope)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn transfer_tokens<L: ResourceLedger, M: ManaLedger>(
     repo: &ResourceRepositoryAdapter<L>,
     mana_ledger: &M,

--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -23,6 +23,12 @@ reqwest.workspace = true
 bulletproofs = "5"
 curve25519-dalek = "4"
 merlin = "3"
+icn-zk = { path = "../icn-zk" }
+ark-std = "0.4"
+ark-serialize = "0.4"
+ark-bn254 = "0.4"
+ark-groth16 = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version

--- a/crates/icn-identity/README.md
+++ b/crates/icn-identity/README.md
@@ -42,6 +42,15 @@ contains characters other than ASCII letters, digits, `-`, `_`, or `.` or if a
 segment exceeds 63 characters. Domains longer than 253 characters are also
 rejected.
 
+## Available ZK Provers
+
+Credential proofs are generated through the `ZkProver` trait. This crate
+includes several implementations:
+
+- `DummyProver` – returns placeholder bytes for testing.
+- `BulletproofsProver` – creates range proofs using the Bulletproofs backend.
+- `Groth16Prover` – produces Groth16 zk‑SNARK proofs over Bn254.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-identity/src/credential.rs
+++ b/crates/icn-identity/src/credential.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use icn_common::{Cid, CommonError, Did};
 
-use crate::{sign_message, verify_signature, SignatureBytes};
 use crate::zk::{ZkError, ZkProver};
+use crate::{sign_message, verify_signature, SignatureBytes};
 use icn_common::ZkCredentialProof;
 
 /// A verifiable credential issued by a DID subject to selective disclosure.
@@ -49,8 +49,7 @@ impl Credential {
             bytes.extend_from_slice(k.as_bytes());
             bytes.extend_from_slice(v.as_bytes());
             let sig = sign_message(key, &bytes);
-            self
-                .signatures
+            self.signatures
                 .insert(k.clone(), SignatureBytes::from_ed_signature(sig));
         }
     }
@@ -61,10 +60,9 @@ impl Credential {
             .claims
             .get(claim)
             .ok_or_else(|| CommonError::IdentityError(format!("claim not found: {claim}")))?;
-        let sig = self
-            .signatures
-            .get(claim)
-            .ok_or_else(|| CommonError::IdentityError(format!("missing signature for claim: {claim}")))?;
+        let sig = self.signatures.get(claim).ok_or_else(|| {
+            CommonError::IdentityError(format!("missing signature for claim: {claim}"))
+        })?;
         let mut bytes = self.issuer.to_string().into_bytes();
         bytes.extend_from_slice(self.holder.to_string().as_bytes());
         bytes.extend_from_slice(claim.as_bytes());
@@ -118,17 +116,18 @@ impl DisclosedCredential {
     /// Verify all disclosed claim signatures against the issuer key.
     pub fn verify(&self, key: &VerifyingKey) -> Result<(), CommonError> {
         for (k, v) in &self.claims {
-            let sig = self
-                .signatures
-                .get(k)
-                .ok_or_else(|| CommonError::IdentityError(format!("missing signature for claim: {k}")))?;
+            let sig = self.signatures.get(k).ok_or_else(|| {
+                CommonError::IdentityError(format!("missing signature for claim: {k}"))
+            })?;
             let mut bytes = self.issuer.to_string().into_bytes();
             bytes.extend_from_slice(self.holder.to_string().as_bytes());
             bytes.extend_from_slice(k.as_bytes());
             bytes.extend_from_slice(v.as_bytes());
             let ed = sig.to_ed_signature()?;
             if !verify_signature(key, &bytes, &ed) {
-                return Err(CommonError::IdentityError(format!("invalid signature for claim: {k}")));
+                return Err(CommonError::IdentityError(format!(
+                    "invalid signature for claim: {k}"
+                )));
             }
         }
         Ok(())
@@ -143,7 +142,11 @@ pub struct CredentialIssuer {
 
 impl CredentialIssuer {
     pub fn new(did: Did, signing_key: SigningKey) -> Self {
-        Self { did, signing_key, prover: None }
+        Self {
+            did,
+            signing_key,
+            prover: None,
+        }
     }
 
     pub fn with_prover(mut self, prover: Box<dyn ZkProver>) -> Self {
@@ -172,8 +175,13 @@ impl CredentialIssuer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::zk::{BulletproofsProver, BulletproofsVerifier, DummyProver, DummyVerifier, ZkVerifier};
     use crate::generate_ed25519_keypair;
+    use crate::zk::{
+        BulletproofsProver, BulletproofsVerifier, DummyProver, DummyVerifier, Groth16Prover,
+        ZkVerifier,
+    };
+    use chrono::Datelike;
+    use icn_common::ZkProofType;
 
     #[test]
     fn dummy_proof_roundtrip() {
@@ -185,7 +193,12 @@ mod tests {
 
         let issuer = CredentialIssuer::new(issuer, sk).with_prover(Box::new(DummyProver));
         let (_, proof_opt) = issuer
-            .issue(holder, claims, Some(Cid::new_v1_sha256(0x55, b"schema")), Some(&["age"]))
+            .issue(
+                holder,
+                claims,
+                Some(Cid::new_v1_sha256(0x55, b"schema")),
+                Some(&["age"]),
+            )
             .unwrap();
         let proof = proof_opt.expect("proof");
         let verifier = DummyVerifier;
@@ -202,11 +215,57 @@ mod tests {
 
         let issuer = CredentialIssuer::new(issuer, sk).with_prover(Box::new(BulletproofsProver));
         let (_, proof_opt) = issuer
-            .issue(holder, claims, Some(Cid::new_v1_sha256(0x55, b"schema")), Some(&[]))
+            .issue(
+                holder,
+                claims,
+                Some(Cid::new_v1_sha256(0x55, b"schema")),
+                Some(&[]),
+            )
             .unwrap();
         let proof = proof_opt.expect("proof");
         let verifier = BulletproofsVerifier;
         assert!(verifier.verify(&proof).unwrap());
     }
-}
 
+    #[test]
+    fn groth16_proof_roundtrip() {
+        use ark_bn254::{Bn254, Fr};
+        use ark_serialize::CanonicalDeserialize;
+        use ark_std::rand::{rngs::StdRng, SeedableRng};
+        use icn_zk::setup as zk_setup;
+        use icn_zk::{self, prepare_vk, verify, AgeOver18Circuit};
+        let (sk, _) = generate_ed25519_keypair();
+        let issuer_did = Did::new("key", "issuer");
+        let holder_did = Did::new("key", "holder");
+        let mut claims = HashMap::new();
+        claims.insert("birth_year".to_string(), "2000".to_string());
+
+        let current_year = chrono::Utc::now().year() as u64;
+        let mut rng = StdRng::seed_from_u64(42);
+        let pk = zk_setup(
+            AgeOver18Circuit {
+                birth_year: 2000,
+                current_year,
+            },
+            &mut rng,
+        )
+        .unwrap();
+        let prover = Groth16Prover::new(pk.clone());
+
+        let issuer = CredentialIssuer::new(issuer_did.clone(), sk).with_prover(Box::new(prover));
+        let (_, proof_opt) = issuer
+            .issue(
+                holder_did.clone(),
+                claims,
+                Some(Cid::new_v1_sha256(0x55, b"schema")),
+                Some(&[]),
+            )
+            .unwrap();
+        let proof = proof_opt.expect("proof");
+        assert_eq!(proof.backend, ZkProofType::Groth16);
+
+        let vk = prepare_vk(&pk);
+        let zk_proof = ark_groth16::Proof::<Bn254>::deserialize_compressed(&*proof.proof).unwrap();
+        assert!(verify(&vk, &zk_proof, &[Fr::from(current_year)]).unwrap());
+    }
+}

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -20,16 +20,11 @@ use unsigned_varint::encode as varint_encode;
 
 pub mod zk;
 pub use zk::{
-    BulletproofsProver,
-    BulletproofsVerifier,
-    DummyProver,
-    DummyVerifier,
-    ZkError,
-    ZkProver,
-    ZkVerifier,
+    BulletproofsProver, BulletproofsVerifier, DummyProver, DummyVerifier, Groth16Prover, ZkError,
+    ZkProver, ZkVerifier,
 };
 pub mod credential;
-pub use credential::{Credential, DisclosedCredential, CredentialIssuer};
+pub use credential::{Credential, CredentialIssuer, DisclosedCredential};
 
 // --- Core Cryptographic Operations & DID:key generation ---
 

--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::single_component_path_imports)]
 
 //! # ICN Mesh Crate
 //! This crate focuses on job orchestration, scheduling, and execution within the
@@ -409,7 +410,13 @@ pub fn score_bid(
     let resource_score = policy.weight_resources * resource_match;
 
     let latency_score = latency_ms
-        .and_then(|ms| if ms > 0 { Some(policy.weight_latency / ms as f64) } else { None })
+        .and_then(|ms| {
+            if ms > 0 {
+                Some(policy.weight_latency / ms as f64)
+            } else {
+                None
+            }
+        })
         .unwrap_or(0.0);
 
     let weighted = price_score + reputation_score + resource_score + latency_score;

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -32,3 +32,10 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
+
+## Available Provers
+Credential proofs can be generated using different backends in the identity crate:
+
+- `DummyProver` – simple testing stub.
+- `BulletproofsProver` – range proofs using Bulletproofs.
+- `Groth16Prover` – Groth16 zk‑SNARK proofs over Bn254.


### PR DESCRIPTION
## Summary
- add Groth16Prover implementation using icn-zk circuits
- expose new prover in icn-identity API
- test Groth16 proof generation
- document available zk provers
- fix clippy issues in auxiliary crates

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile workspace)*
- `cargo test --all-features --workspace` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6872fca267308324a9c5bdc276c35a29