### PR TITLE
[docs] add zk proof host API example and test

### DIFF
--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -78,6 +78,45 @@ When called from WASM, use the `wasm_host_verify_zk_proof` and
 `wasm_host_generate_zk_proof` wrappers which handle passing strings in and out
 of guest memory.
 
+### Example: Generate and Verify
+
+The host API expects JSON strings. A minimal request to `host_generate_zk_proof`
+looks like this:
+
+```json
+{
+  "issuer": "did:key:issuer",
+  "holder": "did:key:holder",
+  "claim_type": "test",
+  "schema": "bafyschema",
+  "backend": "dummy"
+}
+```
+
+`host_generate_zk_proof` returns a JSON `ZkCredentialProof` which can be passed
+directly to `host_verify_zk_proof`:
+
+```json
+{
+  "issuer": "did:key:issuer",
+  "holder": "did:key:holder",
+  "claim_type": "test",
+  "proof": [0, 1, 2],
+  "schema": "bafyschema",
+  "disclosed_fields": [],
+  "challenge": null,
+  "backend": "dummy",
+  "verification_key": null,
+  "public_inputs": null
+}
+```
+
+Invoking `host_verify_zk_proof` with this response yields the boolean result:
+
+```json
+true
+```
+
 ## Production Verification
 
 Production nodes must verify the authenticity of the Groth16 verifying key

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -63,6 +63,10 @@ path = "integration/simple_verification.rs"
 name = "zk_proof_verification"
 path = "integration/zk_proof_verification.rs"
 
+[[test]]
+name = "host_zk_roundtrip"
+path = "integration/host_zk_roundtrip.rs"
+
 [features]
 default = []
 enable-libp2p = ["icn-node/with-libp2p", "icn-runtime/enable-libp2p"]

--- a/tests/integration/host_zk_roundtrip.rs
+++ b/tests/integration/host_zk_roundtrip.rs
@@ -1,0 +1,28 @@
+use icn_common::{Cid, Did};
+use icn_runtime::{context::RuntimeContext, host_generate_zk_proof, host_verify_zk_proof};
+
+#[tokio::test]
+async fn host_generate_then_verify_roundtrip() {
+    let ctx = RuntimeContext::new_with_stubs("did:key:testZk").unwrap();
+    let issuer = Did::new("key", "issuer");
+    let holder = Did::new("key", "holder");
+    let schema = Cid::new_v1_sha256(0x55, b"schema");
+
+    let request = serde_json::json!({
+        "issuer": issuer.to_string(),
+        "holder": holder.to_string(),
+        "claim_type": "test",
+        "schema": schema.to_string(),
+        "backend": "dummy"
+    });
+
+    let proof_json = host_generate_zk_proof(&ctx, &request.to_string())
+        .await
+        .expect("generate proof");
+
+    let verified = host_verify_zk_proof(&ctx, &proof_json)
+        .await
+        .expect("verify proof");
+
+    assert!(verified, "generated proof should verify");
+}


### PR DESCRIPTION
## Summary
- document example JSON usage of `host_generate_zk_proof` and `host_verify_zk_proof`
- integration test to generate and verify a dummy proof
- include new test in integration workspace

## Testing
- `cargo fmt -- tests/integration/host_zk_roundtrip.rs crates/icn-identity/src/zk/mod.rs`
- ❌ `cargo clippy --all-targets --all-features -- -D warnings` *(failed: took too long)*
- ❌ `cargo test --all-features --workspace host_generate_then_verify_roundtrip` *(failed: took too long)*

------
https://chatgpt.com/codex/tasks/task_e_6873d8c2b74883248ef36c997aadfba0