### PR TITLE
Add zero-knowledge proof host ABI

### DIFF
--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -96,6 +96,13 @@ async fn finalize_proposal(ctx: &RuntimeContext, pid: &str) -> Result<(), icn_ru
 }
 ```
 
+### Zero-Knowledge Proofs
+
+`host_verify_zk_proof` validates a serialized `ZkCredentialProof` and returns
+`true` when the proof is valid for the selected backend. `host_generate_zk_proof`
+emits a dummy proof for testing. WASM modules can call these via the
+`wasm_host_verify_zk_proof` and `wasm_host_generate_zk_proof` helpers.
+
 ## Mana Regeneration
 
 `RuntimeContext` can automatically replenish mana. Use

--- a/crates/icn-runtime/src/abi.rs
+++ b/crates/icn-runtime/src/abi.rs
@@ -31,6 +31,16 @@ pub const ABI_HOST_ANCHOR_RECEIPT: u32 = 23;
 /// Retrieves the reputation score for the given DID.
 pub const ABI_HOST_GET_REPUTATION: u32 = 24;
 
+/// ABI Index for `host_verify_zk_proof`.
+/// Verifies a [`ZkCredentialProof`](icn_common::ZkCredentialProof)
+/// provided by the caller.
+pub const ABI_HOST_VERIFY_ZK_PROOF: u32 = 25;
+
+/// ABI Index for `host_generate_zk_proof`.
+/// Creates a placeholder [`ZkCredentialProof`](icn_common::ZkCredentialProof)
+/// using the supplied parameters.
+pub const ABI_HOST_GENERATE_ZK_PROOF: u32 = 26;
+
 // --- Governance ABI Functions (RFC 0010) ---
 // Indices reserved for governance operations defined in RFC 0010.
 

--- a/crates/icn-runtime/tests/zk_proof.rs
+++ b/crates/icn-runtime/tests/zk_proof.rs
@@ -1,0 +1,50 @@
+use icn_common::{Cid, Did, ZkCredentialProof, ZkProofType};
+use icn_runtime::{context::{RuntimeContext, HostAbiError}, host_generate_zk_proof, host_verify_zk_proof};
+use std::str::FromStr;
+
+#[tokio::test]
+async fn generate_and_verify_dummy_proof() {
+    let ctx = RuntimeContext::new_with_stubs("did:key:zProof").unwrap();
+    let issuer = Did::from_str("did:key:zIssuer").unwrap();
+    let holder = Did::from_str("did:key:zHolder").unwrap();
+    let schema = Cid::new_v1_sha256(0x55, b"schema");
+    let req = serde_json::json!({
+        "issuer": issuer.to_string(),
+        "holder": holder.to_string(),
+        "claim_type": "test",
+        "schema": schema.to_string(),
+        "backend": "dummy",
+    });
+    let proof_json = host_generate_zk_proof(&ctx, &req.to_string()).await.unwrap();
+    let proof: ZkCredentialProof = serde_json::from_str(&proof_json).unwrap();
+    assert_eq!(proof.backend, ZkProofType::Other("dummy".into()));
+    let verified = host_verify_zk_proof(&ctx, &proof_json).await.unwrap();
+    assert!(verified);
+}
+
+#[tokio::test]
+async fn verify_invalid_proof_fails() {
+    let ctx = RuntimeContext::new_with_stubs("did:key:zProof2").unwrap();
+    let proof = ZkCredentialProof {
+        issuer: Did::from_str("did:key:zIss").unwrap(),
+        holder: Did::from_str("did:key:zHold").unwrap(),
+        claim_type: "test".into(),
+        proof: vec![1,2,3],
+        schema: Cid::new_v1_sha256(0x55, b"s"),
+        vk_cid: None,
+        disclosed_fields: Vec::new(),
+        challenge: None,
+        backend: ZkProofType::Groth16,
+        verification_key: None,
+        public_inputs: None,
+    };
+    let json = serde_json::to_string(&proof).unwrap();
+    assert!(host_verify_zk_proof(&ctx, &json).await.is_err());
+}
+
+#[tokio::test]
+async fn generate_invalid_json() {
+    let ctx = RuntimeContext::new_with_stubs("did:key:zProof3").unwrap();
+    let err = host_generate_zk_proof(&ctx, "not-json").await.err().unwrap();
+    assert!(matches!(err, HostAbiError::InvalidParameters(_)));
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -62,3 +62,17 @@ See [`docs/examples/zk_membership.json`](examples/zk_membership.json) for a memb
 `~/.icn/zk/`, and signs the verifying key with an Ed25519 key. Use
 `load_proving_key` and `verify_key_signature` to access the stored parameters
 and confirm their authenticity.
+
+## Runtime ABI
+
+Two host functions are provided for working with zero-knowledge proofs:
+
+- **`host_verify_zk_proof`** (`ABI index 25`) – accepts a JSON encoded
+  [`ZkCredentialProof`](../crates/icn-common/src/zk.rs) and returns `true` when
+  verification succeeds.
+- **`host_generate_zk_proof`** (`ABI index 26`) – creates a dummy proof object
+  from supplied parameters, useful for testing flows without a real prover.
+
+When called from WASM, use the `wasm_host_verify_zk_proof` and
+`wasm_host_generate_zk_proof` wrappers which handle passing strings in and out
+of guest memory.


### PR DESCRIPTION
## Summary
- expose ABI indices for verifying and generating ZK proofs
- implement runtime helpers `host_verify_zk_proof` and `host_generate_zk_proof`
- add WASM wrappers and host environment methods
- document ZK proof ABI in runtime README and zk_disclosure guide
- test proof generation and verification

## Testing
- `cargo test -p icn-runtime --test zk_proof`

------
https://chatgpt.com/codex/tasks/task_e_68734ebb66c88324b463858db504ebb6