### PR TITLE
Handle mana refunds for failed ZK verification

### DIFF
--- a/crates/icn-node/tests/zk_refund.rs
+++ b/crates/icn-node/tests/zk_refund.rs
@@ -1,0 +1,58 @@
+use icn_common::{Cid, Did, ZkCredentialProof, ZkProofType};
+use icn_node::app_router_with_options;
+use reqwest::Client;
+use std::str::FromStr;
+use tempfile::tempdir;
+use tokio::task;
+
+#[tokio::test]
+async fn verification_failure_refunds_mana() {
+    let tmp = tempdir().unwrap();
+    let ledger_path = tmp.path().join("ledger.json");
+    let (router, ctx) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(ledger_path),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let initial = ctx.get_mana(&ctx.current_identity).await.unwrap();
+
+    let bad_proof = ZkCredentialProof {
+        issuer: Did::from_str("did:key:bad").unwrap(),
+        holder: Did::from_str("did:key:badholder").unwrap(),
+        claim_type: "test".into(),
+        proof: vec![1, 2, 3],
+        schema: Cid::new_v1_sha256(0x55, b"s"),
+        vk_cid: None,
+        disclosed_fields: Vec::new(),
+        challenge: None,
+        backend: ZkProofType::Groth16,
+        verification_key: None,
+        public_inputs: None,
+    };
+    let client = Client::new();
+    let resp = client
+        .post(&format!("http://{}/identity/verify", addr))
+        .json(&bad_proof)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let final_balance = ctx.get_mana(&ctx.current_identity).await.unwrap();
+    assert_eq!(initial, final_balance);
+    server.abort();
+}

--- a/crates/icn-runtime/src/context/mesh_network.rs
+++ b/crates/icn-runtime/src/context/mesh_network.rs
@@ -1,9 +1,9 @@
 //! Mesh network service types and implementations for the ICN runtime.
 
 use super::errors::HostAbiError;
-use icn_common::Did;
 #[cfg(feature = "enable-libp2p")]
 use icn_common::CommonError;
+use icn_common::Did;
 use icn_identity::{ExecutionReceipt as IdentityExecutionReceipt, SignatureBytes};
 use icn_mesh::{ActualMeshJob, JobId, MeshJobBid};
 use icn_network::NetworkService;
