### PR TITLE
[identity] add groth16 proof support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/icn-api",
     "crates/icn-cli",
     "crates/icn-node",
+    "crates/icn-zk",
     "icn-ccl",
     "crates/icn-templates",
     "tests",

--- a/crates/icn-common/src/zk.rs
+++ b/crates/icn-common/src/zk.rs
@@ -27,6 +27,8 @@ pub struct ZkCredentialProof {
     pub proof: Vec<u8>,
     /// CID of the credential schema this proof adheres to.
     pub schema: Cid,
+    /// CID referencing the verifying key used for the proof.
+    pub verifying_key: Option<Cid>,
     /// Fields from the credential that were disclosed in plain text.
     pub disclosed_fields: Vec<String>,
     /// Optional challenge used in the proof generation.

--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -23,6 +23,9 @@ reqwest.workspace = true
 bulletproofs = "5"
 curve25519-dalek = "4"
 merlin = "3"
+icn-zk = { path = "../icn-zk" }
+bincode = "1.3"
+ark-serialize = "0.4"
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version


### PR DESCRIPTION
## Summary
- allow credential issuer to use Groth16 circuits
- store verifying key cid in `ZkCredentialProof`
- implement `Groth16Prover` with an age-over-18 circuit

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: redundant import in icn-dag)*
- `cargo test --all-features --workspace` *(failed to complete due to build time)*

------
https://chatgpt.com/codex/tasks/task_e_6872fc9a2f4083249319da7803c7429d