### PR TITLE
[governance] scoped policy proof enforcement

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -163,9 +163,12 @@ pub async fn submit_dag_block(
     }
 
     if let Some(enforcer) = &policy_enforcer {
-        if let PolicyCheckResult::Denied { reason } =
-            enforcer.check_permission(DagPayloadOp::SubmitBlock, &actor, block.scope.as_ref())
-        {
+        if let PolicyCheckResult::Denied { reason } = enforcer.check_permission(
+            DagPayloadOp::SubmitBlock,
+            &actor,
+            block.scope.as_ref(),
+            None,
+        ) {
             return Err(CommonError::PolicyDenied(reason));
         }
     }
@@ -1143,7 +1146,8 @@ mod tests {
         let actor = Did::new("key", "allowed");
         let mut submitters = HashSet::new();
         submitters.insert(actor.clone());
-        let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
+        let enforcer =
+            InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), false);
 
         let data = b"block".to_vec();
         let ts = 0u64;
@@ -1179,7 +1183,8 @@ mod tests {
         let store = new_test_storage();
         let actor = Did::new("key", "denied");
         let submitters = HashSet::new();
-        let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
+        let enforcer =
+            InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), false);
 
         let data = b"block".to_vec();
         let ts = 0u64;

--- a/crates/icn-governance/Cargo.toml
+++ b/crates/icn-governance/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 [dependencies]
 icn-common = { path = "../icn-common" }
 icn-eventstore = { path = "../icn-eventstore" }
+icn-identity = { path = "../icn-identity" }
 icn-network = { path = "../icn-network", optional = true } # For federation sync
 icn-protocol = { path = "../icn-protocol", optional = true }
 sled = { version = "0.34", optional = true }

--- a/crates/icn-governance/src/scoped_policy.rs
+++ b/crates/icn-governance/src/scoped_policy.rs
@@ -3,7 +3,8 @@ pub enum PolicyCheckResult {
     Denied { reason: String },
 }
 
-use icn_common::{Did, NodeScope};
+use icn_common::{Did, NodeScope, ZkCredentialProof};
+use icn_identity::{Groth16Verifier, ZkVerifier};
 
 /// Operations that may be subject to scoped policy checks when writing to the DAG.
 #[derive(Debug, Clone, Copy)]
@@ -19,6 +20,7 @@ pub trait ScopedPolicyEnforcer: Send + Sync {
         op: DagPayloadOp,
         actor: &Did,
         scope: Option<&NodeScope>,
+        proof: Option<&ZkCredentialProof>,
     ) -> PolicyCheckResult;
 }
 
@@ -30,6 +32,8 @@ pub struct InMemoryPolicyEnforcer {
     submitters: HashSet<Did>,
     anchorers: HashSet<Did>,
     memberships: HashMap<NodeScope, HashSet<Did>>,
+    require_proof: bool,
+    verifier: Groth16Verifier,
 }
 
 impl InMemoryPolicyEnforcer {
@@ -39,11 +43,32 @@ impl InMemoryPolicyEnforcer {
         submitters: HashSet<Did>,
         anchorers: HashSet<Did>,
         memberships: HashMap<NodeScope, HashSet<Did>>,
+        require_proof: bool,
     ) -> Self {
         Self {
             submitters,
             anchorers,
             memberships,
+            require_proof,
+            verifier: Groth16Verifier::default(),
+        }
+    }
+
+    fn validate_proof(&self, proof: Option<&ZkCredentialProof>) -> PolicyCheckResult {
+        if !self.require_proof {
+            return PolicyCheckResult::Allowed;
+        }
+
+        match proof {
+            Some(p) => match self.verifier.verify(p) {
+                Ok(true) => PolicyCheckResult::Allowed,
+                _ => PolicyCheckResult::Denied {
+                    reason: "credential proof invalid".to_string(),
+                },
+            },
+            None => PolicyCheckResult::Denied {
+                reason: "credential proof required".to_string(),
+            },
         }
     }
 }
@@ -54,6 +79,7 @@ impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
         op: DagPayloadOp,
         actor: &Did,
         scope: Option<&NodeScope>,
