### PR TITLE
Add Groth16 proof verification method with cache

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -29,7 +29,9 @@ ark-groth16 = "0.4"
 ark-bn254 = "0.4"
 ark-serialize = "0.4"
 ark-std = "0.4"
+ark-snark = "0.4"
 directories-next = "2"
+serde_json = "1.0"
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -88,3 +88,8 @@ icn-protocol = { path = "../crates/icn-protocol" }
 icn-identity = { path = "../crates/icn-identity" }
 icn-network = { path = "../crates/icn-network" }
 icn-api = { path = "../crates/icn-api" }
+icn-zk = { path = "../crates/icn-zk" }
+ark-groth16 = "0.4"
+ark-bn254 = "0.4"
+ark-serialize = "0.4"
+rand_core = "0.6"


### PR DESCRIPTION
## Summary
- support verifying Groth16 proofs directly via `Groth16Verifier::verify_proof`
- cache prepared verifying keys when provided in proofs
- parse public inputs from proofs
- test cache behaviour and key signature handling
- send valid proofs through API integration test

## Testing
- `cargo test -p icn-identity --lib --quiet`
- `cargo test --test zk_proof_verification --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68734e9a10248324bf9dfd4dfda2cea3