### PR TITLE
[identity] add prepared verifying key cache

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -30,6 +30,8 @@ ark-bn254 = "0.4"
 ark-serialize = "0.4"
 ark-std = "0.4"
 ark-snark = "0.4"
+once_cell = "1.21"
+lru = "0.16"
 directories-next = "2"
 serde_json = "1.0"
 

--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -5,12 +5,13 @@
 
 use core::convert::TryInto;
 use icn_common::{Cid, ZkCredentialProof, ZkProofType, ZkRevocationProof};
-use std::{any::Any, collections::HashMap};
-use serde_json::Value;
 use serde_json;
+use serde_json::Value;
+use std::any::Any;
 use thiserror::Error;
 
 pub mod key_manager;
+pub mod vk_cache;
 pub use key_manager::Groth16KeyManager;
 
 /// Errors that can occur when verifying zero-knowledge proofs.
@@ -429,7 +430,6 @@ impl ZkProver for Groth16Prover {
 pub struct Groth16Verifier {
     vk: ark_groth16::PreparedVerifyingKey<ark_bn254::Bn254>,
     public_inputs: Vec<ark_bn254::Fr>,
-    cache: std::sync::Mutex<std::collections::HashMap<Cid, ark_groth16::PreparedVerifyingKey<ark_bn254::Bn254>>>,
 }
 
 impl Groth16Verifier {
@@ -438,11 +438,7 @@ impl Groth16Verifier {
         vk: ark_groth16::PreparedVerifyingKey<ark_bn254::Bn254>,
         public_inputs: Vec<ark_bn254::Fr>,
     ) -> Self {
-        Self {
-            vk,
-            public_inputs,
-            cache: std::sync::Mutex::new(HashMap::new()),
-        }
+        Self { vk, public_inputs }
     }
 
     /// Verify the supplied [`ZkCredentialProof`] using a cached prepared key if
@@ -450,8 +446,8 @@ impl Groth16Verifier {
     /// verifier's defaults.
     pub fn verify_proof(&self, proof: &ZkCredentialProof) -> Result<bool, ZkError> {
         use ark_groth16::{Groth16, Proof, VerifyingKey};
-        use ark_snark::SNARK;
         use ark_serialize::CanonicalDeserialize;
+        use ark_snark::SNARK;
 
         if proof.backend != ZkProofType::Groth16 {
             return Err(ZkError::UnsupportedBackend(proof.backend.clone()));
@@ -470,18 +466,9 @@ impl Groth16Verifier {
             None => self.public_inputs.clone(),
         };
 
-        // Fetch or prepare verifying key
+        // Fetch or prepare verifying key using global cache
         let pvk = if let Some(vk_bytes) = &proof.verification_key {
-            let cid = Cid::new_v1_sha256(0x55, vk_bytes);
-            let mut cache = self.cache.lock().unwrap();
-            cache
-                .entry(cid)
-                .or_insert_with(|| {
-                    let vk = VerifyingKey::<ark_bn254::Bn254>::deserialize_compressed(vk_bytes.as_slice())
-                        .expect("verifying key bytes");
-                    Groth16::<ark_bn254::Bn254>::process_vk(&vk).expect("prepare vk")
-                })
-                .clone()
+            vk_cache::PreparedVkCache::get_or_insert(vk_bytes)?
         } else {
             self.vk.clone()
         };
@@ -494,7 +481,11 @@ impl Groth16Verifier {
 fn parse_public_inputs(v: &Value) -> Result<Vec<ark_bn254::Fr>, ZkError> {
     let arr = v.as_array().ok_or(ZkError::InvalidProof)?;
     arr.iter()
-        .map(|val| val.as_u64().map(ark_bn254::Fr::from).ok_or(ZkError::InvalidProof))
+        .map(|val| {
+            val.as_u64()
+                .map(ark_bn254::Fr::from)
+                .ok_or(ZkError::InvalidProof)
+        })
         .collect()
 }
 
@@ -770,7 +761,10 @@ mod tests {
         use icn_zk::{prepare_vk, prove, setup, AgeOver18Circuit};
 
         let mut rng = StdRng::seed_from_u64(42);
-        let circuit = AgeOver18Circuit { birth_year: 2000, current_year: 2020 };
+        let circuit = AgeOver18Circuit {
+            birth_year: 2000,
+            current_year: 2020,
+        };
         let pk = setup(circuit.clone(), &mut rng).unwrap();
         let proof_obj = prove(&pk, circuit, &mut rng).unwrap();
         let mut proof_bytes = Vec::new();
@@ -778,7 +772,7 @@ mod tests {
         let mut vk_bytes = Vec::new();
         pk.vk.serialize_compressed(&mut vk_bytes).unwrap();
 
-        let mut verifier = Groth16Verifier::new(prepare_vk(&pk), vec![ark_bn254::Fr::from(2020u64)]);
+        let verifier = Groth16Verifier::new(prepare_vk(&pk), vec![ark_bn254::Fr::from(2020u64)]);
         let proof = ZkCredentialProof {
             issuer: Did::new("key", "issuer"),
             holder: Did::new("key", "holder"),
@@ -794,11 +788,7 @@ mod tests {
         };
 
         assert!(verifier.verify_proof(&proof).unwrap());
-        let cache_len = verifier.cache.lock().unwrap().len();
-        assert_eq!(cache_len, 1);
         assert!(verifier.verify_proof(&proof).unwrap());
-        let cache_len2 = verifier.cache.lock().unwrap().len();
-        assert_eq!(cache_len2, 1);
     }
 
     #[test]
@@ -820,7 +810,10 @@ mod tests {
         use icn_zk::{prepare_vk, prove, setup, AgeOver18Circuit};
 
         let mut rng = StdRng::seed_from_u64(42);
-        let circuit = AgeOver18Circuit { birth_year: 2000, current_year: 2021 };
+        let circuit = AgeOver18Circuit {
+            birth_year: 2000,
+            current_year: 2021,
+        };
         let pk = setup(circuit.clone(), &mut rng).unwrap();
         let proof_obj = prove(&pk, circuit, &mut rng).unwrap();
         let mut proof_bytes = Vec::new();
@@ -829,7 +822,7 @@ mod tests {
         pk.vk.serialize_compressed(&mut vk_bytes).unwrap();
 
         // Verifier has incorrect default inputs
-        let mut verifier = Groth16Verifier::new(prepare_vk(&pk), vec![ark_bn254::Fr::from(9999u64)]);
+        let verifier = Groth16Verifier::new(prepare_vk(&pk), vec![ark_bn254::Fr::from(9999u64)]);
         let proof = ZkCredentialProof {
             issuer: Did::new("key", "issuer"),
             holder: Did::new("key", "holder"),

--- a/crates/icn-identity/src/zk/vk_cache.rs
+++ b/crates/icn-identity/src/zk/vk_cache.rs
@@ -1,0 +1,30 @@
+use ark_bn254::Bn254;
+use ark_groth16::{Groth16, PreparedVerifyingKey, VerifyingKey};
+use ark_serialize::CanonicalDeserialize;
+use ark_snark::SNARK;
+use lru::LruCache;
+use once_cell::sync::Lazy;
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+use super::ZkError;
+
+static PREPARED_VK_CACHE: Lazy<Mutex<LruCache<Vec<u8>, PreparedVerifyingKey<Bn254>>>> =
+    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(16).expect("non-zero"))));
+
+pub struct PreparedVkCache;
+
+impl PreparedVkCache {
+    pub fn get_or_insert(bytes: &[u8]) -> Result<PreparedVerifyingKey<Bn254>, ZkError> {
+        let mut cache = PREPARED_VK_CACHE.lock().expect("cache lock");
+        if let Some(pvk) = cache.get(bytes) {
+            return Ok(pvk.clone());
+        }
+
+        let vk = VerifyingKey::<Bn254>::deserialize_compressed(bytes)
+            .map_err(|_| ZkError::InvalidProof)?;
+        let pvk = Groth16::<Bn254>::process_vk(&vk).map_err(|_| ZkError::VerificationFailed)?;
+        cache.put(bytes.to_vec(), pvk.clone());
+        Ok(pvk)
+    }
+}

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -2881,14 +2881,13 @@ async fn zk_verify_handler(
         .spend_mana(&state.runtime_context.current_identity, ZK_VERIFY_COST_MANA)
         .await
     {
-        return map_rust_error_to_json_response(e, StatusCode::BAD_REQUEST)
-            .into_response();
+        return map_rust_error_to_json_response(e, StatusCode::BAD_REQUEST).into_response();
     }
 
     let verifier: Box<dyn ZkVerifier> = match proof.backend {
-        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier::default()),
+        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier),
         ZkProofType::Groth16 => Box::new(Groth16Verifier::default()),
-        _ => Box::new(DummyVerifier::default()),
+        _ => Box::new(DummyVerifier),
     };
 
     match verifier.verify(&proof) {

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -32,8 +32,8 @@ extern crate bincode;
 use icn_common::{Cid, CommonError, Did, NodeInfo};
 use icn_mesh::JobId;
 use icn_reputation::ReputationStore;
-use serde::Deserialize;
 use log::{debug, error, info, warn};
+use serde::Deserialize;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -728,9 +728,9 @@ pub async fn host_verify_zk_proof(
     })?;
 
     let verifier: Box<dyn ZkVerifier> = match proof.backend {
-        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier::default()),
+        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier),
         ZkProofType::Groth16 => Box::new(Groth16Verifier::default()),
-        _ => Box::new(DummyVerifier::default()),
+        _ => Box::new(DummyVerifier),
     };
 
     verifier
@@ -744,17 +744,17 @@ pub async fn host_verify_zk_revocation_proof(
     proof_json: &str,
 ) -> Result<bool, HostAbiError> {
     use icn_common::{ZkProofType, ZkRevocationProof};
-    use icn_identity::{BulletproofsVerifier, DummyVerifier, Groth16Verifier};
     use icn_identity::zk::ZkRevocationVerifier;
+    use icn_identity::{BulletproofsVerifier, DummyVerifier, Groth16Verifier};
 
     let proof: ZkRevocationProof = serde_json::from_str(proof_json).map_err(|e| {
         HostAbiError::InvalidParameters(format!("Invalid ZkRevocationProof JSON: {e}"))
     })?;
 
     let verifier: Box<dyn ZkRevocationVerifier> = match proof.backend {
-        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier::default()),
+        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier),
         ZkProofType::Groth16 => Box::new(Groth16Verifier::default()),
-        _ => Box::new(DummyVerifier::default()),
+        _ => Box::new(DummyVerifier),
     };
 
     verifier
@@ -812,8 +812,7 @@ pub async fn host_generate_zk_proof(
         public_inputs: req.public_inputs,
     };
 
-    serde_json::to_string(&proof)
-        .map_err(|e| HostAbiError::SerializationError(format!("{e}")))
+    serde_json::to_string(&proof).map_err(|e| HostAbiError::SerializationError(format!("{e}")))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- implement `PreparedVkCache` for Groth16 verifying keys
- use `PreparedVkCache` in `Groth16Verifier`
- register cache module in identity crate
- adjust runtime and node to avoid default construction warnings

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: deprecated and style warnings in other crates)*
- `cargo test -p icn-identity` *(fails to complete due to build errors)*

------
https://chatgpt.com/codex/tasks/task_e_6873dbfed62083248e696acf199edfbd