### PR TITLE
Add Groth16Prover implementation

### DIFF
--- a/crates/icn-identity/README.md
+++ b/crates/icn-identity/README.md
@@ -42,6 +42,16 @@ contains characters other than ASCII letters, digits, `-`, `_`, or `.` or if a
 segment exceeds 63 characters. Domains longer than 253 characters are also
 rejected.
 
+## Zero-Knowledge Provers
+
+Credential issuance can optionally generate zero-knowledge proofs via the
+`ZkProver` trait. This crate includes the following prover implementations:
+
+- `DummyProver` – generates placeholder proofs for testing.
+- `BulletproofsProver` – produces range proofs using the Bulletproofs protocol.
+- `Groth16Prover` – generic prover for Groth16 circuits such as age, membership
+  or reputation checks.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.


### PR DESCRIPTION
## Summary
- implement `Groth16Prover` with generic proving key
- support multiple circuits and expose constructor
- document supported provers in identity README
- add unit test covering Groth16 prover

## Testing
- `cargo test -p icn-identity --all-features`

------
https://chatgpt.com/codex/tasks/task_e_68730aee2cec8324a037b903b9134c6f