### PR TITLE
Add optional revocation proof checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ devnet, and expanded security guidance.
 - Repository hygiene files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, .editorconfig).
 - Workspace consistency for Cargo.toml files.
 - Optional improvements: rust-toolchain.toml, dependabot.yml, issue templates, CHANGELOG.md.
+- Scoped policy checks now accept `ZkRevocationProof` alongside credential proofs.
 - Kademlia DHT record storage and peer discovery behind `experimental-libp2p`.
 - New scoring algorithm in `icn-mesh` with reputation-based `select_executor`.
 - Introduced `icn-reputation` crate providing `ReputationStore` trait and in-memory implementation.

--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -169,6 +169,7 @@ pub async fn submit_dag_block(
             &actor,
             block.scope.as_ref(),
             None,
+            None,
         ) {
             return Err(CommonError::PolicyDenied(reason));
         }

--- a/crates/icn-common/src/lib.rs
+++ b/crates/icn-common/src/lib.rs
@@ -14,7 +14,7 @@ pub mod resilience;
 pub use resilience::{CircuitBreaker, CircuitBreakerError, CircuitState};
 pub mod resource_token;
 pub mod zk;
-pub use zk::{ZkCredentialProof, ZkProofType};
+pub use zk::{ZkCredentialProof, ZkProofType, ZkRevocationProof};
 
 pub const ICN_CORE_VERSION: &str = "0.2.0-beta";
 

--- a/crates/icn-common/src/zk.rs
+++ b/crates/icn-common/src/zk.rs
@@ -42,3 +42,23 @@ pub struct ZkCredentialProof {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub public_inputs: Option<serde_json::Value>,
 }
+
+/// A proof that a specific credential has not been revoked.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ZkRevocationProof {
+    /// DID of the issuer maintaining the revocation registry.
+    pub issuer: Did,
+    /// DID of the credential subject.
+    pub subject: Did,
+    /// Raw bytes of the zero-knowledge revocation proof.
+    #[serde(with = "serde_bytes")]
+    pub proof: Vec<u8>,
+    /// Backend proving system used for this proof.
+    pub backend: ZkProofType,
+    /// Optional verification key bytes used to verify the proof.
+    #[serde(with = "serde_bytes", default, skip_serializing_if = "Option::is_none")]
+    pub verification_key: Option<Vec<u8>>,
+    /// Optional public input values required for verification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_inputs: Option<serde_json::Value>,
+}

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1115,7 +1115,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         RuntimeContext::new_production(
             node_did.clone(),
             network_service,
-            signer,
+            signer.clone(),
             Arc::new(icn_identity::KeyDidResolver),
             dag_store_for_rt,
             mana_ledger,


### PR DESCRIPTION
## Summary
- add `ZkRevocationProof` to common zk types
- support revocation proof verification in runtime host APIs
- enforce revocation proof in scoped policy enforcer
- adapt API and integration tests
- document change in changelog

## Testing
- `cargo check -p icn-governance`
- `cargo check -p icn-node`
- `cargo test --workspace --all-features -- --list` *(fails: Command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6873d3a8bed48324a412a1699d2cdb03