### PR TITLE
Add TimestampValidityCircuit

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -9,7 +9,12 @@ use ark_std::rand::{CryptoRng, RngCore};
 mod circuits;
 mod params;
 
-pub use circuits::{AgeOver18Circuit, MembershipCircuit, ReputationCircuit};
+pub use circuits::{
+    AgeOver18Circuit,
+    MembershipCircuit,
+    ReputationCircuit,
+    TimestampValidityCircuit,
+};
 pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};
 
 /// Generate Groth16 parameters for a given circuit.

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -54,3 +54,22 @@ fn circuit_parameters_roundtrip() {
     let vk = fetched.prepared_vk().unwrap();
     assert!(verify(&vk, &proof, &[Fr::from(2020u64)]).unwrap());
 }
+
+#[test]
+fn timestamp_validity_proof() {
+    let circuit = TimestampValidityCircuit {
+        timestamp: 1_650_000_000,
+        not_before: 1_600_000_000,
+        not_after: 1_700_000_000,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(
+        &vk,
+        &proof,
+        &[Fr::from(1_600_000_000u64), Fr::from(1_700_000_000u64)]
+    )
+    .unwrap());
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -50,6 +50,7 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `AgeOver18Circuit` – proves a birth year is at least 18 years in the past.
 - `MembershipCircuit` – proves the subject is a registered member.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
+- `TimestampValidityCircuit` – proves a timestamp falls within a valid range.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
 


### PR DESCRIPTION
## Summary
- add `TimestampValidityCircuit` proving a timestamp is within bounds
- expose new circuit in crate API
- test proving and verifying the timestamp range
- document new circuit in ZK disclosure guide

## Testing
- `cargo test -p icn-zk -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_687337041f148324b63d0c2d9a741755