### PR TITLE
Add MembershipProofCircuit and example

### DIFF
--- a/crates/icn-zk/src/circuits.rs
+++ b/crates/icn-zk/src/circuits.rs
@@ -45,6 +45,24 @@ impl ConstraintSynthesizer<Fr> for MembershipCircuit {
     }
 }
 
+/// Prove that a private membership flag matches an expected public value.
+#[derive(Clone)]
+pub struct MembershipProofCircuit {
+    /// Membership flag provided by the prover (private).
+    pub membership_flag: bool,
+    /// Expected membership value published by the verifier (public).
+    pub expected: bool,
+}
+
+impl ConstraintSynthesizer<Fr> for MembershipProofCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let flag = Boolean::new_witness(cs.clone(), || Ok(self.membership_flag))?;
+        let expected = Boolean::new_input(cs, || Ok(self.expected))?;
+        flag.enforce_equal(&expected)?;
+        Ok(())
+    }
+}
+
 /// Prove that `reputation >= threshold`.
 #[derive(Clone)]
 pub struct ReputationCircuit {

--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -10,9 +10,7 @@ mod circuits;
 mod params;
 
 pub use circuits::{
-    AgeOver18Circuit,
-    MembershipCircuit,
-    ReputationCircuit,
+    AgeOver18Circuit, MembershipCircuit, MembershipProofCircuit, ReputationCircuit,
     TimestampValidityCircuit,
 };
 pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -25,6 +25,19 @@ fn membership_proof() {
 }
 
 #[test]
+fn membership_flag_proof() {
+    let circuit = MembershipProofCircuit {
+        membership_flag: true,
+        expected: true,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(1u64)]).unwrap());
+}
+
+#[test]
 fn reputation_threshold_proof() {
     let circuit = ReputationCircuit {
         reputation: 10,

--- a/docs/examples/zk_membership.json
+++ b/docs/examples/zk_membership.json
@@ -1,0 +1,7 @@
+{
+  "proof": "0xdeadbeef",
+  "public_inputs": {
+    "statement": "membership",
+    "expected": true
+  }
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -49,10 +49,12 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 
 - `AgeOver18Circuit` – proves a birth year is at least 18 years in the past.
 - `MembershipCircuit` – proves the subject is a registered member.
+- `MembershipProofCircuit` – proves a private membership flag equals the expected value.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
 - `TimestampValidityCircuit` – proves a timestamp falls within a valid range.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
+See [`docs/examples/zk_membership.json`](examples/zk_membership.json) for a membership proof example.
 
 ### Groth16KeyManager
 `Groth16KeyManager` generates Groth16 parameters, stores them under


### PR DESCRIPTION
## Summary
- add `MembershipProofCircuit` to icn-zk for verifying a private boolean
- export the circuit from the crate API
- test new circuit
- document membership proof usage with JSON example

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68733b5c3a50832489b50c746d3b8acb