### PR TITLE
Add zk revocation docs

### DIFF
--- a/crates/icn-identity/README.md
+++ b/crates/icn-identity/README.md
@@ -52,6 +52,18 @@ Credential issuance can optionally generate zero-knowledge proofs via the
 - `Groth16Prover` – generic prover for Groth16 circuits such as age, membership
   or reputation checks.
 
+## Credential Revocation Workflow
+
+1. **Revocation Announcement** – When a credential must be revoked, the issuer
+   publishes a revocation identifier to the DAG so all peers can discover it.
+2. **Proof Generation** – Holders generate a zero-knowledge proof referencing
+   this identifier to show a credential has been revoked (or remains valid).
+3. **Verification** – Verifiers check the proof against the published
+   revocation list without learning any additional credential details.
+
+This approach allows selective disclosure of revocation status while keeping the
+credential contents private.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/docs/ICN_FEATURE_OVERVIEW.md
+++ b/docs/ICN_FEATURE_OVERVIEW.md
@@ -158,6 +158,7 @@ ICN enables autonomous federated systems that support cooperative coordination w
 - **Tamper-Evident Audit Logs**: Comprehensive action tracking
 - **WASM Sandboxing**: Secure execution environment
 - **DID-Based Authentication**: Decentralized identity verification
+- **Credential Revocation Support**: Revocation lists with zero-knowledge proof-of-revocation
 
 ### **🚧 In Development**
 - **Zero-Knowledge Proofs**: Anonymous voting and selective disclosure

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -77,3 +77,7 @@ Two host functions are provided for working with zero-knowledge proofs:
 When called from WASM, use the `wasm_host_verify_zk_proof` and
 `wasm_host_generate_zk_proof` wrappers which handle passing strings in and out
 of guest memory.
+
+## Proof-of-Revocation
+Zero-knowledge proofs can also show that a credential has been revoked without revealing the credential itself. When an issuer marks a credential as revoked, a revocation identifier is published to the DAG. Holders generate a ZK proof referencing this identifier to demonstrate revocation or non-revocation. Verifiers check the proof against the revocation list without ever seeing the original credential contents.
+


### PR DESCRIPTION
## Summary
- document ZK proof-of-revocation
- list revocation support in feature overview
- explain revocation flow in icn-identity README

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all-features --workspace --no-run` *(fails: value borrowed here after move)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused_mut)*

------
https://chatgpt.com/codex/tasks/task_e_6873d3f66984832485239e8bd6a9835e