### PR TITLE
Add registry tests for zk and identity crates

### DIFF
--- a/crates/icn-identity/tests/credential_store.rs
+++ b/crates/icn-identity/tests/credential_store.rs
@@ -1,0 +1,31 @@
+use icn_common::{Cid, Did};
+use icn_identity::credential::CredentialIssuer;
+use icn_identity::credential_store::InMemoryCredentialStore;
+use icn_identity::generate_ed25519_keypair;
+
+#[test]
+fn store_insert_get_revoke() {
+    let (sk, _pk) = generate_ed25519_keypair();
+    let issuer_did = Did::new("key", "issuer");
+    let holder_did = Did::new("key", "holder");
+    let mut claims = std::collections::HashMap::new();
+    claims.insert("birth_year".to_string(), "2000".to_string());
+    let issuer = CredentialIssuer::new(issuer_did.clone(), sk);
+    let (cred, _) = issuer
+        .issue(
+            holder_did,
+            claims,
+            Some(Cid::new_v1_sha256(0x55, b"schema")),
+            None,
+            None,
+        )
+        .unwrap();
+    let cid = Cid::new_v1_sha256(0x55, b"cred");
+    let store = InMemoryCredentialStore::new();
+    store.insert(cid.clone(), cred.clone());
+    assert_eq!(store.get(&cid), Some(cred.clone()));
+    let schemas = store.list_schemas();
+    assert!(schemas.contains(&cred.schema.clone().unwrap()));
+    assert!(store.revoke(&cid));
+    assert!(store.get(&cid).is_none());
+}


### PR DESCRIPTION
## Summary
- ensure circuit parameter registry works across multiple entries
- verify credential store registry use

## Testing
- `cargo test -p icn-zk -p icn-identity`
- `cargo clippy -p icn-zk -p icn-identity --all-targets --all-features -- -D warnings` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc1d2748832484d1fcded1ef39fb