### PR TITLE
[icn-zk] add balance range circuit

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -9,7 +9,7 @@ use ark_std::rand::{CryptoRng, RngCore};
 mod circuits;
 mod params;
 
-pub use circuits::{AgeOver18Circuit, MembershipCircuit, ReputationCircuit};
+pub use circuits::{AgeOver18Circuit, BalanceRangeCircuit, MembershipCircuit, ReputationCircuit};
 pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};
 
 /// Generate Groth16 parameters for a given circuit.

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -38,6 +38,20 @@ fn reputation_threshold_proof() {
 }
 
 #[test]
+fn balance_range_proof() {
+    let circuit = BalanceRangeCircuit {
+        balance: 8,
+        min: 5,
+        max: 10,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(5u64), Fr::from(10u64)]).unwrap());
+}
+
+#[test]
 fn circuit_parameters_roundtrip() {
     let circuit = AgeOver18Circuit {
         birth_year: 2000,

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -50,6 +50,7 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `AgeOver18Circuit` – proves a birth year is at least 18 years in the past.
 - `MembershipCircuit` – proves the subject is a registered member.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
+- `BalanceRangeCircuit` – proves a balance falls within a specified range.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
 


### PR DESCRIPTION
## Summary
- introduce `BalanceRangeCircuit` proving a balance lies within a public range
- re-export new circuit in library
- test proving and verifying balance ranges
- document circuit in ZK disclosure guide

## Testing
- `cargo clippy -p icn-zk --all-targets --all-features -- -D warnings`
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_687333b370c88324b00bbe2160f5ef73