### PR TITLE
Add credential management API

### DIFF
--- a/crates/icn-api/Cargo.toml
+++ b/crates/icn-api/Cargo.toml
@@ -13,6 +13,7 @@ icn-protocol = { path = "../icn-protocol" }
 icn-governance = { path = "../icn-governance", features = ["serde"] }
 icn-economics = { path = "../icn-economics", optional = true }
 icn-mesh = { path = "../icn-mesh", optional = true }
+icn-identity = { path = "../icn-identity" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { workspace = true }

--- a/crates/icn-api/src/identity_trait.rs
+++ b/crates/icn-api/src/identity_trait.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use icn_common::{Cid, CommonError, Did, VerifiableCredential};
+use icn_common::{Cid, CommonError, Did};
+use icn_identity::Credential as VerifiableCredential;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -16,6 +17,7 @@ pub struct IssueCredentialRequest {
 /// Response containing the issued credential.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CredentialResponse {
+    pub cid: Cid,
     pub credential: VerifiableCredential,
 }
 
@@ -23,6 +25,11 @@ pub struct CredentialResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VerificationResponse {
     pub valid: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevokeCredentialRequest {
+    pub cid: Cid,
 }
 
 #[async_trait]
@@ -36,4 +43,10 @@ pub trait IdentityApi {
         &self,
         credential: VerifiableCredential,
     ) -> Result<VerificationResponse, CommonError>;
+
+    async fn get_credential(&self, cid: Cid) -> Result<CredentialResponse, CommonError>;
+
+    async fn revoke_credential(&self, cid: Cid) -> Result<(), CommonError>;
+
+    async fn list_schemas(&self) -> Result<Vec<Cid>, CommonError>;
 }

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -43,6 +43,7 @@ static HTTP_BREAKER: Lazy<AsyncMutex<CircuitBreaker<SystemTimeProvider>>> = Lazy
 pub mod dag_trait;
 pub mod federation_trait;
 pub mod governance_trait;
+pub mod identity_trait;
 /// Prometheus metrics helpers
 pub mod metrics;
 use crate::governance_trait::{

--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 icn-common = { path = "../icn-common" }
+dashmap = "5"
 
 # --- crypto ---
 ed25519-dalek = { version = "2.0.0-pre.3", features = ["rand_core"] }

--- a/crates/icn-identity/src/credential_store.rs
+++ b/crates/icn-identity/src/credential_store.rs
@@ -1,0 +1,39 @@
+use dashmap::DashMap;
+use std::sync::Arc;
+
+use icn_common::Cid;
+
+use crate::credential::Credential;
+
+/// Simple in-memory store for issued credentials.
+#[derive(Clone, Default)]
+pub struct InMemoryCredentialStore {
+    creds: Arc<DashMap<Cid, Credential>>,
+}
+
+impl InMemoryCredentialStore {
+    pub fn new() -> Self {
+        Self {
+            creds: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub fn insert(&self, cid: Cid, cred: Credential) {
+        self.creds.insert(cid, cred);
+    }
+
+    pub fn get(&self, cid: &Cid) -> Option<Credential> {
+        self.creds.get(cid).map(|c| c.clone())
+    }
+
+    pub fn revoke(&self, cid: &Cid) -> bool {
+        self.creds.remove(cid).is_some()
+    }
+
+    pub fn list_schemas(&self) -> Vec<Cid> {
+        self.creds
+            .iter()
+            .filter_map(|e| e.value().schema.clone())
+            .collect()
+    }
+}

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -25,6 +25,8 @@ pub use zk::{
 };
 pub mod credential;
 pub use credential::{Credential, CredentialIssuer, DisclosedCredential};
+pub mod credential_store;
+pub use credential_store::InMemoryCredentialStore;
 
 // --- Core Cryptographic Operations & DID:key generation ---
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -40,6 +40,10 @@ name = "parameter_change"
 path = "integration/parameter_change.rs"
 
 [[test]]
+name = "credential_issuance"
+path = "integration/credential_issuance.rs"
+
+[[test]]
 name = "ccl_operator_precedence"
 path = "../icn-ccl/tests/operator_precedence.rs"
 
@@ -83,3 +87,4 @@ icn-common = { path = "../crates/icn-common" }
 icn-protocol = { path = "../crates/icn-protocol" }
 icn-identity = { path = "../crates/icn-identity" }
 icn-network = { path = "../crates/icn-network" }
+icn-api = { path = "../crates/icn-api" }

--- a/tests/integration/credential_issuance.rs
+++ b/tests/integration/credential_issuance.rs
@@ -1,10 +1,13 @@
-use icn_api::identity_trait::IssueCredentialRequest;
+use icn_api::identity_trait::{
+    CredentialResponse, IssueCredentialRequest, RevokeCredentialRequest, VerificationResponse,
+};
+use icn_common::{Cid, Did};
+use icn_identity::Credential;
 use icn_node::app_router_with_options;
-use icn_common::{Cid, Did, VerifiableCredential};
-use reqwest::Client;
+use reqwest::{Client, StatusCode};
+use std::collections::BTreeMap;
 use tokio::task;
 use tokio::time::{sleep, Duration};
-use std::collections::BTreeMap;
 
 #[tokio::test]
 async fn credential_issue_route() {
@@ -33,7 +36,7 @@ async fn credential_issue_route() {
 
     sleep(Duration::from_millis(100)).await;
     let client = Client::new();
-    let url = format!("http://{}/identity/issue", addr);
+    let url = format!("http://{}/identity/credentials/issue", addr);
 
     let mut attrs = BTreeMap::new();
     attrs.insert("role".to_string(), "tester".to_string());
@@ -45,10 +48,46 @@ async fn credential_issue_route() {
         expiration: 1,
     };
 
-    let resp = client.post(url).json(&req).send().await.unwrap();
+    let resp = client.post(&url).json(&req).send().await.unwrap();
     assert!(resp.status().is_success());
-    let cred: VerifiableCredential = resp.json().await.unwrap();
-    assert!(cred.verify_against_key(ctx.signer.verifying_key_ref()).is_ok());
+    let resp_body: CredentialResponse = resp.json().await.unwrap();
+    let cid = resp_body.cid.clone();
+    let cred: Credential = resp_body.credential;
+    for (k, _) in &cred.claims {
+        assert!(cred.verify_claim(k, ctx.signer.verifying_key_ref()).is_ok());
+    }
+
+    // retrieve
+    let get_url = format!("http://{}/identity/credentials/{}", addr, cid.to_string());
+    let resp = client.get(&get_url).send().await.unwrap();
+    assert!(resp.status().is_success());
+    let retrieved: CredentialResponse = resp.json().await.unwrap();
+    assert_eq!(retrieved.cid, cid);
+
+    // verify via API
+    let verify_url = format!("http://{}/identity/credentials/verify", addr);
+    let resp = client
+        .post(&verify_url)
+        .json(&retrieved.credential)
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    let v: VerificationResponse = resp.json().await.unwrap();
+    assert!(v.valid);
+
+    // revoke
+    let revoke_url = format!("http://{}/identity/credentials/revoke", addr);
+    let resp = client
+        .post(&revoke_url)
+        .json(&RevokeCredentialRequest { cid: cid.clone() })
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    let resp = client.get(&get_url).send().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     server.abort();
 }


### PR DESCRIPTION
## Summary
- extend identity API with credential query, revoke, and schema listing
- implement credential handlers in icn-node
- provide in-memory credential store
- test credential issuance via HTTP

## Testing
- `cargo test --test credential_issuance -- --test-threads=1`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68732de29b7083249e1b7152cabedfe1