### PR TITLE
[docs] describe zk credential proofs

### DIFF
--- a/docs/examples/proposal_with_zk_proof.json
+++ b/docs/examples/proposal_with_zk_proof.json
@@ -1,0 +1,20 @@
+{
+  "proposer_did": "did:key:alice",
+  "proposal": { "type": "PolicyChange", "title": "open_membership" },
+  "description": "Adopt open membership policy",
+  "duration_secs": 86400,
+  "quorum": 3,
+  "threshold": 0.6,
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:alice",
+    "claim_type": "membership",
+    "proof": "0x123456",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xdeadbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -53,6 +53,7 @@ The InterCooperative Network (ICN) governance framework enables communities, coo
 #### **1. Proposal System**
 - **Draft Phase**: Collaborative proposal development
 - **Deliberation Phase**: Community discussion and refinement
+- **Credential Verification**: Proposers attach a zero-knowledge credential proof demonstrating they hold required roles.
 - **Voting Phase**: Democratic decision-making
 - **Execution Phase**: Automatic policy implementation
 - **Amendment Process**: Iterative improvement and adaptation
@@ -153,6 +154,7 @@ fn validate_vote(voter: Did, proposal: Proposal, vote: Vote) -> Bool {
 - **Ballot Creation**: Formal voting interface
 - **Voter Notification**: Alert all eligible participants
 - **Vote Collection**: Secure, anonymous vote recording
+- **Eligibility Proof**: Each ballot includes a zero-knowledge credential proof verifying the voter meets membership requirements.
 - **Real-Time Tallying**: Live vote count display
 
 ### **4. Execution Phase**
@@ -292,7 +294,7 @@ fn emergency_decision(crisis: Crisis) -> EmergencyResponse {
 - **Vote Privacy**: Anonymous voting with public verification
 - **Tamper Evidence**: Cryptographic proof of vote integrity
 - **Audit Trails**: Complete history of all governance actions
-- **Identity Verification**: Secure member authentication
+- **Identity Verification**: Secure member authentication using verifiable credentials and zero-knowledge proofs
 
 ### **Anti-Manipulation Measures**
 - **Sybil Resistance**: Multiple identity prevention


### PR DESCRIPTION
## Summary
- update governance framework to mention credential verification for proposals and votes
- add example proposal JSON showing embedded zero-knowledge proof

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: timed out)*
- `cargo test --all-features --workspace` *(failed: timed out)*
- `cargo test -p icn-ccl` *(failed: timed out)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68732df18db8832496992b12ba378c6e