### PR TITLE
[api] batch proof verification

### DIFF
--- a/ICN_API_REFERENCE.md
+++ b/ICN_API_REFERENCE.md
@@ -35,6 +35,8 @@
 | `/network/local-peer-id` | GET | Show local peer ID | ✅ Working |
 | `/network/connect` | POST | Connect to a peer | ✅ Working |
 | `/network/peers` | GET | List network peers | ✅ Working |
+| `/identity/verify` | POST | Verify a zero-knowledge proof | ✅ Working |
+| `/identity/verify/batch` | POST | Verify multiple proofs | ✅ Working |
 | `/transaction/submit` | POST | Submit a transaction | ✅ Working |
 | `/tokens/classes` | GET | List token classes | 🚧 Experimental |
 | `/tokens/class` | POST | Create a token class | 🚧 Experimental |
@@ -49,6 +51,24 @@
 | `/federation/leave` | POST | Leave the federation | ✅ Working |
 | `/federation/status` | GET | Current federation status | ✅ Working |
 | `/metrics` | GET | Prometheus metrics | ✅ Working |
+
+### Identity Proof Verification
+
+Example verifying a single proof:
+
+```bash
+curl -X POST http://127.0.0.1:7845/identity/verify \
+  -H 'Content-Type: application/json' \
+  -d '{"issuer":"did:key:abc","holder":"did:key:def",...}'
+```
+
+Verifying multiple proofs:
+
+```bash
+curl -X POST http://127.0.0.1:7845/identity/verify/batch \
+  -H 'Content-Type: application/json' \
+  -d '{"proofs": [ {...}, {...} ] }'
+```
 
 ---
 This document summarizes the HTTP endpoints. See [docs/API.md](docs/API.md) for complete details and authentication requirements.

--- a/crates/icn-api/src/identity_trait.rs
+++ b/crates/icn-api/src/identity_trait.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use icn_common::{Cid, CommonError, Did};
+use icn_common::{Cid, CommonError, Did, ZkCredentialProof};
 use icn_identity::Credential as VerifiableCredential;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -32,6 +32,19 @@ pub struct RevokeCredentialRequest {
     pub cid: Cid,
 }
 
+/// Request containing multiple zero-knowledge credential proofs to verify.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyProofsRequest {
+    pub proofs: Vec<ZkCredentialProof>,
+}
+
+/// Response for batch proof verification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchVerificationResponse {
+    /// Verification result for each proof in the request.
+    pub verified: Vec<bool>,
+}
+
 #[async_trait]
 pub trait IdentityApi {
     async fn issue_credential(
@@ -49,4 +62,10 @@ pub trait IdentityApi {
     async fn revoke_credential(&self, cid: Cid) -> Result<(), CommonError>;
 
     async fn list_schemas(&self) -> Result<Vec<Cid>, CommonError>;
+
+    /// Verify multiple zero-knowledge credential proofs in a single request.
+    async fn verify_proofs(
+        &self,
+        req: VerifyProofsRequest,
+    ) -> Result<BatchVerificationResponse, CommonError>;
 }

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -728,9 +728,9 @@ pub async fn host_verify_zk_proof(
     })?;
 
     let verifier: Box<dyn ZkVerifier> = match proof.backend {
-        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier::default()),
+        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier),
         ZkProofType::Groth16 => Box::new(Groth16Verifier::default()),
-        _ => Box::new(DummyVerifier::default()),
+        _ => Box::new(DummyVerifier),
     };
 
     verifier
@@ -752,9 +752,9 @@ pub async fn host_verify_zk_revocation_proof(
     })?;
 
     let verifier: Box<dyn ZkRevocationVerifier> = match proof.backend {
-        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier::default()),
+        ZkProofType::Bulletproofs => Box::new(BulletproofsVerifier),
         ZkProofType::Groth16 => Box::new(Groth16Verifier::default()),
-        _ => Box::new(DummyVerifier::default()),
+        _ => Box::new(DummyVerifier),
     };
 
     verifier


### PR DESCRIPTION
## Summary
- add batch verification structs and trait method in `icn-api`
- implement `/identity/verify/batch` handler in `icn-node`
- support batch verification in `icn-cli`
- document proof verification endpoints and examples

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-ccl` and clippy warnings in icn-node)*
- `cargo test --all-features --workspace` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc181d148324b194bba2b3cd7dc2