### PR TITLE
Add prepared verifying key cache for Groth16

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -29,6 +29,8 @@ ark-groth16 = "0.4"
 ark-bn254 = "0.4"
 ark-serialize = "0.4"
 ark-std = "0.4"
+once_cell = "1.21"
+lru = "0.16"
 directories-next = "2"
 
 # Ensure old ones are removed if they conflict or are replaced

--- a/crates/icn-identity/src/zk/vk_cache.rs
+++ b/crates/icn-identity/src/zk/vk_cache.rs
@@ -1,0 +1,33 @@
+use ark_bn254::Bn254;
+use ark_groth16::{prepare_verifying_key, PreparedVerifyingKey, VerifyingKey};
+use ark_serialize::CanonicalDeserialize;
+use lru::LruCache;
+use once_cell::sync::Lazy;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+use super::ZkError;
+
+/// Cache of prepared verifying keys keyed by their serialized representation.
+static PREPARED_VK_CACHE: Lazy<Mutex<LruCache<Vec<u8>, PreparedVerifyingKey<Bn254>>>> =
+    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(32).unwrap())));
+
+/// Convenience wrapper around the global prepared verifying key cache.
+pub struct PreparedVkCache;
+
+impl PreparedVkCache {
+    /// Deserialize the verifying key and insert it into the cache if absent.
+    pub fn get_or_insert(bytes: &[u8]) -> Result<PreparedVerifyingKey<Bn254>, ZkError> {
+        let mut cache = PREPARED_VK_CACHE
+            .lock()
+            .expect("prepared vk cache mutex poisoned");
+        if let Some(pvk) = cache.get(bytes) {
+            return Ok(pvk.clone());
+        }
+        let vk = VerifyingKey::<Bn254>::deserialize_compressed(bytes)
+            .map_err(|_| ZkError::InvalidProof)?;
+        let pvk = prepare_verifying_key(&vk);
+        cache.put(bytes.to_vec(), pvk.clone());
+        Ok(pvk)
+    }
+}


### PR DESCRIPTION
## Summary
- add new `PreparedVkCache` in identity crate
- use cache in `Groth16Verifier` when verification key bytes are supplied

## Testing
- `cargo clippy -p icn-identity -- -D warnings`
- `cargo test -p icn-identity`


------
https://chatgpt.com/codex/tasks/task_e_68734e98f748832493e1815f5e8ffe95