### PR TITLE
Add timestamp validity circuit for zk proofs

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -8,7 +8,9 @@ use ark_std::rand::{CryptoRng, RngCore};
 
 mod circuits;
 
-pub use circuits::{AgeOver18Circuit, MembershipCircuit, ReputationCircuit};
+pub use circuits::{
+    AgeOver18Circuit, MembershipCircuit, ReputationCircuit, TimestampValidityCircuit,
+};
 
 /// Generate Groth16 parameters for a given circuit.
 pub fn setup<C: ConstraintSynthesizer<Fr>, R: RngCore + CryptoRng>(

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -36,3 +36,17 @@ fn reputation_threshold_proof() {
     let vk = prepare_vk(&pk);
     assert!(verify(&vk, &proof, &[Fr::from(10u64)]).unwrap());
 }
+
+#[test]
+fn timestamp_validity_proof() {
+    let circuit = TimestampValidityCircuit {
+        timestamp: 50,
+        not_before: 40,
+        not_after: 60,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(40u64), Fr::from(60u64)]).unwrap());
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -50,5 +50,6 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `AgeOver18Circuit` – proves a birth year is at least 18 years in the past.
 - `MembershipCircuit` – proves the subject is a registered member.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
+- `TimestampValidityCircuit` – proves a timestamp falls within a not-before/not-after range.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.


### PR DESCRIPTION
## Summary
- implement `TimestampValidityCircuit` in icn-zk
- re-export the circuit in the crate API
- test proving a timestamp is within bounds
- document the circuit in zk_disclosure guide

## Testing
- `cargo fmt --all`
- `just lint` *(fails: clippy errors in unrelated crates)*
- `just test` *(interrupted due to long compile time)*

------
https://chatgpt.com/codex/tasks/task_e_68732ddddf5c832488e8a9f16cd3aeaa