### PR TITLE
Document credential proof requirements

### DIFF
--- a/docs/examples/block_submission_with_proof.json
+++ b/docs/examples/block_submission_with_proof.json
@@ -1,0 +1,16 @@
+{
+  "block_cid": "bafyblockcid",
+  "payload": "aGVsbG8=",
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:alice",
+    "claim_type": "membership",
+    "proof": "0x123456",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xdeadbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/examples/vote_with_credential_proof.json
+++ b/docs/examples/vote_with_credential_proof.json
@@ -1,0 +1,17 @@
+{
+  "voter_did": "did:key:bob",
+  "proposal_id": "1234",
+  "choice": "Yes",
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:bob",
+    "claim_type": "membership",
+    "proof": "0x123456",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xdeadbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -88,6 +88,9 @@ pub struct Proposal {
     pub content_cid: Option<Cid>,
     pub proposal_type: ProposalType,
     pub author: Did,
+    /// Optional zero-knowledge proof that the proposer holds the
+    /// required role or membership credential
+    pub credential_proof: Option<ZkCredentialProof>,
     pub created_at: DateTime<Utc>,
     pub voting_ends_at: DateTime<Utc>,
     pub vote_threshold: VoteThreshold,
@@ -155,6 +158,8 @@ fn validate_vote(voter: Did, proposal: Proposal, vote: Vote) -> Bool {
 - **Voter Notification**: Alert all eligible participants
 - **Vote Collection**: Secure, anonymous vote recording
 - **Eligibility Proof**: Each ballot includes a zero-knowledge credential proof verifying the voter meets membership requirements.
+- **Field Usage**: Both proposal and vote payloads include a `credential_proof`
+  object. Nodes verify this proof before accepting the action.
 - **Real-Time Tallying**: Live vote count display
 
 ### **4. Execution Phase**
@@ -361,6 +366,11 @@ fn emergency_decision(crisis: Crisis) -> EmergencyResponse {
 - **Document Clearly**: Maintain clear governance documentation
 - **Plan for Change**: Design governance to evolve over time
 - **Balance Efficiency and Democracy**: Find the right trade-offs
+
+### **Node Configuration**
+Operators can enforce credential checks by enabling the `require_proof` option
+when constructing an `InMemoryPolicyEnforcer`. When set to `true`, all DAG
+submissions and governance actions must include a valid `credential_proof`.
 
 ---
 

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -77,3 +77,21 @@ Two host functions are provided for working with zero-knowledge proofs:
 When called from WASM, use the `wasm_host_verify_zk_proof` and
 `wasm_host_generate_zk_proof` wrappers which handle passing strings in and out
 of guest memory.
+
+## Example API Requests
+
+Verify a credential proof directly against a node:
+
+```bash
+curl -X POST https://node.example.com/identity/verify \
+    -H 'Content-Type: application/json' \
+    -d @docs/examples/zk_membership.json
+```
+
+Submit a DAG block that includes a credential proof:
+
+```bash
+curl -X POST https://node.example.com/dag/submit-block \
+    -H 'Content-Type: application/json' \
+    -d @docs/examples/block_submission_with_proof.json
+```


### PR DESCRIPTION
## Summary
- describe `credential_proof` field in governance framework
- show how to verify proofs and submit DAG blocks with proofs
- add example vote and block JSON payloads
- note `require_proof` setting for policy enforcement

## Testing
- `cargo check -p icn-common`

------
https://chatgpt.com/codex/tasks/task_e_6873d41238f88324b65834e04d62d5e2