### PR TITLE
[icn-zk] Add CircuitParameters storage

### DIFF
--- a/crates/icn-zk/Cargo.toml
+++ b/crates/icn-zk/Cargo.toml
@@ -12,8 +12,10 @@ ark-r1cs-std = "0.4"
 ark-groth16 = "0.4"
 ark-bn254 = "0.4"
 ark-snark = "0.4"
+ark-serialize = "0.4"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 
 [dev-dependencies]
 ark-std = { version = "0.4", features = ["std"] }

--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -7,8 +7,10 @@ use ark_snark::SNARK;
 use ark_std::rand::{CryptoRng, RngCore};
 
 mod circuits;
+mod params;
 
 pub use circuits::{AgeOver18Circuit, MembershipCircuit, ReputationCircuit};
+pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};
 
 /// Generate Groth16 parameters for a given circuit.
 pub fn setup<C: ConstraintSynthesizer<Fr>, R: RngCore + CryptoRng>(

--- a/crates/icn-zk/src/params.rs
+++ b/crates/icn-zk/src/params.rs
@@ -1,0 +1,60 @@
+use ark_bn254::Bn254;
+use ark_groth16::{PreparedVerifyingKey, ProvingKey};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use serde::{Deserialize, Serialize};
+
+/// Serialized circuit parameters produced by a trusted setup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CircuitParameters {
+    /// Compressed Groth16 proving key bytes.
+    #[serde(with = "serde_bytes")]
+    pub proving_key: Vec<u8>,
+}
+
+impl CircuitParameters {
+    /// Convert the parameters into a [`ProvingKey`].
+    pub fn proving_key(&self) -> Result<ProvingKey<Bn254>, ark_serialize::SerializationError> {
+        ProvingKey::<Bn254>::deserialize_compressed(&self.proving_key[..])
+    }
+
+    /// Derive a prepared verifying key from the stored proving key.
+    pub fn prepared_vk(
+        &self,
+    ) -> Result<PreparedVerifyingKey<Bn254>, ark_serialize::SerializationError> {
+        let pk = self.proving_key()?;
+        Ok(crate::prepare_vk(&pk))
+    }
+
+    /// Create parameters from an existing proving key.
+    pub fn from_proving_key(
+        pk: &ProvingKey<Bn254>,
+    ) -> Result<Self, ark_serialize::SerializationError> {
+        let mut bytes = Vec::new();
+        pk.serialize_compressed(&mut bytes)?;
+        Ok(Self { proving_key: bytes })
+    }
+}
+
+/// Storage trait for circuit parameters keyed by circuit name.
+pub trait CircuitParametersStorage {
+    /// Store parameters for the given circuit name.
+    fn put(&mut self, name: &str, params: CircuitParameters);
+    /// Fetch parameters for the given circuit name if present.
+    fn get(&self, name: &str) -> Option<CircuitParameters>;
+}
+
+/// In-memory implementation of [`CircuitParametersStorage`].
+#[derive(Default)]
+pub struct MemoryParametersStorage {
+    inner: std::collections::HashMap<String, CircuitParameters>,
+}
+
+impl CircuitParametersStorage for MemoryParametersStorage {
+    fn put(&mut self, name: &str, params: CircuitParameters) {
+        self.inner.insert(name.to_string(), params);
+    }
+
+    fn get(&self, name: &str) -> Option<CircuitParameters> {
+        self.inner.get(name).cloned()
+    }
+}

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -36,3 +36,21 @@ fn reputation_threshold_proof() {
     let vk = prepare_vk(&pk);
     assert!(verify(&vk, &proof, &[Fr::from(10u64)]).unwrap());
 }
+
+#[test]
+fn circuit_parameters_roundtrip() {
+    let circuit = AgeOver18Circuit {
+        birth_year: 2000,
+        current_year: 2020,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let params = CircuitParameters::from_proving_key(&pk).unwrap();
+    let mut store = MemoryParametersStorage::default();
+    store.put("age_over_18", params.clone());
+    let fetched = store.get("age_over_18").unwrap();
+    let pk2 = fetched.proving_key().unwrap();
+    let proof = prove(&pk2, circuit, &mut rng).unwrap();
+    let vk = fetched.prepared_vk().unwrap();
+    assert!(verify(&vk, &proof, &[Fr::from(2020u64)]).unwrap());
+}


### PR DESCRIPTION
## Summary
- store Groth16 trusted setup parameters
- provide in-memory parameter store and helpers
- test roundtrip proving/verification with stored parameters

## Testing
- `cargo clippy -p icn-zk --all-targets --all-features -- -D warnings`
- `cargo test -p icn-zk`
- `cargo fmt --all -- --check`

------
https://chatgpt.com/codex/tasks/task_e_68732c74d3e48324976418c703c4f381