### PR TITLE
Add zk host proof example and test

### DIFF
--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -77,3 +77,61 @@ Two host functions are provided for working with zero-knowledge proofs:
 When called from WASM, use the `wasm_host_verify_zk_proof` and
 `wasm_host_generate_zk_proof` wrappers which handle passing strings in and out
 of guest memory.
+
+### Usage Example
+
+The snippet below demonstrates a minimal round trip using the host functions.
+
+#### Generate a Proof
+
+Request
+```json
+{
+  "issuer": "did:key:zIssuer",
+  "holder": "did:key:zHolder",
+  "claim_type": "test",
+  "schema": "bafySchemaCid",
+  "backend": "dummy"
+}
+```
+
+Response
+```json
+{
+  "issuer": "did:key:zIssuer",
+  "holder": "did:key:zHolder",
+  "claim_type": "test",
+  "proof": [1, 2, 3],
+  "schema": "bafySchemaCid",
+  "vk_cid": null,
+  "disclosed_fields": [],
+  "challenge": null,
+  "backend": "dummy",
+  "verification_key": null,
+  "public_inputs": null
+}
+```
+
+#### Verify the Proof
+
+Request
+```json
+{
+  "issuer": "did:key:zIssuer",
+  "holder": "did:key:zHolder",
+  "claim_type": "test",
+  "proof": [1, 2, 3],
+  "schema": "bafySchemaCid",
+  "vk_cid": null,
+  "disclosed_fields": [],
+  "challenge": null,
+  "backend": "dummy",
+  "verification_key": null,
+  "public_inputs": null
+}
+```
+
+Response
+```json
+true
+```

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -63,6 +63,10 @@ path = "integration/simple_verification.rs"
 name = "zk_proof_verification"
 path = "integration/zk_proof_verification.rs"
 
+[[test]]
+name = "zk_host_roundtrip"
+path = "integration/zk_host_roundtrip.rs"
+
 [features]
 default = []
 enable-libp2p = ["icn-node/with-libp2p", "icn-runtime/enable-libp2p"]

--- a/tests/integration/zk_host_roundtrip.rs
+++ b/tests/integration/zk_host_roundtrip.rs
@@ -1,0 +1,21 @@
+use icn_common::{Cid, Did};
+use icn_runtime::{context::RuntimeContext, host_generate_zk_proof, host_verify_zk_proof};
+use std::str::FromStr;
+
+#[tokio::test]
+async fn host_generate_then_verify() {
+    let ctx = RuntimeContext::new_with_stubs("did:key:test").unwrap();
+    let issuer = Did::from_str("did:key:issuer").unwrap();
+    let holder = Did::from_str("did:key:holder").unwrap();
+    let schema = Cid::new_v1_sha256(0x55, b"schema");
+    let req = serde_json::json!({
+        "issuer": issuer.to_string(),
+        "holder": holder.to_string(),
+        "claim_type": "test",
+        "schema": schema.to_string(),
+        "backend": "dummy"
+    });
+    let proof_json = host_generate_zk_proof(&ctx, &req.to_string()).await.unwrap();
+    let verified = host_verify_zk_proof(&ctx, &proof_json).await.unwrap();
+    assert!(verified);
+}


### PR DESCRIPTION
## Summary
- document usage of host_generate_zk_proof and host_verify_zk_proof
- add integration test exercising the host functions
- register the new test in the integration test crate

## Testing
- `cargo test -p icn-integration-tests --no-default-features --test zk_host_roundtrip` *(failed: could not compile `icn-node`)*

------
https://chatgpt.com/codex/tasks/task_e_6873d48def4c8324ac0f850c0470a737