### PR TITLE
Add ZK revocation docs

### DIFF
--- a/crates/icn-identity/README.md
+++ b/crates/icn-identity/README.md
@@ -49,8 +49,15 @@ Credential issuance can optionally generate zero-knowledge proofs via the
 
 - `DummyProver` – generates placeholder proofs for testing.
 - `BulletproofsProver` – produces range proofs using the Bulletproofs protocol.
-- `Groth16Prover` – generic prover for Groth16 circuits such as age, membership
-  or reputation checks.
+- `Groth16Prover` – generic prover for Groth16 circuits such as age, membership or reputation checks.
+
+## Credential Revocation Workflow
+
+Zero-knowledge revocation proofs allow verifiers to check that a credential remains valid without revealing registry details.
+
+1. An issuer records the credential identifier in its revocation registry and creates a `ZkRevocationProof`.
+2. The holder includes this proof when presenting the credential or a credential proof.
+3. Verifiers call `verify_revocation` using their configured `ZkRevocationVerifier`. A successful result confirms the credential is not revoked.
 
 ## Contributing
 

--- a/docs/ICN_FEATURE_OVERVIEW.md
+++ b/docs/ICN_FEATURE_OVERVIEW.md
@@ -158,6 +158,7 @@ ICN enables autonomous federated systems that support cooperative coordination w
 - **Tamper-Evident Audit Logs**: Comprehensive action tracking
 - **WASM Sandboxing**: Secure execution environment
 - **DID-Based Authentication**: Decentralized identity verification
+- **Credential Revocation Support**: ZK proof-of-revocation for credentials
 
 ### **🚧 In Development**
 - **Zero-Knowledge Proofs**: Anonymous voting and selective disclosure

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -104,3 +104,12 @@ Example proof payload referencing a cached key:
   "public_inputs": { "membership": true }
 }
 ```
+## Proof of Revocation
+
+Verifiable credentials can be invalidated without revealing their contents. The `ZkRevocationProof` structure allows a holder to prove that a credential has not been revoked while keeping the revocation registry private.
+
+1. **Issuer** marks the credential ID in its revocation registry and generates a zero-knowledge revocation proof.
+2. **Holder** presents this `ZkRevocationProof` together with their credential or credential proof.
+3. **Verifier** calls `verify_revocation` on a configured `ZkRevocationVerifier` implementation. If the proof succeeds, the credential is considered active without exposing registry entries.
+
+Revocation proofs can be produced by `icn-identity`'s `Groth16Prover` or any custom prover implementing `ZkProver`.


### PR DESCRIPTION
## Summary
- document how ZK revocation proofs work
- mention revocation support in the feature overview
- describe the revocation workflow in the identity crate

## Testing
- `cargo test --all-features --workspace` *(fails: could not compile `icn-ccl` test due to E0599)*

------
https://chatgpt.com/codex/tasks/task_e_6873d8dd89548324aa22dbd456b59a98