### PR TITLE
Support proofs in DAG operations

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -354,11 +354,19 @@ pub fn load_or_generate_identity(
 #[derive(Deserialize)]
 struct DagBlockPayload {
     data: Vec<u8>,
+    #[serde(default)]
+    credential_proof: Option<icn_common::ZkCredentialProof>,
+    #[serde(default)]
+    revocation_proof: Option<icn_common::ZkRevocationProof>,
 }
 
 #[derive(Deserialize)]
 struct ContractSourcePayload {
     source: String,
+    #[serde(default)]
+    credential_proof: Option<icn_common::ZkCredentialProof>,
+    #[serde(default)]
+    revocation_proof: Option<icn_common::ZkRevocationProof>,
 }
 
 #[derive(Deserialize)]
@@ -1572,13 +1580,12 @@ async fn dag_put_handler(
     State(state): State<AppState>,
     Json(block): Json<DagBlockPayload>,
 ) -> impl IntoResponse {
-    // Use RuntimeContext's dag_store now
     let ts = 0u64;
     let author = Did::new("key", "tester");
     let sig_opt = None;
     let cid = icn_common::compute_merkle_cid(0x71, &block.data, &[], ts, &author, &sig_opt, &None);
     let dag_block = CoreDagBlock {
-        cid,
+        cid: cid.clone(),
         data: block.data,
         links: vec![],
         timestamp: ts,
@@ -1586,9 +1593,27 @@ async fn dag_put_handler(
         signature: sig_opt,
         scope: None,
     };
-    let mut store = state.runtime_context.dag_store.lock().await;
-    match store.put(&dag_block).await {
-        Ok(()) => (StatusCode::CREATED, Json(dag_block.cid.to_string())).into_response(),
+    let block_json = match serde_json::to_string(&dag_block) {
+        Ok(j) => j,
+        Err(e) => {
+            return map_rust_error_to_json_response(
+                format!("Failed to serialize DagBlock: {e}"),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+            .into_response();
+        }
+    };
+    match icn_api::submit_dag_block(
+        state.runtime_context.dag_store.clone(),
+        block_json,
+        state.runtime_context.policy_enforcer.clone(),
+        state.runtime_context.current_identity.clone(),
+        block.credential_proof,
+        block.revocation_proof,
+    )
+    .await
+    {
+        Ok(_) => (StatusCode::CREATED, Json(cid.to_string())).into_response(),
         Err(e) => map_rust_error_to_json_response(
             format!("DAG put error: {}", e),
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -1826,6 +1851,8 @@ async fn contracts_post_handler(
         block_json,
         state.runtime_context.policy_enforcer.clone(),
         state.runtime_context.current_identity.clone(),
+        payload.credential_proof,
+        payload.revocation_proof,
     )
     .await
     {
@@ -2881,8 +2908,7 @@ async fn zk_verify_handler(
         .spend_mana(&state.runtime_context.current_identity, ZK_VERIFY_COST_MANA)
         .await
     {
-        return map_rust_error_to_json_response(e, StatusCode::BAD_REQUEST)
-            .into_response();
+        return map_rust_error_to_json_response(e, StatusCode::BAD_REQUEST).into_response();
     }
 
     let verifier: Box<dyn ZkVerifier> = match proof.backend {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -340,6 +340,12 @@ paths:
               $ref: '#/components/schemas/DagBlockPayload'
             example:
               data: "aGVsbG8="
+              credential_proof:
+                issuer: "did:key:issuer"
+                holder: "did:key:holder"
+                claim_type: "membership"
+                proof: "0x1234"
+                schema: "bafyschemacid"
       responses:
         '200':
           description: CID string
@@ -672,6 +678,12 @@ paths:
               $ref: '#/components/schemas/ContractSourcePayload'
             example:
               source: "(module ...)"
+              credential_proof:
+                issuer: "did:key:issuer"
+                holder: "did:key:holder"
+                claim_type: "membership"
+                proof: "0x1234"
+                schema: "bafyschemacid"
       responses:
         '200':
           description: Upload result
@@ -930,12 +942,18 @@ components:
       properties:
         proposal_id:
           type: string
-    DagBlockPayload:
-      type: object
-      properties:
-        data:
-          type: string
-          format: byte
+  DagBlockPayload:
+    type: object
+    properties:
+      data:
+        type: string
+        format: byte
+      credential_proof:
+        $ref: '#/components/schemas/ZkCredentialProof'
+        nullable: true
+      revocation_proof:
+        $ref: '#/components/schemas/ZkRevocationProof'
+        nullable: true
     CidRequest:
       type: object
       properties:
@@ -997,11 +1015,17 @@ components:
           type: array
           items:
             type: object
-    ContractSourcePayload:
-      type: object
-      properties:
-        source:
-          type: string
+  ContractSourcePayload:
+    type: object
+    properties:
+      source:
+        type: string
+      credential_proof:
+        $ref: '#/components/schemas/ZkCredentialProof'
+        nullable: true
+      revocation_proof:
+        $ref: '#/components/schemas/ZkRevocationProof'
+        nullable: true
     PeerPayload:
       type: object
       properties:
@@ -1012,6 +1036,58 @@ components:
       properties:
         peer:
           type: string
+    ZkCredentialProof:
+      type: object
+      properties:
+        issuer:
+          type: string
+        holder:
+          type: string
+        claim_type:
+          type: string
+        proof:
+          type: string
+          format: byte
+        schema:
+          type: string
+        vk_cid:
+          type: string
+          nullable: true
+        disclosed_fields:
+          type: array
+          items:
+            type: string
+        challenge:
+          type: string
+          nullable: true
+        backend:
+          type: string
+        verification_key:
+          type: string
+          format: byte
+          nullable: true
+        public_inputs:
+          type: object
+          nullable: true
+    ZkRevocationProof:
+      type: object
+      properties:
+        issuer:
+          type: string
+        subject:
+          type: string
+        proof:
+          type: string
+          format: byte
+        backend:
+          type: string
+        verification_key:
+          type: string
+          format: byte
+          nullable: true
+        public_inputs:
+          type: object
+          nullable: true
     FederationStatus:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- allow proofs when submitting DAG blocks
- pass optional proofs from node handlers
- document new fields in openapi spec

## Testing
- `cargo clippy -p icn-api -p icn-node --all-targets -- -D warnings` *(fails: use of `default` in icn-runtime)*
- `cargo test -p icn-api --lib` *(fails: test_cast_vote_api and test_submit_and_retrieve_dag_block_api)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc9fa084832492bd4bbff1ddb6bc