### PR TITLE
Add BalanceRangeCircuit to icn-zk

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -10,8 +10,8 @@ mod circuits;
 mod params;
 
 pub use circuits::{
-    AgeOver18Circuit, MembershipCircuit, MembershipProofCircuit, ReputationCircuit,
-    TimestampValidityCircuit,
+    AgeOver18Circuit, BalanceRangeCircuit, MembershipCircuit, MembershipProofCircuit,
+    ReputationCircuit, TimestampValidityCircuit,
 };
 pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};
 

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -86,3 +86,17 @@ fn timestamp_validity_proof() {
     )
     .unwrap());
 }
+
+#[test]
+fn balance_range_proof() {
+    let circuit = BalanceRangeCircuit {
+        balance: 75,
+        min: 50,
+        max: 100,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(&vk, &proof, &[Fr::from(50u64), Fr::from(100u64)]).unwrap());
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -52,6 +52,7 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `MembershipProofCircuit` – proves a private membership flag equals the expected value.
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
 - `TimestampValidityCircuit` – proves a timestamp falls within a valid range.
+- `BalanceRangeCircuit` – proves a private balance lies between a public minimum and maximum.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
 See [`docs/examples/zk_membership.json`](examples/zk_membership.json) for a membership proof example.


### PR DESCRIPTION
## Summary
- add `BalanceRangeCircuit` proving a balance is between a min and max
- re-export new circuit
- document new circuit in zk disclosure guide
- test proving a balance range

## Testing
- `cargo clippy -p icn-zk -- -D warnings`
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_687348cf3f8c83249d4973c565ac0053