### PR TITLE
Support revocation proofs in scoped policy checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ devnet, and expanded security guidance.
 - HTTP gateway enabling REST job submission and status queries.
 - Containerized 3-node federation devnet with Docker and integration tests.
 - `Ed25519Signer` replaces `StubSigner` for production runtime; tests may continue using `StubSigner`.
+- Optional `ZkRevocationProof` checks for policy enforcement in `icn-governance`.
 - Comprehensive production security guide covering Ed25519 migration, TLS, and authentication.
 - Enhanced API documentation with all current endpoints, authentication, and TLS features.
 - Updated feature overview reflecting production-ready status and completed Phase 5 milestones.
@@ -42,6 +43,7 @@ devnet, and expanded security guidance.
 - Enhanced API documentation to include TLS, authentication, and all current endpoints.
 - Updated feature overview moving many items from "In Development" to "Implemented" status.
 - Improved quick start examples with production configuration options.
+- `ScopedPolicyEnforcer::check_permission` now accepts an optional `ZkRevocationProof` argument.
 
 ### Deprecated
 

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -169,6 +169,7 @@ pub async fn submit_dag_block(
             &actor,
             block.scope.as_ref(),
             None,
+            None,
         ) {
             return Err(CommonError::PolicyDenied(reason));
         }

--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -14,7 +14,7 @@ pub mod resilience;
 pub use resilience::{CircuitBreaker, CircuitBreakerError, CircuitState};
 pub mod resource_token;
 pub mod zk;
-pub use zk::{ZkCredentialProof, ZkProofType};
+pub use zk::{ZkCredentialProof, ZkProofType, ZkRevocationProof};
 
 pub const ICN_CORE_VERSION: &str = "0.2.0-beta";
 

--- a/crates/icn-common/src/zk.rs
+++ b/crates/icn-common/src/zk.rs
@@ -42,3 +42,25 @@ pub struct ZkCredentialProof {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_inputs: Option<serde_json::Value>,
 }
+
+/// Proof that a credential has not been revoked.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkRevocationProof {
+    /// DID of the credential issuer.
+    pub issuer: Did,
+    /// DID of the credential holder.
+    pub holder: Did,
+    /// CID of the credential being checked for revocation.
+    pub credential_cid: Cid,
+    /// Raw bytes of the zero-knowledge proof.
+    #[serde(with = "serde_bytes")]
+    pub proof: Vec<u8>,
+    /// Backend proving system used for this proof.
+    pub backend: ZkProofType,
+    /// Optional verification key bytes used to verify the proof.
+    #[serde(with = "serde_bytes", default, skip_serializing_if = "Option::is_none")]
+    pub verification_key: Option<Vec<u8>>,
+    /// Optional public input values required for verification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_inputs: Option<serde_json::Value>,
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -29,6 +29,8 @@ See [`docs/examples/zk_example.json`](examples/zk_example.json) for a minimal JS
 `ZkCredentialProof` objects exchanged with ICN nodes are JSON encoded. Optional
 fields may be omitted when not needed.
 
+`ZkRevocationProof` follows a similar JSON structure and proves that a credential has not been revoked.
+
 ```json
 {
   "issuer": "did:key:example:issuer",

--- a/tests/integration/policy_enforcer.rs
+++ b/tests/integration/policy_enforcer.rs
@@ -23,12 +23,14 @@ async fn anchor_block_with_policy<E: ScopedPolicyEnforcer>(
     block: &DagBlock,
     enforcer: &E,
     proof: Option<&ZkCredentialProof>,
+    revocation: Option<&ZkRevocationProof>,
 ) -> Result<(), PolicyError> {
     if let PolicyCheckResult::Denied { .. } = enforcer.check_permission(
         DagPayloadOp::SubmitBlock,
         &block.author_did,
         block.scope.as_ref(),
         proof,
+        revocation,
     ) {
         return Err(PolicyError::Unauthorized);
     }
@@ -70,7 +72,7 @@ async fn authorized_dag_write_succeeds() {
         scope: None,
     };
 
-    anchor_block_with_policy(&ctx, &block, &enforcer, None)
+    anchor_block_with_policy(&ctx, &block, &enforcer, None, None)
         .await
         .expect("write succeeds");
 
@@ -100,7 +102,7 @@ async fn unauthorized_write_denied() {
         scope: None,
     };
 
-    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None).await;
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None, None).await;
     assert_eq!(res, Err(PolicyError::Unauthorized));
 }
 
@@ -131,7 +133,7 @@ async fn invalid_parent_is_rejected() {
         scope: None,
     };
 
-    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None).await;
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None, None).await;
     assert_eq!(res, Err(PolicyError::InvalidParent));
 }
 
@@ -163,7 +165,7 @@ async fn scope_membership_enforced() {
         scope: Some(scope),
     };
 
-    anchor_block_with_policy(&ctx, &block, &enforcer, None)
+    anchor_block_with_policy(&ctx, &block, &enforcer, None, None)
         .await
         .expect("scoped write succeeds");
 }
@@ -189,7 +191,7 @@ async fn proof_required_without_proof_fails() {
         scope: None,
     };
 
-    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None).await;
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, None, None).await;
     assert_eq!(res, Err(PolicyError::Unauthorized));
 }
 
@@ -228,7 +230,7 @@ async fn proof_required_invalid_proof_fails() {
         scope: None,
     };
 
-    let res = anchor_block_with_policy(&ctx, &block, &enforcer, Some(&invalid)).await;
+    let res = anchor_block_with_policy(&ctx, &block, &enforcer, Some(&invalid), None).await;
     assert_eq!(res, Err(PolicyError::Unauthorized));
 }
 
@@ -269,7 +271,7 @@ async fn proof_required_valid_proof_allows() {
         scope: None,
     };
 
-    anchor_block_with_policy(&ctx, &block, &enforcer, Some(&proof))
+    anchor_block_with_policy(&ctx, &block, &enforcer, Some(&proof), None)
         .await
         .expect("write succeeds with proof");
     let stored = ctx.dag_store.lock().await.get(&cid).unwrap();


### PR DESCRIPTION
## Summary
- add `ZkRevocationProof` type
- verify revocation proof with `Groth16Verifier`
- extend `ScopedPolicyEnforcer` API to accept a revocation proof
- update API and integration tests for new argument
- document new proof type
- note API change in CHANGELOG

## Testing
- `cargo check -p icn-governance -p icn-common -p icn-identity -p icn-api --all-features`
- `cargo test --test policy_enforcer --no-run` *(failed: compilation took too long)*

------
https://chatgpt.com/codex/tasks/task_e_68734ea90e688324860e680422fe3628