### PR TITLE
Improve ZK proof docs

### DIFF
--- a/docs/examples/dag_put_with_proof.json
+++ b/docs/examples/dag_put_with_proof.json
@@ -1,0 +1,15 @@
+{
+  "data": "0xdeadbeef",
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:alice",
+    "claim_type": "membership",
+    "proof": "0x123456",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xdeadbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/examples/vote_with_zk_proof.json
+++ b/docs/examples/vote_with_zk_proof.json
@@ -1,0 +1,17 @@
+{
+  "voter_did": "did:key:bob",
+  "proposal_id": "example_proposal_id",
+  "vote_option": "yes",
+  "credential_proof": {
+    "issuer": "did:key:federation",
+    "holder": "did:key:bob",
+    "claim_type": "membership",
+    "proof": "0x123456",
+    "schema": "bafyschemacid",
+    "disclosed_fields": [],
+    "challenge": null,
+    "backend": "groth16",
+    "verification_key": "0xdeadbeef",
+    "public_inputs": { "membership": true }
+  }
+}

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -157,6 +157,15 @@ fn validate_vote(voter: Did, proposal: Proposal, vote: Vote) -> Bool {
 - **Eligibility Proof**: Each ballot includes a zero-knowledge credential proof verifying the voter meets membership requirements.
 - **Real-Time Tallying**: Live vote count display
 
+### Credential Proofs
+
+Proposers and voters attach a `credential_proof` object when submitting
+governance actions. The proof follows the format described in
+[`zk_disclosure.md`](zk_disclosure.md) and typically demonstrates
+membership status. Nodes verify this proof before accepting the proposal or
+vote. Operators may enforce mandatory proofs by creating the
+`InMemoryPolicyEnforcer` with `require_proof` enabled.
+
 ### **4. Execution Phase**
 - **Automatic Implementation**: CCL contracts execute decisions
 - **Monitoring**: Track implementation progress

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -113,3 +113,24 @@ Verifiable credentials can be invalidated without revealing their contents. The 
 3. **Verifier** calls `verify_revocation` on a configured `ZkRevocationVerifier` implementation. If the proof succeeds, the credential is considered active without exposing registry entries.
 
 Revocation proofs can be produced by `icn-identity`'s `Groth16Prover` or any custom prover implementing `ZkProver`.
+
+## Example API Requests
+
+Verify a credential proof:
+
+```bash
+curl -X POST http://localhost:7845/identity/verify \
+     -H "Content-Type: application/json" \
+     --data @docs/examples/zk_membership.json
+```
+
+Submit a DAG block with an attached proof:
+
+```bash
+curl -X POST http://localhost:7845/dag/put \
+     -H "Content-Type: application/json" \
+     --data @docs/examples/dag_put_with_proof.json
+```
+
+Nodes can enforce proof submission by creating the
+`InMemoryPolicyEnforcer` with `require_proof` set to `true`.


### PR DESCRIPTION
## Summary
- document `credential_proof` on proposals and votes
- show how to verify and submit a block with a credential proof
- add JSON example payloads with proofs

## Testing
- `cargo fmt --all -- --check`
- `just test` *(fails: build too heavy)*

------
https://chatgpt.com/codex/tasks/task_e_6873df2f883083248d2d155db50d21a0