### PR TITLE
Add ZK proof batch verification

### DIFF
--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -47,5 +47,19 @@ pub fn verify(
     Groth16::<Bn254>::verify_with_processed_vk(vk, public_inputs, proof)
 }
 
+/// Verify multiple Groth16 proofs with a single verifying key.
+/// Returns `Ok(true)` if all proofs succeed.
+pub fn verify_batch<'a>(
+    vk: &PreparedVerifyingKey<Bn254>,
+    batch: &[(&'a Proof<Bn254>, &'a [Fr])],
+) -> Result<bool, SynthesisError> {
+    for (proof, inputs) in batch.iter() {
+        if !Groth16::<Bn254>::verify_with_processed_vk(vk, inputs, proof)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- support verifying multiple Groth16 proofs in a single batch
- test new batch verification helper

## Testing
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_6873d39090808324b56e6b3b62e41d0c