+        proof: Option<&ZkCredentialProof>,
     ) -> PolicyCheckResult {
         match op {
             DagPayloadOp::SubmitBlock => {
@@ -65,14 +91,14 @@ impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
                             .map(|m| m.contains(actor))
                             .unwrap_or(false)
                         {
-                            PolicyCheckResult::Allowed
+                            self.validate_proof(proof)
                         } else {
                             PolicyCheckResult::Denied {
                                 reason: "actor not in scope".to_string(),
                             }
                         }
                     } else {
-                        PolicyCheckResult::Allowed
+                        self.validate_proof(proof)
                     }
                 } else {
                     PolicyCheckResult::Denied {
@@ -89,14 +115,14 @@ impl ScopedPolicyEnforcer for InMemoryPolicyEnforcer {
                             .map(|m| m.contains(actor))
                             .unwrap_or(false)
                         {
-                            PolicyCheckResult::Allowed
+                            self.validate_proof(proof)
                         } else {
                             PolicyCheckResult::Denied {
                                 reason: "actor not in scope".to_string(),
                             }
                         }
                     } else {
-                        PolicyCheckResult::Allowed
+                        self.validate_proof(proof)
                     }
                 } else {
                     PolicyCheckResult::Denied {

--- a/tests/integration/policy_enforcer.rs
+++ b/tests/integration/policy_enforcer.rs
@@ -1,9 +1,14 @@
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
-use icn_common::{compute_merkle_cid, DagBlock, DagLink, Did, NodeScope};
+use icn_common::{compute_merkle_cid, Cid, DagBlock, DagLink, Did, NodeScope, ZkCredentialProof};
 use icn_governance::scoped_policy::{
     DagPayloadOp, InMemoryPolicyEnforcer, PolicyCheckResult, ScopedPolicyEnforcer,
+};
+use icn_identity::{
+    credential::CredentialIssuer,
+    generate_ed25519_keypair,
+    zk::{Groth16Circuit, Groth16Prover},
 };
 use icn_runtime::context::RuntimeContext;
 
@@ -17,11 +22,13 @@ async fn anchor_block_with_policy<E: ScopedPolicyEnforcer>(
     ctx: &RuntimeContext,
     block: &DagBlock,
     enforcer: &E,
+    proof: Option<&ZkCredentialProof>,
 ) -> Result<(), PolicyError> {
     if let PolicyCheckResult::Denied { .. } = enforcer.check_permission(
         DagPayloadOp::SubmitBlock,
         &block.author_did,
         block.scope.as_ref(),
+        proof,
     ) {
         return Err(PolicyError::Unauthorized);
     }
@@ -48,7 +55,7 @@ async fn authorized_dag_write_succeeds() {
     let alice = Did::from_str("did:example:alice").unwrap();
     let mut submitters = HashSet::new();
     submitters.insert(alice.clone());
-    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), false);
 
     let data = b"block".to_vec();
     let ts = 0u64;
@@ -63,7 +70,7 @@ async fn authorized_dag_write_succeeds() {
         scope: None,
     };
 
-    anchor_block_with_policy(&ctx, &block, &enforcer)
+    anchor_block_with_policy(&ctx, &block, &enforcer, None)
         .await
         .expect("write succeeds");
 
@@ -77,7 +84,7 @@ async fn unauthorized_write_denied() {
     let alice = Did::from_str("did:example:alice").unwrap();
     let mut submitters = HashSet::new();
     submitters.insert(alice.clone());
-    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), false);
 
     let eve = Did::from_str("did:example:eve").unwrap();
     let data = b"bad".to_vec();
@@ -93,7 +100,7 @@ async fn unauthorized_write_denied() {
         scope: None,
     };
 
-    let res = anchor_block_with_policy(&ctx, &block, &enforcer).await;
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None).await;
     assert_eq!(res, Err(PolicyError::Unauthorized));
 }
 
@@ -103,7 +110,7 @@ async fn invalid_parent_is_rejected() {
     let alice = Did::from_str("did:example:alice").unwrap();
     let mut submitters = HashSet::new();
     submitters.insert(alice.clone());
-    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), false);
 
     let missing_cid = compute_merkle_cid(0x71, b"parent", &[], 0, &alice, &None, &None);
     let link = DagLink {
@@ -124,7 +131,7 @@ async fn invalid_parent_is_rejected() {
         scope: None,
     };
 
-    let res = anchor_block_with_policy(&ctx, &block, &enforcer).await;
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None).await;
     assert_eq!(res, Err(PolicyError::InvalidParent));
 }
 
@@ -141,7 +148,7 @@ async fn scope_membership_enforced() {
         set.insert(alice.clone());
         set
     });
-    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), memberships);
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), memberships, false);
 
     let data = b"scoped".to_vec();
     let ts = 0u64;
