### PR TITLE
[docs] document credential proofs

### DIFF
--- a/docs/examples/submit_block_with_proof.json
+++ b/docs/examples/submit_block_with_proof.json
@@ -1,0 +1,28 @@
+{
+  "block": {
+    "cid": {
+      "version": 1,
+      "codec": 113,
+      "hash_alg": 18,
+      "hash_bytes": "0xabc123"
+    },
+    "data": "0xdeadbeef",
+    "links": [],
+    "timestamp": 0,
+    "author_did": "did:key:alice",
+    "signature": null,
+    "scope": null
+  },
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:alice",
+    "claim_type": "membership",
+    "proof": "0xabc123",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xdeadbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/examples/vote_with_zk_proof.json
+++ b/docs/examples/vote_with_zk_proof.json
@@ -1,0 +1,16 @@
+{
+  "proposal_id": "proposal-uuid",
+  "vote": "Yes",
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:member",
+    "claim_type": "membership",
+    "proof": "0xabc123",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xdeadbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -58,6 +58,32 @@ The InterCooperative Network (ICN) governance framework enables communities, coo
 - **Execution Phase**: Automatic policy implementation
 - **Amendment Process**: Iterative improvement and adaptation
 
+#### **Credential Proof Integration**
+Proposals and votes include a `credential_proof` field carrying a
+[`ZkCredentialProof`](../crates/icn-common/src/zk.rs). Nodes verify this
+object before accepting the operation. The same field is used on ballots to
+prove voting eligibility.
+
+Example proposal payload:
+```json
+{
+  "proposer_did": "did:key:alice",
+  "proposal": { "type": "PolicyChange", "title": "open_membership" },
+  "description": "Adopt open membership policy",
+  "duration_secs": 86400,
+  "credential_proof": { "issuer": "did:key:federation", "proof": "0x123" }
+}
+```
+
+Example vote payload:
+```json
+{
+  "proposal_id": "proposal-uuid",
+  "vote": "Yes",
+  "credential_proof": { "issuer": "did:key:federation", "proof": "0x123" }
+}
+```
+
 #### **2. Voting Mechanisms**
 - **Simple Majority**: Basic democratic decisions
 - **Supermajority**: Constitutional changes and critical decisions

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -104,3 +104,33 @@ Example proof payload referencing a cached key:
   "public_inputs": { "membership": true }
 }
 ```
+
+## Example API Requests
+
+### Verify a Credential Proof
+
+```bash
+curl -X POST https://localhost:8080/identity/verify \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  --data-binary @docs/examples/zk_membership.json
+```
+
+Returns `{"verified": true}` when the proof is valid.
+
+### Submit a DAG Block with Proof
+
+Operators may require a credential proof when submitting DAG blocks.
+
+```bash
+curl -X POST https://localhost:8080/dag/put \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  --data-binary @docs/examples/submit_block_with_proof.json
+```
+
+### Enforcing Proofs
+
+Set `require_proof = true` when constructing `InMemoryPolicyEnforcer` to reject
+submissions that lack a valid `credential_proof`. This ensures all identity,
+governance, and DAG operations provide verifiable credentials.


### PR DESCRIPTION
## Summary
- document how governance proposals and votes include `credential_proof`
- update zk guide with API call examples and enforcement notes
- add JSON examples for votes and block submission with proofs

## Testing
- `cargo fmt --all -- --check` *(fails)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused mut)*
- `cargo test --all-features --workspace` *(partial build; interrupted)*
- `cargo test -p icn-ccl` *(partial build; interrupted)*
- `just test-ccl-contracts` *(fails: command not found)*
- `just test-covm-execution` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873d8fbfb8c832489392addfc3bf694