### PR TITLE
Add BalanceRangeCircuit with test

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -10,9 +10,7 @@ mod circuits;
 mod params;
 
 pub use circuits::{
-    AgeOver18Circuit,
-    MembershipCircuit,
-    ReputationCircuit,
+    AgeOver18Circuit, BalanceRangeCircuit, MembershipCircuit, ReputationCircuit,
     TimestampValidityCircuit,
 };
 pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -73,3 +73,17 @@ fn timestamp_validity_proof() {
     )
     .unwrap());
 }
+
+#[test]
+fn balance_range_proof() {
+    let circuit = BalanceRangeCircuit {
+        balance: 50,
+        min: 0,
+        max: 100,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(0u64), Fr::from(100u64)]).unwrap());
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -51,6 +51,7 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `MembershipCircuit` – proves the subject is a registered member.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
 - `TimestampValidityCircuit` – proves a timestamp falls within a valid range.
+- `BalanceRangeCircuit` – proves a balance is between a minimum and maximum value.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
 


### PR DESCRIPTION
## Summary
- add `BalanceRangeCircuit` for verifying a balance is within `[min, max]`
- expose new circuit in `lib.rs`
- test proving and verifying a balance range
- document the circuit in `zk_disclosure.md`

## Testing
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68733b7a9b748324a80566249ead7b6e