@@ -58,6 +58,7 @@ pub struct SelectionPolicy {
 /// Governance cost constants.
 pub const PROPOSAL_COST_MANA: u64 = 10;
 pub const VOTE_COST_MANA: u64 = 1;
+pub const ZK_VERIFY_COST_MANA: u64 = 2;
 
 /// Mesh network service trait for handling mesh jobs, proposals, and votes.
 /// Using async_trait to make it object-safe
@@ -81,10 +82,7 @@ pub trait MeshNetworkService: Send + Sync + std::fmt::Debug {
         expected_executor: &Did,
         timeout: StdDuration,
     ) -> Result<Option<IdentityExecutionReceipt>, HostAbiError>;
-    async fn submit_bid_for_job(
-        &self,
-        bid: &icn_mesh::MeshJobBid,
-    ) -> Result<(), HostAbiError>;
+    async fn submit_bid_for_job(&self, bid: &icn_mesh::MeshJobBid) -> Result<(), HostAbiError>;
     async fn submit_execution_receipt(
         &self,
         receipt: &icn_identity::ExecutionReceipt,
@@ -161,8 +159,8 @@ impl MeshNetworkService for DefaultMeshNetworkService {
         // Convert JobSpec to protocol JobSpec
         let protocol_job_spec = icn_protocol::JobSpec {
             kind: match &job.spec.kind {
-                icn_mesh::JobKind::Echo { payload } => icn_protocol::JobKind::Echo { 
-                    payload: payload.clone() 
+                icn_mesh::JobKind::Echo { payload } => icn_protocol::JobKind::Echo {
+                    payload: payload.clone(),
                 },
                 icn_mesh::JobKind::CclWasm => icn_protocol::JobKind::CclWasm,
                 icn_mesh::JobKind::GenericPlaceholder => icn_protocol::JobKind::Generic,
@@ -172,7 +170,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             required_resources: icn_protocol::ResourceRequirements {
                 cpu_cores: job.spec.required_resources.cpu_cores,
                 memory_mb: job.spec.required_resources.memory_mb,
-                storage_mb: 0, // TODO: Add storage to job spec
+                storage_mb: 0,                // TODO: Add storage to job spec
                 max_execution_time_secs: 300, // 5 minutes default
             },
         };
@@ -200,15 +198,18 @@ impl MeshNetworkService for DefaultMeshNetworkService {
         self.inner
             .broadcast_signed_message(signed)
             .await
-            .map_err(|e| HostAbiError::NetworkError(format!("Failed to broadcast job announcement: {}", e)))
+            .map_err(|e| {
+                HostAbiError::NetworkError(format!("Failed to broadcast job announcement: {}", e))
+            })
     }
 
     async fn announce_proposal(&self, proposal_bytes: Vec<u8>) -> Result<(), HostAbiError> {
         debug!("DefaultMeshNetworkService: announcing proposal");
 
-        let proposal: icn_governance::Proposal = bincode::deserialize(&proposal_bytes).map_err(|e| {
-            HostAbiError::SerializationError(format!("Failed to deserialize proposal: {}", e))
-        })?;
+        let proposal: icn_governance::Proposal =
+            bincode::deserialize(&proposal_bytes).map_err(|e| {
+                HostAbiError::SerializationError(format!("Failed to deserialize proposal: {}", e))
+            })?;
 
         let message = ProtocolMessage {
             payload: MessagePayload::GovernanceProposalAnnouncement(GovernanceProposalMessage {
@@ -258,28 +259,38 @@ impl MeshNetworkService for DefaultMeshNetworkService {
         job_id: &JobId,
         duration: StdDuration,
     ) -> Result<Vec<MeshJobBid>, HostAbiError> {
-        log::info!("[MeshNetwork] Collecting bids for job {:?} for {}s", job_id, duration.as_secs());
+        log::info!(
+            "[MeshNetwork] Collecting bids for job {:?} for {}s",
+            job_id,
+            duration.as_secs()
+        );
 
         let mut bids = Vec::new();
-        
+
         // Subscribe to network messages to collect bids
-        let mut receiver = self.inner.subscribe().await
-            .map_err(|e| HostAbiError::NetworkError(format!("Failed to subscribe to network: {}", e)))?;
+        let mut receiver = self.inner.subscribe().await.map_err(|e| {
+            HostAbiError::NetworkError(format!("Failed to subscribe to network: {}", e))
+        })?;
 
         let deadline = tokio::time::Instant::now() + duration;
-        
+
         while tokio::time::Instant::now() < deadline {
             let remaining = deadline.duration_since(tokio::time::Instant::now());
-            
+
             match tokio::time::timeout(remaining, receiver.recv()).await {
                 Ok(Some(signed_message)) => {
                     // Check if this is a bid for our job
-                    if let MessagePayload::MeshBidSubmission(bid_message) = &signed_message.payload {
+                    if let MessagePayload::MeshBidSubmission(bid_message) = &signed_message.payload
+                    {
                         let protocol_job_id = icn_common::Cid::from(job_id.clone());
                         if bid_message.job_id == protocol_job_id {
-                            log::info!("[MeshNetwork] Received bid from {} for job {:?}: {} mana",
-                                     bid_message.executor_did, job_id, bid_message.cost_mana);
-                            
+                            log::info!(
+                                "[MeshNetwork] Received bid from {} for job {:?}: {} mana",
+                                bid_message.executor_did,
+                                job_id,
+                                bid_message.cost_mana
+                            );
+
                             // Convert protocol bid message to MeshJobBid
                             let mesh_bid = icn_mesh::MeshJobBid {
                                 job_id: job_id.clone(),
@@ -291,7 +302,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
                                 },
                                 signature: icn_identity::SignatureBytes(vec![]), // TODO: Extract from message signature
                             };
-                            
+
                             // TODO: In a real implementation, we'd verify the bid signature
                             // For now, we'll accept all properly formatted bids
                             bids.push(mesh_bid);
@@ -309,17 +320,22 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             }
         }
 
-        log::info!("[MeshNetwork] Bid collection completed: {} bids for job {:?}", bids.len(), job_id);
+        log::info!(
+            "[MeshNetwork] Bid collection completed: {} bids for job {:?}",
+            bids.len(),
+            job_id
+        );
         Ok(bids)
     }
 
     /// Submit a bid for a job (used by executor nodes)
-    async fn submit_bid_for_job(
-        &self,
-        bid: &icn_mesh::MeshJobBid,
-    ) -> Result<(), HostAbiError> {
-        log::info!("[MeshNetwork] Submitting bid for job {:?}: {} mana from {}", 
-                  bid.job_id, bid.price_mana, bid.executor_did);
+    async fn submit_bid_for_job(&self, bid: &icn_mesh::MeshJobBid) -> Result<(), HostAbiError> {
+        log::info!(
+            "[MeshNetwork] Submitting bid for job {:?}: {} mana from {}",
+            bid.job_id,
+            bid.price_mana,
+            bid.executor_did
+        );
 
         // Convert MeshJobBid to protocol message
         let bid_message = icn_protocol::MeshBidSubmissionMessage {
@@ -330,7 +346,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             offered_resources: icn_protocol::ResourceRequirements {
                 cpu_cores: bid.resources.cpu_cores,
                 memory_mb: bid.resources.memory_mb,
-                storage_mb: 0, // TODO: Add storage to Resources
+                storage_mb: 0,                // TODO: Add storage to Resources
                 max_execution_time_secs: 300, // 5 minutes default
             },
             reputation_score: 100, // TODO: Get actual reputation score
@@ -357,13 +373,16 @@ impl MeshNetworkService for DefaultMeshNetworkService {
         &self,
         receipt: &icn_identity::ExecutionReceipt,
     ) -> Result<(), HostAbiError> {
-        log::info!("[MeshNetwork] Submitting execution receipt for job {:?} from {}", 
-                  receipt.job_id, receipt.executor_did);
+        log::info!(
+            "[MeshNetwork] Submitting execution receipt for job {:?} from {}",
+            receipt.job_id,
+            receipt.executor_did
+        );
 
         // Create execution metadata
         let execution_metadata = icn_protocol::ExecutionMetadata {
             wall_time_ms: receipt.cpu_ms, // Use cpu_ms as wall time for now
-            peak_memory_mb: 0, // TODO: Track actual memory usage
+            peak_memory_mb: 0,            // TODO: Track actual memory usage
             exit_code: if receipt.success { 0 } else { 1 },
             execution_logs: None, // TODO: Capture execution logs
         };
@@ -395,7 +414,8 @@ impl MeshNetworkService for DefaultMeshNetworkService {
     ) -> Result<(), HostAbiError> {
         log::info!(
             "[MeshNetwork] Notifying executor {} of assignment for job {:?}",
-            notice.executor_did, notice.job_id
+            notice.executor_did,
+            notice.job_id
         );
 
         let assignment_message = MeshJobAssignmentMessage {
@@ -414,7 +434,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             signature: SignatureBytes(Vec::new()),
             version: 1,
         };
-        
+
         let signed = self.sign_message(&message)?;
         self.inner
             .broadcast_signed_message(signed)
@@ -432,28 +452,38 @@ impl MeshNetworkService for DefaultMeshNetworkService {
     ) -> Result<Option<IdentityExecutionReceipt>, HostAbiError> {
         log::info!(
             "[MeshNetwork] Waiting for receipt from {} for job {:?} (timeout: {}s)",
-            expected_executor, job_id, timeout.as_secs()
+            expected_executor,
+            job_id,
+            timeout.as_secs()
         );
 
         // Subscribe to network messages to wait for receipt
-        let mut receiver = self.inner.subscribe().await
-            .map_err(|e| HostAbiError::NetworkError(format!("Failed to subscribe to network: {}", e)))?;
+        let mut receiver = self.inner.subscribe().await.map_err(|e| {
+            HostAbiError::NetworkError(format!("Failed to subscribe to network: {}", e))
+        })?;
 
         let deadline = tokio::time::Instant::now() + timeout;
-        
+
         while tokio::time::Instant::now() < deadline {
             let remaining = deadline.duration_since(tokio::time::Instant::now());
-            
+
             match tokio::time::timeout(remaining, receiver.recv()).await {
                 Ok(Some(signed_message)) => {
                     // Check if this is a receipt for our job
-                    if let MessagePayload::MeshReceiptSubmission(receipt_message) = &signed_message.payload {
+                    if let MessagePayload::MeshReceiptSubmission(receipt_message) =
+                        &signed_message.payload
+                    {
                         let receipt = &receipt_message.receipt;
-                        
-                        if receipt.job_id == job_id.clone().into() && receipt.executor_did == *expected_executor {
-                            log::info!("[MeshNetwork] Received execution receipt from {} for job {:?}",
-                                     expected_executor, job_id);
-                            
+
+                        if receipt.job_id == job_id.clone().into()
+                            && receipt.executor_did == *expected_executor
+                        {
+                            log::info!(
+                                "[MeshNetwork] Received execution receipt from {} for job {:?}",
+                                expected_executor,
+                                job_id
+                            );
+
                             // TODO: Verify receipt signature
                             return Ok(Some(receipt.clone()));
                         }
@@ -470,8 +500,11 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             }
         }
 
-        log::warn!("[MeshNetwork] No receipt received from {} for job {:?} within timeout", 
-                  expected_executor, job_id);
+        log::warn!(
+            "[MeshNetwork] No receipt received from {} for job {:?} within timeout",
+            expected_executor,
+            job_id
+        );
         Ok(None)
     }
 }

--- a/crates/icn-runtime/tests/zk_proof.rs
+++ b/crates/icn-runtime/tests/zk_proof.rs
@@ -1,10 +1,14 @@
 use icn_common::{Cid, Did, ZkCredentialProof, ZkProofType};
-use icn_runtime::{context::{RuntimeContext, HostAbiError}, host_generate_zk_proof, host_verify_zk_proof};
+use icn_runtime::{
+    context::{mesh_network::ZK_VERIFY_COST_MANA, HostAbiError, RuntimeContext},
+    host_generate_zk_proof, host_verify_zk_proof,
+};
 use std::str::FromStr;
 
 #[tokio::test]
 async fn generate_and_verify_dummy_proof() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zProof").unwrap();
+    let ctx =
+        RuntimeContext::new_with_stubs_and_mana("did:key:zProof", ZK_VERIFY_COST_MANA * 2).unwrap();
     let issuer = Did::from_str("did:key:zIssuer").unwrap();
     let holder = Did::from_str("did:key:zHolder").unwrap();
     let schema = Cid::new_v1_sha256(0x55, b"schema");
@@ -15,7 +19,9 @@ async fn generate_and_verify_dummy_proof() {
         "schema": schema.to_string(),
         "backend": "dummy",
     });
-    let proof_json = host_generate_zk_proof(&ctx, &req.to_string()).await.unwrap();
+    let proof_json = host_generate_zk_proof(&ctx, &req.to_string())
+        .await
+        .unwrap();
     let proof: ZkCredentialProof = serde_json::from_str(&proof_json).unwrap();
     assert_eq!(proof.backend, ZkProofType::Other("dummy".into()));
     let verified = host_verify_zk_proof(&ctx, &proof_json).await.unwrap();
@@ -24,12 +30,13 @@ async fn generate_and_verify_dummy_proof() {
 
 #[tokio::test]
 async fn verify_invalid_proof_fails() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zProof2").unwrap();
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zProof2", ZK_VERIFY_COST_MANA * 2)
+        .unwrap();
     let proof = ZkCredentialProof {
         issuer: Did::from_str("did:key:zIss").unwrap(),
         holder: Did::from_str("did:key:zHold").unwrap(),
         claim_type: "test".into(),
-        proof: vec![1,2,3],
+        proof: vec![1, 2, 3],
         schema: Cid::new_v1_sha256(0x55, b"s"),
         vk_cid: None,
         disclosed_fields: Vec::new(),
@@ -44,7 +51,46 @@ async fn verify_invalid_proof_fails() {
 
 #[tokio::test]
 async fn generate_invalid_json() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zProof3").unwrap();
-    let err = host_generate_zk_proof(&ctx, "not-json").await.err().unwrap();
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zProof3", ZK_VERIFY_COST_MANA * 2)
+        .unwrap();
+    let err = host_generate_zk_proof(&ctx, "not-json")
+        .await
+        .err()
+        .unwrap();
     assert!(matches!(err, HostAbiError::InvalidParameters(_)));
+}
+
+#[tokio::test]
+async fn verify_invalid_proof_refunds_mana() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zRefund1", ZK_VERIFY_COST_MANA * 2)
+        .unwrap();
+    let initial = ctx.get_mana(&ctx.current_identity).await.unwrap();
+    let proof = ZkCredentialProof {
+        issuer: Did::from_str("did:key:zIss2").unwrap(),
+        holder: Did::from_str("did:key:zHold2").unwrap(),
+        claim_type: "test".into(),
+        proof: vec![1, 2, 3],
+        schema: Cid::new_v1_sha256(0x55, b"s"),
+        vk_cid: None,
+        disclosed_fields: Vec::new(),
+        challenge: None,
+        backend: ZkProofType::Groth16,
+        verification_key: None,
+        public_inputs: None,
+    };
+    let json = serde_json::to_string(&proof).unwrap();
+    assert!(host_verify_zk_proof(&ctx, &json).await.is_err());
+    let final_balance = ctx.get_mana(&ctx.current_identity).await.unwrap();
+    assert_eq!(initial, final_balance);
+}
+
+#[tokio::test]
+async fn malformed_proof_refunds_mana() {
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zRefund2", ZK_VERIFY_COST_MANA * 2)
+        .unwrap();
+    let initial = ctx.get_mana(&ctx.current_identity).await.unwrap();
+    let err = host_verify_zk_proof(&ctx, "{not json").await.err().unwrap();
+    assert!(matches!(err, HostAbiError::InvalidParameters(_)));
+    let final_balance = ctx.get_mana(&ctx.current_identity).await.unwrap();
+    assert_eq!(initial, final_balance);
 }


### PR DESCRIPTION
## Summary
- charge ZK proof verification mana through a new `ZK_VERIFY_COST_MANA` constant
- refund mana in runtime proof verification helpers when verification fails
- refund mana in the node HTTP handler when verification fails
- test mana refund logic for malformed and failing proofs

## Testing
- `cargo test -p icn-runtime --test zk_proof -- --test-threads=1`
- `cargo test -p icn-node --test zk_refund -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_6873fc2da2e88324a957046e0d3955be