### PR TITLE
Document credential proofs in governance flows

### DIFF
--- a/docs/examples/block_submission_with_proof.json
+++ b/docs/examples/block_submission_with_proof.json
@@ -1,0 +1,15 @@
+{
+  "data": "aGVsbG8=",
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:alice",
+    "claim_type": "membership",
+    "proof": "0x1234",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0x1234",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/examples/vote_with_zk_proof.json
+++ b/docs/examples/vote_with_zk_proof.json
@@ -1,0 +1,16 @@
+{
+  "proposal_id": "proposal-uuid",
+  "vote": "Yes",
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:bob",
+    "claim_type": "membership",
+    "proof": "0xabcdef",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -72,6 +72,19 @@ The InterCooperative Network (ICN) governance framework enables communities, coo
 - **Revocable Trust**: Withdraw delegation at any time
 - **Transitive Delegation**: Delegates can further delegate
 
+### **Credential Proof Payloads**
+
+Governance operations accept an optional `credential_proof` field that carries a
+[`ZkCredentialProof`](zk_disclosure.md) object. Proposals and ballots include this
+field to demonstrate that the submitter or voter meets membership requirements.
+Operators can enforce mandatory proofs by enabling `require_proof` in the
+`InMemoryPolicyEnforcer` configuration. When enabled, nodes reject submissions
+that omit a valid proof.
+
+See [`docs/examples/proposal_with_zk_proof.json`](examples/proposal_with_zk_proof.json)
+and [`docs/examples/vote_with_zk_proof.json`](examples/vote_with_zk_proof.json)
+for example payloads.
+
 ---
 
 ## 🗳️ **Governance Primitives**

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -62,3 +62,29 @@ See [`docs/examples/zk_membership.json`](examples/zk_membership.json) for a memb
 `~/.icn/zk/`, and signs the verifying key with an Ed25519 key. Use
 `load_proving_key` and `verify_key_signature` to access the stored parameters
 and confirm their authenticity.
+
+## Example API Usage with Proofs
+
+The `/identity/verify` endpoint allows a node to validate a credential proof
+before it is attached to another operation. Submit the proof JSON directly:
+
+```bash
+curl -X POST https://localhost:8080/identity/verify \
+  -H "Content-Type: application/json" \
+  -d @docs/examples/zk_membership.json
+```
+
+Credential proofs can also accompany DAG block submissions. Include the object
+under the `credential_proof` field when calling the block submission endpoint:
+
+```bash
+curl -X POST https://localhost:8080/dag/put \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": "aGVsbG8=",
+    "credential_proof": { /* proof fields */ }
+  }'
+```
+
+See [`docs/examples/block_submission_with_proof.json`](examples/block_submission_with_proof.json)
+for a complete payload.


### PR DESCRIPTION
## Summary
- document how proposals and votes carry a `credential_proof`
- show API usage of `/identity/verify` and block submission with a proof
- add example JSON payloads for votes and block submissions with proofs

## Testing
- `just validate` *(failed: signal 2)*

------
https://chatgpt.com/codex/tasks/task_e_68734f9eb9c8832496af60a65604639f