### PR TITLE
Add Groth16 prover and verifier

### DIFF
--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -20,16 +20,11 @@ use unsigned_varint::encode as varint_encode;
 
 pub mod zk;
 pub use zk::{
-    BulletproofsProver,
-    BulletproofsVerifier,
-    DummyProver,
-    DummyVerifier,
-    ZkError,
-    ZkProver,
-    ZkVerifier,
+    BulletproofsProver, BulletproofsVerifier, DummyProver, DummyVerifier, Groth16Prover,
+    Groth16Verifier, ZkError, ZkProver, ZkVerifier,
 };
 pub mod credential;
-pub use credential::{Credential, DisclosedCredential, CredentialIssuer};
+pub use credential::{Credential, CredentialIssuer, DisclosedCredential};
 
 // --- Core Cryptographic Operations & DID:key generation ---
 


### PR DESCRIPTION
## Summary
- add Groth16Prover implementation using icn_zk
- wire Groth16Verifier with zk setup/verify
- re-export new types via identity crate
- test Groth16 proving and verification

## Testing
- `cargo test -p icn-identity --all-features`

------
https://chatgpt.com/codex/tasks/task_e_6873026fb5bc8324b700d82b20a64483