@@ -156,7 +163,115 @@ async fn scope_membership_enforced() {
         scope: Some(scope),
     };
 
-    anchor_block_with_policy(&ctx, &block, &enforcer)
+    anchor_block_with_policy(&ctx, &block, &enforcer, None)
         .await
         .expect("scoped write succeeds");
+}
+
+#[tokio::test]
+async fn proof_required_without_proof_fails() {
+    let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
+    let alice = Did::from_str("did:example:alice").unwrap();
+    let mut submitters = HashSet::new();
+    submitters.insert(alice.clone());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), true);
+
+    let data = b"block".to_vec();
+    let ts = 0u64;
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &alice, &None, &None);
+    let block = DagBlock {
+        cid,
+        data,
+        links: vec![],
+        timestamp: ts,
+        author_did: alice.clone(),
+        signature: None,
+        scope: None,
+    };
+
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None).await;
+    assert_eq!(res, Err(PolicyError::Unauthorized));
+}
+
+#[tokio::test]
+async fn proof_required_invalid_proof_fails() {
+    let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
+    let alice = Did::from_str("did:example:alice").unwrap();
+    let mut submitters = HashSet::new();
+    submitters.insert(alice.clone());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), true);
+
+    let invalid = ZkCredentialProof {
+        issuer: alice.clone(),
+        holder: alice.clone(),
+        claim_type: "age_over_18".into(),
+        proof: vec![0u8; 10],
+        schema: Cid::new_v1_sha256(0x55, b"schema"),
+        vk_cid: None,
+        disclosed_fields: Vec::new(),
+        challenge: None,
+        backend: icn_common::ZkProofType::Groth16,
+        verification_key: None,
+        public_inputs: None,
+    };
+
+    let data = b"block".to_vec();
+    let ts = 0u64;
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &alice, &None, &None);
+    let block = DagBlock {
+        cid,
+        data,
+        links: vec![],
+        timestamp: ts,
+        author_did: alice.clone(),
+        signature: None,
+        scope: None,
+    };
+
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, Some(&invalid)).await;
+    assert_eq!(res, Err(PolicyError::Unauthorized));
+}
+
+#[tokio::test]
+async fn proof_required_valid_proof_allows() {
+    let ctx = RuntimeContext::new_with_stubs("did:example:alice").unwrap();
+    let alice = Did::from_str("did:example:alice").unwrap();
+    let mut submitters = HashSet::new();
+    submitters.insert(alice.clone());
+    let enforcer = InMemoryPolicyEnforcer::new(submitters, HashSet::new(), HashMap::new(), true);
+
+    let (sk, _) = generate_ed25519_keypair();
+    let issuer =
+        CredentialIssuer::new(alice.clone(), sk).with_prover(Box::new(Groth16Prover::default()));
+    let mut claims = HashMap::new();
+    claims.insert("birth_year".to_string(), "2000".to_string());
+    let (_, proof_opt) = issuer
+        .issue(
+            alice.clone(),
+            claims,
+            Some(Cid::new_v1_sha256(0x55, b"schema")),
+            Some(&[]),
+            Some(Groth16Circuit::AgeOver18 { current_year: 2020 }),
+        )
+        .unwrap();
+    let proof = proof_opt.expect("proof");
+
+    let data = b"block".to_vec();
+    let ts = 0u64;
+    let cid = compute_merkle_cid(0x71, &data, &[], ts, &alice, &None, &None);
+    let block = DagBlock {
+        cid: cid.clone(),
+        data,
+        links: vec![],
+        timestamp: ts,
+        author_did: alice.clone(),
+        signature: None,
+        scope: None,
+    };
+
+    anchor_block_with_policy(&ctx, &block, &enforcer, Some(&proof))
+        .await
+        .expect("write succeeds with proof");
+    let stored = ctx.dag_store.lock().await.get(&cid).unwrap();
+    assert!(stored.is_some());
 }


### PR DESCRIPTION
## Summary
- extend `ScopedPolicyEnforcer` to accept optional ZkCredentialProof
- verify proofs in `InMemoryPolicyEnforcer` with `Groth16Verifier`
- require valid proofs in new policy enforcer integration tests

## Testing
- `cargo fmt --all -- --check`
- ❌ `cargo clippy --all-targets --all-features -- -D warnings` *(failed: interrupted due to timeout)*
- ❌ `cargo test --all-features --workspace` *(failed: interrupted due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68732df0c0588324b2d3d247ca9a4173