### PR TITLE
Move zk verify mana cost constant to runtime

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -85,9 +85,7 @@ use crate::config::{NodeConfig, StorageBackendType, StorageConfig};
 use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
 #[cfg(feature = "enable-libp2p")]
 use libp2p::Multiaddr;
-
-/// Mana cost charged for verifying a zero-knowledge proof.
-const ZK_VERIFY_COST_MANA: u64 = 2;
+use icn_runtime::ZK_VERIFY_COST_MANA;
 
 static NODE_START_TIME: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/icn-runtime/src/constants.rs
+++ b/crates/icn-runtime/src/constants.rs
@@ -1,0 +1,8 @@
+//! Runtime-wide constants used across the node and runtime crates.
+
+/// Mana cost charged for verifying a zero-knowledge proof.
+///
+/// This mirrors the previous value defined in `icn-node` and is
+/// re-exported for consumers of `icn-runtime`.
+pub const ZK_VERIFY_COST_MANA: u64 = 2;
+

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -18,6 +18,7 @@ pub mod context;
 pub mod executor;
 pub mod memory;
 pub mod metrics;
+pub mod constants;
 
 // Re-export important types for convenience
 pub use context::{DagStoreMutexType, HostAbiError, RuntimeContext, Signer};
@@ -28,6 +29,7 @@ pub use icn_dag::StorageService;
 
 // Re-export ABI constants
 pub use abi::*;
+pub use constants::ZK_VERIFY_COST_MANA;
 extern crate bincode;
 use icn_common::{Cid, CommonError, Did, NodeInfo};
 use icn_mesh::JobId;


### PR DESCRIPTION
## Summary
- define `ZK_VERIFY_COST_MANA` in `icn-runtime`
- re-export the constant from `icn-runtime`'s `lib.rs`
- use the runtime constant inside `icn-node`

## Testing
- `cargo test -p icn-node --no-run` *(fails: could not compile `icn-node` tests)*

------
https://chatgpt.com/codex/tasks/task_e_6873fc2fb0c48324ba51ed40950475d2