### PR TITLE
Add proof attempt tracking to reputation

### DIFF
--- a/crates/icn-reputation/README.md
+++ b/crates/icn-reputation/README.md
@@ -4,5 +4,9 @@ This crate provides reputation tracking utilities for the InterCooperative Netwo
 It defines the `ReputationStore` trait used by the mesh scheduling logic and a simple
 in-memory implementation useful for testing.
 
+`record_proof_attempt` is provided to track zero-knowledge proof verifications.
+`host_verify_zk_proof` and `host_verify_zk_revocation_proof` call this method to
+reward or penalize provers.
+
 See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
 See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.

--- a/crates/icn-reputation/src/rocksdb_store.rs
+++ b/crates/icn-reputation/src/rocksdb_store.rs
@@ -49,4 +49,12 @@ impl ReputationStore for RocksdbReputationStore {
         let new_score = if updated < 0 { 0 } else { updated as u64 };
         self.write_score(executor, new_score);
     }
+
+    fn record_proof_attempt(&self, prover: &Did, success: bool) {
+        let current = self.read_score(prover);
+        let delta: i64 = if success { 1 } else { -1 };
+        let updated = (current as i64) + delta;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        self.write_score(prover, new_score);
+    }
 }

--- a/crates/icn-reputation/src/sled_store.rs
+++ b/crates/icn-reputation/src/sled_store.rs
@@ -57,4 +57,12 @@ impl ReputationStore for SledReputationStore {
         let new_score = if updated < 0 { 0 } else { updated as u64 };
         self.write_score(executor, new_score);
     }
+
+    fn record_proof_attempt(&self, prover: &Did, success: bool) {
+        let current = self.read_score(prover);
+        let delta: i64 = if success { 1 } else { -1 };
+        let updated = (current as i64) + delta;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        self.write_score(prover, new_score);
+    }
 }

--- a/crates/icn-reputation/src/sqlite_store.rs
+++ b/crates/icn-reputation/src/sqlite_store.rs
@@ -91,6 +91,23 @@ impl ReputationStore for SqliteReputationStore {
             }
         }
     }
+
+    fn record_proof_attempt(&self, prover: &Did, success: bool) {
+        let fut = async {
+            let current = self.read_score(prover).await.unwrap_or(0);
+            let delta: i64 = if success { 1 } else { -1 };
+            let updated = (current as i64) + delta;
+            let new_score = if updated < 0 { 0 } else { updated as u64 };
+            let _ = self.write_score(prover, new_score).await;
+        };
+        match tokio::runtime::Handle::try_current() {
+            Ok(h) => h.block_on(fut),
+            Err(_) => {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                rt.block_on(fut);
+            }
+        }
+    }
 }
 
 #[cfg(all(feature = "persist-sqlite", feature = "async"))]
@@ -107,5 +124,13 @@ impl AsyncReputationStore for SqliteReputationStore {
         let updated = (current as i64) + delta;
         let new_score = if updated < 0 { 0 } else { updated as u64 };
         let _ = self.write_score(executor, new_score).await;
+    }
+
+    async fn record_proof_attempt(&self, prover: &Did, success: bool) {
+        let current = self.read_score(prover).await.unwrap_or(0);
+        let delta: i64 = if success { 1 } else { -1 };
+        let updated = (current as i64) + delta;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        let _ = self.write_score(prover, new_score).await;
     }
 }

--- a/crates/icn-runtime/tests/zk_proof.rs
+++ b/crates/icn-runtime/tests/zk_proof.rs
@@ -1,10 +1,18 @@
 use icn_common::{Cid, Did, ZkCredentialProof, ZkProofType};
-use icn_runtime::{context::{RuntimeContext, HostAbiError}, host_generate_zk_proof, host_verify_zk_proof};
+use icn_reputation::{InMemoryReputationStore, ReputationStore};
+use icn_runtime::context::mana::SimpleManaLedger;
+use icn_runtime::{
+    context::{
+        HostAbiError, RuntimeContext as Rc, ServiceConfigBuilder, ServiceEnvironment, StubSigner,
+    },
+    host_generate_zk_proof, host_verify_zk_proof,
+};
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn generate_and_verify_dummy_proof() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zProof").unwrap();
+    let ctx = Rc::new_with_stubs("did:key:zProof").unwrap();
     let issuer = Did::from_str("did:key:zIssuer").unwrap();
     let holder = Did::from_str("did:key:zHolder").unwrap();
     let schema = Cid::new_v1_sha256(0x55, b"schema");
@@ -15,7 +23,9 @@ async fn generate_and_verify_dummy_proof() {
         "schema": schema.to_string(),
         "backend": "dummy",
     });
-    let proof_json = host_generate_zk_proof(&ctx, &req.to_string()).await.unwrap();
+    let proof_json = host_generate_zk_proof(&ctx, &req.to_string())
+        .await
+        .unwrap();
     let proof: ZkCredentialProof = serde_json::from_str(&proof_json).unwrap();
     assert_eq!(proof.backend, ZkProofType::Other("dummy".into()));
     let verified = host_verify_zk_proof(&ctx, &proof_json).await.unwrap();
