### PR TITLE
Add BalanceRangeCircuit for ICN zero-knowledge proofs

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -8,7 +8,7 @@ use ark_std::rand::{CryptoRng, RngCore};
 
 mod circuits;
 
-pub use circuits::{AgeOver18Circuit, MembershipCircuit, ReputationCircuit};
+pub use circuits::{AgeOver18Circuit, BalanceRangeCircuit, MembershipCircuit, ReputationCircuit};
 
 /// Generate Groth16 parameters for a given circuit.
 pub fn setup<C: ConstraintSynthesizer<Fr>, R: RngCore + CryptoRng>(

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -36,3 +36,17 @@ fn reputation_threshold_proof() {
     let vk = prepare_vk(&pk);
     assert!(verify(&vk, &proof, &[Fr::from(10u64)]).unwrap());
 }
+
+#[test]
+fn balance_range_proof() {
+    let circuit = BalanceRangeCircuit {
+        balance: 50,
+        min: 10,
+        max: 100,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(10u64), Fr::from(100u64)]).unwrap());
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -50,5 +50,6 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `AgeOver18Circuit` – proves a birth year is at least 18 years in the past.
 - `MembershipCircuit` – proves the subject is a registered member.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
+- `BalanceRangeCircuit` – proves a private balance falls within a provided range.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.


### PR DESCRIPTION
## Summary
- add `BalanceRangeCircuit` proving a balance is within a min/max range
- export the new circuit via `icn-zk`
- add unit test covering the new circuit
- document the circuit in the ZK disclosure guide

## Testing
- `cargo clippy --all-targets --all-features -p icn-zk -- -D warnings`
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68732dde81fc8324b642569123ce63d4