### PR TITLE
Integrate circuit registry for zk proof verification

### DIFF
--- a/crates/icn-identity/src/zk/circuit_registry.rs
+++ b/crates/icn-identity/src/zk/circuit_registry.rs
@@ -1,0 +1,55 @@
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Entry describing a Groth16 circuit's verifying key and expected public inputs.
+#[derive(Clone)]
+pub struct CircuitEntry {
+    /// Serialized verifying key bytes.
+    pub verifying_key: Vec<u8>,
+    /// Public inputs expected by the circuit as `u64` values.
+    pub public_inputs: Vec<u64>,
+}
+
+/// In-memory registry mapping `(claim_type, version)` pairs to circuit data.
+#[derive(Default)]
+pub struct CircuitRegistry {
+    map: HashMap<(String, Option<String>), CircuitEntry>,
+}
+
+impl CircuitRegistry {
+    /// Register circuit data for the given claim type and optional version.
+    pub fn register(&mut self, claim_type: &str, version: Option<&str>, entry: CircuitEntry) {
+        self.map.insert(
+            (claim_type.to_string(), version.map(|v| v.to_string())),
+            entry,
+        );
+    }
+
+    /// Fetch circuit data for the claim type and version if present.
+    pub fn get(&self, claim_type: &str, version: Option<&str>) -> Option<CircuitEntry> {
+        self.map
+            .get(&(claim_type.to_string(), version.map(|v| v.to_string())))
+            .cloned()
+            .or_else(|| self.map.get(&(claim_type.to_string(), None)).cloned())
+    }
+}
+
+static GLOBAL_REGISTRY: Lazy<Mutex<CircuitRegistry>> =
+    Lazy::new(|| Mutex::new(CircuitRegistry::default()));
+
+/// Register circuit data in the global registry.
+pub fn register_circuit(claim_type: &str, version: Option<&str>, entry: CircuitEntry) {
+    GLOBAL_REGISTRY
+        .lock()
+        .expect("registry mutex poisoned")
+        .register(claim_type, version, entry);
+}
+
+/// Lookup circuit data from the global registry.
+pub fn get_circuit(claim_type: &str, version: Option<&str>) -> Option<CircuitEntry> {
+    GLOBAL_REGISTRY
+        .lock()
+        .expect("registry mutex poisoned")
+        .get(claim_type, version)
+}

--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -12,7 +12,9 @@ use thiserror::Error;
 
 pub mod key_manager;
 pub use key_manager::Groth16KeyManager;
+pub mod circuit_registry;
 pub mod vk_cache;
+pub use circuit_registry::{get_circuit, register_circuit, CircuitEntry, CircuitRegistry};
 
 /// Errors that can occur when verifying zero-knowledge proofs.
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -48,6 +48,10 @@ chrono = { version = "0.4", features = ["serde"] }
 tempfile = "3"
 fastrand = "2.0"
 sysinfo = { version = "0.29", features = ["multithread"] }
+ark-bn254 = "0.4"
+ark-groth16 = "0.4"
+ark-serialize = "0.4"
+ark-snark = "0.4"
 
 [dev-dependencies]
 anyhow = "1.0.75"
@@ -61,6 +65,8 @@ serial_test = { version = "3", features = ["async"] }
 env_logger = "0.11"
 # temp-dir = "0.1"
 criterion = { version = "0.5", features = ["async"] }
+icn-zk = { path = "../icn-zk" }
+rand_core = "0.6"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- introduce `CircuitRegistry` in identity module for mapping claim types to verifying keys
- update runtime's `host_verify_zk_proof` to fetch verifying keys from the registry
- add dev deps and update tests to use registry
- ensure verification succeeds with registry-provided circuits

## Testing
- `cargo test -p icn-identity --lib`
- `cargo test -p icn-runtime --test zk_proof`

------
https://chatgpt.com/codex/tasks/task_e_6873fc1eacd08324aa83eb747cd2436b