@@ -24,12 +34,12 @@ async fn generate_and_verify_dummy_proof() {
 
 #[tokio::test]
 async fn verify_invalid_proof_fails() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zProof2").unwrap();
+    let ctx = Rc::new_with_stubs("did:key:zProof2").unwrap();
     let proof = ZkCredentialProof {
         issuer: Did::from_str("did:key:zIss").unwrap(),
         holder: Did::from_str("did:key:zHold").unwrap(),
         claim_type: "test".into(),
-        proof: vec![1,2,3],
+        proof: vec![1, 2, 3],
         schema: Cid::new_v1_sha256(0x55, b"s"),
         vk_cid: None,
         disclosed_fields: Vec::new(),
@@ -44,7 +54,49 @@ async fn verify_invalid_proof_fails() {
 
 #[tokio::test]
 async fn generate_invalid_json() {
-    let ctx = RuntimeContext::new_with_stubs("did:key:zProof3").unwrap();
-    let err = host_generate_zk_proof(&ctx, "not-json").await.err().unwrap();
+    let ctx = Rc::new_with_stubs("did:key:zProof3").unwrap();
+    let err = host_generate_zk_proof(&ctx, "not-json")
+        .await
+        .err()
+        .unwrap();
     assert!(matches!(err, HostAbiError::InvalidParameters(_)));
+}
+
+#[tokio::test]
+async fn reputation_updated_on_proof_result() {
+    let store = Arc::new(InMemoryReputationStore::new());
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    let ledger = SimpleManaLedger::new(temp.path().to_path_buf());
+    let cfg = ServiceConfigBuilder::new(ServiceEnvironment::Testing)
+        .with_identity(Did::from_str("did:key:verifier").unwrap())
+        .with_signer(Arc::new(StubSigner::new()))
+        .with_did_resolver(Arc::new(icn_identity::KeyDidResolver))
+        .with_mana_ledger(ledger)
+        .with_reputation_store(store.clone())
+        .build()
+        .unwrap();
+    let ctx = Rc::from_service_config(cfg).unwrap();
+
+    let issuer = Did::from_str("did:key:issuer").unwrap();
+    let holder = Did::from_str("did:key:holder").unwrap();
+    let schema = Cid::new_v1_sha256(0x55, b"schema");
+    let req = serde_json::json!({
+        "issuer": issuer.to_string(),
+        "holder": holder.to_string(),
+        "claim_type": "test",
+        "schema": schema.to_string(),
+        "backend": "dummy",
+    });
+    let proof_json = host_generate_zk_proof(&ctx, &req.to_string())
+        .await
+        .unwrap();
+    assert!(host_verify_zk_proof(&ctx, &proof_json).await.unwrap());
+    assert_eq!(store.get_reputation(&holder), 1);
+
+    store.set_score(holder.clone(), 1);
+    let mut bad: ZkCredentialProof = serde_json::from_str(&proof_json).unwrap();
+    bad.backend = ZkProofType::Groth16;
+    let j = serde_json::to_string(&bad).unwrap();
+    assert!(host_verify_zk_proof(&ctx, &j).await.is_err());
+    assert_eq!(store.get_reputation(&holder), 0);
 }

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -117,6 +117,9 @@ Invoking `host_verify_zk_proof` with this response yields the boolean result:
 true
 ```
 
+After verification the runtime updates the prover's reputation via
+`record_proof_attempt`, incrementing on success and decrementing on failure.
+
 ## Production Verification
 
 Production nodes must verify the authenticity of the Groth16 verifying key
@@ -150,6 +153,7 @@ Verifiable credentials can be invalidated without revealing their contents. The 
 1. **Issuer** marks the credential ID in its revocation registry and generates a zero-knowledge revocation proof.
 2. **Holder** presents this `ZkRevocationProof` together with their credential or credential proof.
 3. **Verifier** calls `verify_revocation` on a configured `ZkRevocationVerifier` implementation. If the proof succeeds, the credential is considered active without exposing registry entries.
+   Reputation for the subject DID is updated using `record_proof_attempt`.
 
 Revocation proofs can be produced by `icn-identity`'s `Groth16Prover` or any custom prover implementing `ZkProver`.
 


### PR DESCRIPTION
## Summary
- extend `ReputationStore` API with `record_proof_attempt`
- update all store implementations
- call `record_proof_attempt` after zk proof verification
- test reputation updates for proofs
- document proof reputation effects

## Testing
- `cargo test -p icn-runtime --test zk_proof --quiet`
- `cargo check -p icn-reputation`
- `cargo check -p icn-runtime`


------
https://chatgpt.com/codex/tasks/task_e_6873fc39cf688324b3f5cc0a94f33c42