### PR TITLE
Add zk key generation CLI

### DIFF
--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -13,6 +13,11 @@ icn-network = { path = "../icn-network" }
 icn-mesh = { path = "../icn-mesh" }
 icn-ccl = { path = "../../icn-ccl" }
 icn-dag = { path = "../icn-dag" }
+icn-identity = { path = "../icn-identity" }
+icn-runtime = { path = "../icn-runtime" }
+icn-zk = { path = "../icn-zk" }
+ark-serialize = "0.4"
+ark-std = "0.4"
 anyhow = "1.0"
 base64 = "0.21"
 bincode = "1"

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -31,6 +31,8 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
 *   **Identity Operations:**
     *   `icn-cli identity generate-proof <PROOF_REQUEST_JSON>`: Produce a zero-knowledge proof from the supplied request JSON.
     *   `icn-cli identity verify-proof <PROOF_JSON>`: Verify a proof and print whether it is valid.
+*   **Zero-Knowledge Operations:**
+    *   `icn-cli zk generate-key`: Generate a Groth16 proving key and output the verifying key signature.
 *   **Miscellaneous:**
     *   `icn-cli hello`: A simple command to check if the CLI is responsive.
     *   `icn-cli help` or `icn-cli --help`: Displays usage information.
@@ -45,6 +47,14 @@ cargo run -p icn-cli -- identity generate-proof '{"member_did":"did:example:123"
 # Verify the returned proof
 cargo run -p icn-cli -- identity verify-proof '{"proof":"base64string","backend":"Groth16"}'
 # => "verified: true"
+```
+
+### Example: Generate Groth16 Keys
+
+```bash
+# Generate a proving key and verifying key signature
+cargo run -p icn-cli -- zk generate-key
+# => '{"proving_key_path":"./groth16_proving_key.bin","verifying_key_signature_hex":"abc..."}'
 ```
 
 ## Error Handling

--- a/crates/icn-cli/tests/zk_generate_key.rs
+++ b/crates/icn-cli/tests/zk_generate_key.rs
@@ -1,0 +1,25 @@
+use assert_cmd::prelude::*;
+use serde_json::Value;
+use serial_test::serial;
+use std::process::Command;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn zk_generate_key_outputs_paths() {
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["zk", "generate-key"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let v: Value = serde_json::from_str(&stdout).unwrap();
+    let path = v["proving_key_path"].as_str().unwrap();
+    assert!(std::path::Path::new(path).exists());
+    assert!(v["verifying_key_signature_hex"].as_str().unwrap().len() > 0);
+}


### PR DESCRIPTION
## Summary
- add `zk generate-key` command to `icn-cli`
- sign generated Groth16 verifying key with `Ed25519Signer`
- document new command with example usage
- test the new CLI subcommand

## Testing
- `cargo test -p icn-cli zk_generate_key -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68732de6e0b08324ada41ead0d7cbf59