### PR TITLE
[tests] update credential issuance route

### DIFF
--- a/tests/integration/credential_issuance.rs
+++ b/tests/integration/credential_issuance.rs
@@ -33,7 +33,7 @@ async fn credential_issue_route() {
 
     sleep(Duration::from_millis(100)).await;
     let client = Client::new();
-    let url = format!("http://{}/identity/issue", addr);
+    let url = format!("http://{}/identity/credentials/issue", addr);
 
     let mut attrs = BTreeMap::new();
     attrs.insert("role".to_string(), "tester".to_string());


### PR DESCRIPTION
## Summary
- update credential issuance integration test route

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-node`)*

------
https://chatgpt.com/codex/tasks/task_e_68732de30ea48324959a9976236d8517