### PR TITLE
[icn-zk] composite proof circuit

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -10,8 +10,8 @@ mod circuits;
 mod params;
 
 pub use circuits::{
-    AgeOver18Circuit, BalanceRangeCircuit, MembershipCircuit, MembershipProofCircuit,
-    ReputationCircuit, TimestampValidityCircuit,
+    AgeOver18Circuit, AgeRepMembershipCircuit, BalanceRangeCircuit, MembershipCircuit,
+    MembershipProofCircuit, ReputationCircuit, TimestampValidityCircuit,
 };
 pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};
 

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -100,3 +100,24 @@ fn balance_range_proof() {
     let vk = prepare_vk(&pk);
     assert!(verify(&vk, &proof, &[Fr::from(50u64), Fr::from(100u64)]).unwrap());
 }
+
+#[test]
+fn age_rep_membership_proof() {
+    let circuit = AgeRepMembershipCircuit {
+        birth_year: 2000,
+        current_year: 2020,
+        reputation: 10,
+        threshold: 5,
+        is_member: true,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    assert!(verify(
+        &vk,
+        &proof,
+        &[Fr::from(2020u64), Fr::from(10u64), Fr::from(1u64)]
+    )
+    .unwrap());
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -53,6 +53,7 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
 - `TimestampValidityCircuit` – proves a timestamp falls within a valid range.
 - `BalanceRangeCircuit` – proves a private balance lies between a public minimum and maximum.
+- `AgeRepMembershipCircuit` – proves age over 18, membership status, and reputation threshold in one proof.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
 See [`docs/examples/zk_membership.json`](examples/zk_membership.json) for a membership proof example.


### PR DESCRIPTION
## Summary
- add `AgeRepMembershipCircuit` to combine age, reputation, and membership checks
- expose new circuit from the `icn-zk` crate
- test proving/verification for combined circuit
- document the new circuit in zk disclosure guide

## Testing
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68734dade754832485827da1c6d90ab1