### PR TITLE
Add membership proof circuit

### DIFF
--- a/crates/icn-zk/src/circuits.rs
+++ b/crates/icn-zk/src/circuits.rs
@@ -45,6 +45,24 @@ impl ConstraintSynthesizer<Fr> for MembershipCircuit {
     }
 }
 
+/// Prove that a private membership flag matches an expected public value.
+#[derive(Clone)]
+pub struct MembershipProofCircuit {
+    /// Membership flag held by the prover (private witness).
+    pub membership_flag: bool,
+    /// Expected flag provided by the verifier (public input).
+    pub expected_flag: bool,
+}
+
+impl ConstraintSynthesizer<Fr> for MembershipProofCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let witness = Boolean::new_witness(cs.clone(), || Ok(self.membership_flag))?;
+        let expected = Boolean::new_input(cs, || Ok(self.expected_flag))?;
+        witness.enforce_equal(&expected)?;
+        Ok(())
+    }
+}
+
 /// Prove that `reputation >= threshold`.
 #[derive(Clone)]
 pub struct ReputationCircuit {

--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -8,7 +8,9 @@ use ark_std::rand::{CryptoRng, RngCore};
 
 mod circuits;
 
-pub use circuits::{AgeOver18Circuit, MembershipCircuit, ReputationCircuit};
+pub use circuits::{
+    AgeOver18Circuit, MembershipCircuit, MembershipProofCircuit, ReputationCircuit,
+};
 
 /// Generate Groth16 parameters for a given circuit.
 pub fn setup<C: ConstraintSynthesizer<Fr>, R: RngCore + CryptoRng>(

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -25,6 +25,19 @@ fn membership_proof() {
 }
 
 #[test]
+fn membership_flag_equality() {
+    let circuit = MembershipProofCircuit {
+        membership_flag: true,
+        expected_flag: true,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(1u64)]).unwrap());
+}
+
+#[test]
 fn reputation_threshold_proof() {
     let circuit = ReputationCircuit {
         reputation: 10,

--- a/docs/examples/zk_membership.json
+++ b/docs/examples/zk_membership.json
@@ -1,0 +1,7 @@
+{
+  "proof": "0xfeedface",
+  "public_inputs": {
+    "statement": "membership",
+    "expected": true
+  }
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -24,6 +24,16 @@ This document provides a short overview of when zero-knowledge proofs (ZKPs) are
 
 See [`docs/examples/zk_example.json`](examples/zk_example.json) for a minimal JSON representation of a proof.
 
+## Membership Proofs
+The `MembershipProofCircuit` is used when a verifier needs to confirm a holder's membership status without revealing other credential data. The prover supplies their private `membership_flag` and the verifier publishes the expected boolean. The circuit simply enforces equality between these values.
+
+```json
+{
+  "proof": "0xfeedface",
+  "public_inputs": { "statement": "membership", "expected": true }
+}
+```
+
 ### Credential Proof JSON Format
 
 `ZkCredentialProof` objects exchanged with ICN nodes are JSON encoded. Optional
@@ -49,6 +59,8 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 
 - `AgeOver18Circuit` – proves a birth year is at least 18 years in the past.
 - `MembershipCircuit` – proves the subject is a registered member.
+- `MembershipProofCircuit` – proves a private membership flag matches the verifier's expectation.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
+See [`docs/examples/zk_membership.json`](examples/zk_membership.json) for a membership proof example.


### PR DESCRIPTION
## Summary
- implement `MembershipProofCircuit` in icn-zk
- expose circuit in crate API and test it
- document membership proofs with JSON example

## Testing
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68732ddddd188324b6cd14a891db6a4a