### PR TITLE
[runtime] move node start time constant

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -83,14 +83,13 @@ use tokio::sync::{Mutex as AsyncMutex, Mutex as TokioMutex};
 use uuid::Uuid;
 
 use crate::config::{NodeConfig, StorageBackendType, StorageConfig};
+use icn_runtime::constants::NODE_START_TIME;
 use icn_runtime::context::mesh_network::ZK_VERIFY_COST_MANA;
 
 #[cfg(feature = "enable-libp2p")]
 use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
 #[cfg(feature = "enable-libp2p")]
 use libp2p::Multiaddr;
-
-static NODE_START_TIME: AtomicU64 = AtomicU64::new(0);
 
 // Initialize node start time (call this when the node starts)
 fn init_node_start_time() {

--- a/crates/icn-runtime/src/constants.rs
+++ b/crates/icn-runtime/src/constants.rs
@@ -1,0 +1,5 @@
+use std::sync::atomic::AtomicU64;
+
+/// Global atomic storing the node start time in seconds since Unix epoch.
+/// Used by components to report uptime metrics.
+pub static NODE_START_TIME: AtomicU64 = AtomicU64::new(0);

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod abi;
 pub mod config;
+pub mod constants;
 pub mod context;
 pub mod executor;
 pub mod memory;


### PR DESCRIPTION
## Summary
- create runtime constants module for `NODE_START_TIME`
- reference runtime constant from `icn-node`

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `icn-identity`)*
- `cargo test --all-features --workspace` *(fails: could not compile `icn-identity`)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874194cca5c8324995889c853cc8e94