### PR TITLE
[icn-zk] Add batch proof verification

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -47,5 +47,25 @@ pub fn verify(
     Groth16::<Bn254>::verify_with_processed_vk(vk, public_inputs, proof)
 }
 
+/// Verify multiple Groth16 proofs using the same prepared verifying key.
+/// Returns `Ok(true)` only if all proofs are valid.
+pub fn verify_batch(
+    vk: &PreparedVerifyingKey<Bn254>,
+    proofs: &[Proof<Bn254>],
+    public_inputs: &[Vec<Fr>],
+) -> Result<bool, SynthesisError> {
+    if proofs.len() != public_inputs.len() {
+        return Err(SynthesisError::AssignmentMissing);
+    }
+
+    for (proof, inputs) in proofs.iter().zip(public_inputs.iter()) {
+        if !verify(vk, proof, inputs)? {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -100,3 +100,15 @@ fn balance_range_proof() {
     let vk = prepare_vk(&pk);
     assert!(verify(&vk, &proof, &[Fr::from(50u64), Fr::from(100u64)]).unwrap());
 }
+
+#[test]
+fn batch_verify_proofs() {
+    let circuit = MembershipCircuit { is_member: true };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let proof1 = prove(&pk, circuit.clone(), &mut rng).unwrap();
+    let proof2 = prove(&pk, circuit, &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    let inputs = vec![vec![Fr::from(1u64)], vec![Fr::from(1u64)]];
+    assert!(verify_batch(&vk, &[proof1, proof2], &inputs).unwrap());
+}

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -53,6 +53,7 @@ The `icn-zk` crate exposes reusable circuits that can be compiled into proofs:
 - `ReputationCircuit` – proves a reputation score meets a required threshold.
 - `TimestampValidityCircuit` – proves a timestamp falls within a valid range.
 - `BalanceRangeCircuit` – proves a private balance lies between a public minimum and maximum.
+- `verify_batch` – verifies multiple proofs against the same verifying key.
 
 See [`docs/examples/zk_age_over_18.json`](examples/zk_age_over_18.json) for a sample proof payload.
 See [`docs/examples/zk_membership.json`](examples/zk_membership.json) for a membership proof example.


### PR DESCRIPTION
## Summary
- support verifying multiple Groth16 proofs at once
- test new batch verification helper
- document verify_batch in ZK guide

## Testing
- `cargo fmt --all -- --check`
- ❌ `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build dependencies too heavy)*
- ❌ `cargo test --all-features --workspace` *(failed: build took too long)*
- ❌ `cargo test -p icn-ccl` *(failed: build took too long)*
- ❌ `just test-ccl-contracts` *(failed: command not found)*
- ❌ `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68734dce029883248a04763bab1fa1fe