### PR TITLE
Track proof attempts in reputation store

### DIFF
--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -78,8 +78,20 @@ pub trait ZkProver: Send + Sync {
 }
 
 /// Verifier implementation for the Bulletproofs proving system.
-#[derive(Debug, Default)]
-pub struct BulletproofsVerifier;
+#[derive(Debug)]
+pub struct BulletproofsVerifier {
+    reputation_store: std::sync::Arc<dyn icn_reputation::ReputationStore>,
+    thresholds: icn_zk::ReputationThresholds,
+}
+
+impl Default for BulletproofsVerifier {
+    fn default() -> Self {
+        Self {
+            reputation_store: std::sync::Arc::new(icn_reputation::InMemoryReputationStore::new()),
+            thresholds: icn_zk::ReputationThresholds::default(),
+        }
+    }
+}
 
 impl ZkVerifier for BulletproofsVerifier {
     fn verify(&self, proof: &ZkCredentialProof) -> Result<bool, ZkError> {

--- a/crates/icn-reputation/README.md
+++ b/crates/icn-reputation/README.md
@@ -4,5 +4,10 @@ This crate provides reputation tracking utilities for the InterCooperative Netwo
 It defines the `ReputationStore` trait used by the mesh scheduling logic and a simple
 in-memory implementation useful for testing.
 
+`ReputationStore` now exposes `record_proof_attempt` allowing runtimes to
+increase or decrease reputation based on zero-knowledge proof verification
+results. Successful proofs increment the prover's score while invalid proofs
+decrement it, with scores never dropping below zero.
+
 See [CONTEXT.md](../../CONTEXT.md) for ICN Core design philosophy and crate roles.
 See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guidelines.

--- a/crates/icn-reputation/src/rocksdb_store.rs
+++ b/crates/icn-reputation/src/rocksdb_store.rs
@@ -6,6 +6,7 @@ use rocksdb::DB;
 use std::path::PathBuf;
 
 #[cfg(feature = "persist-rocksdb")]
+#[derive(Debug)]
 pub struct RocksdbReputationStore {
     db: DB,
 }
@@ -48,5 +49,13 @@ impl ReputationStore for RocksdbReputationStore {
         let updated = (current as i64) + delta;
         let new_score = if updated < 0 { 0 } else { updated as u64 };
         self.write_score(executor, new_score);
+    }
+
+    fn record_proof_attempt(&self, prover: &Did, success: bool) {
+        let current = self.read_score(prover);
+        let base: i64 = if success { 1 } else { -1 };
+        let updated = (current as i64) + base;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        self.write_score(prover, new_score);
     }
 }

--- a/crates/icn-reputation/src/sled_store.rs
+++ b/crates/icn-reputation/src/sled_store.rs
@@ -11,6 +11,7 @@ use sled;
 
 /// Persistent sled-backed reputation store.
 #[cfg(feature = "persist-sled")]
+#[derive(Debug)]
 pub struct SledReputationStore {
     tree: sled::Tree,
 }
@@ -56,5 +57,13 @@ impl ReputationStore for SledReputationStore {
         let updated = (current as i64) + delta;
         let new_score = if updated < 0 { 0 } else { updated as u64 };
         self.write_score(executor, new_score);
+    }
+
+    fn record_proof_attempt(&self, prover: &Did, success: bool) {
+        let current = self.read_score(prover);
+        let base: i64 = if success { 1 } else { -1 };
+        let updated = (current as i64) + base;
+        let new_score = if updated < 0 { 0 } else { updated as u64 };
+        self.write_score(prover, new_score);
     }
 }

--- a/crates/icn-reputation/tests/rocksdb.rs
+++ b/crates/icn-reputation/tests/rocksdb.rs
@@ -20,6 +20,12 @@ mod tests {
         store.record_execution(&did, true, 1000);
         assert_eq!(store.get_reputation(&did), 2);
 
+        store.record_proof_attempt(&did, true);
+        assert_eq!(store.get_reputation(&did), 3);
+
+        store.record_proof_attempt(&did, false);
+        assert_eq!(store.get_reputation(&did), 2);
+
         drop(store);
         let reopened = RocksdbReputationStore::new(path).unwrap();
         assert_eq!(reopened.get_reputation(&did), 2);

--- a/crates/icn-reputation/tests/sled.rs
+++ b/crates/icn-reputation/tests/sled.rs
@@ -20,6 +20,12 @@ mod tests {
         store.record_execution(&did, true, 1000);
         assert_eq!(store.get_reputation(&did), 2);
 
+        store.record_proof_attempt(&did, true);
+        assert_eq!(store.get_reputation(&did), 3);
+
+        store.record_proof_attempt(&did, false);
+        assert_eq!(store.get_reputation(&did), 2);
+
         drop(store);
         let reopened = SledReputationStore::new(path).unwrap();
         assert_eq!(reopened.get_reputation(&did), 2);

--- a/crates/icn-reputation/tests/sqlite.rs
+++ b/crates/icn-reputation/tests/sqlite.rs
@@ -20,6 +20,12 @@ mod tests {
         store.record_execution(&did, true, 1000).await;
         assert_eq!(store.get_reputation(&did).await, 2);
 
+        store.record_proof_attempt(&did, true).await;
+        assert_eq!(store.get_reputation(&did).await, 3);
+
+        store.record_proof_attempt(&did, false).await;
+        assert_eq!(store.get_reputation(&did).await, 2);
+
         drop(store);
         let reopened = SqliteReputationStore::new(path).await.unwrap();
         assert_eq!(reopened.get_reputation(&did).await, 2);

--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -741,13 +741,19 @@ pub async fn host_verify_zk_proof(
     };
 
     match verifier.verify(&proof) {
-        Ok(true) => Ok(true),
+        Ok(true) => {
+            ctx.reputation_store
+                .record_proof_attempt(&proof.issuer, true);
+            Ok(true)
+        }
         Ok(false) => {
             ctx.credit_mana(
                 &ctx.current_identity,
                 context::mesh_network::ZK_VERIFY_COST_MANA,
             )
             .await?;
+            ctx.reputation_store
+                .record_proof_attempt(&proof.issuer, false);
             Ok(false)
         }
         Err(e) => {
@@ -756,6 +762,8 @@ pub async fn host_verify_zk_proof(
                 context::mesh_network::ZK_VERIFY_COST_MANA,
             )
             .await?;
+            ctx.reputation_store
+                .record_proof_attempt(&proof.issuer, false);
             Err(HostAbiError::InvalidParameters(format!("{e}")))
         }
     }
@@ -788,13 +796,19 @@ pub async fn host_verify_zk_revocation_proof(
     };
 
     match verifier.verify_revocation(&proof) {
-        Ok(true) => Ok(true),
+        Ok(true) => {
+            ctx.reputation_store
+                .record_proof_attempt(&proof.issuer, true);
+            Ok(true)
+        }
         Ok(false) => {
             ctx.credit_mana(
                 &ctx.current_identity,
                 context::mesh_network::ZK_VERIFY_COST_MANA,
             )
             .await?;
+            ctx.reputation_store
+                .record_proof_attempt(&proof.issuer, false);
             Ok(false)
         }
         Err(e) => {
@@ -803,6 +817,8 @@ pub async fn host_verify_zk_revocation_proof(
                 context::mesh_network::ZK_VERIFY_COST_MANA,
             )
             .await?;
+            ctx.reputation_store
+                .record_proof_attempt(&proof.issuer, false);
             Err(HostAbiError::InvalidParameters(format!("{e}")))
         }
     }

--- a/crates/icn-runtime/tests/zk_proof.rs
+++ b/crates/icn-runtime/tests/zk_proof.rs
@@ -29,6 +29,55 @@ async fn generate_and_verify_dummy_proof() {
 }
 
 #[tokio::test]
+async fn verify_updates_reputation() {
+    let ctx =
+        RuntimeContext::new_with_stubs_and_mana("did:key:zRep", ZK_VERIFY_COST_MANA * 2).unwrap();
+    let issuer = Did::from_str("did:key:zIssuerRep").unwrap();
+    let holder = Did::from_str("did:key:zHolderRep").unwrap();
+    let schema = Cid::new_v1_sha256(0x55, b"schema");
+    let req = serde_json::json!({
+        "issuer": issuer.to_string(),
+        "holder": holder.to_string(),
+        "claim_type": "test",
+        "schema": schema.to_string(),
+        "backend": "dummy",
+    });
+    let proof_json = host_generate_zk_proof(&ctx, &req.to_string())
+        .await
+        .unwrap();
+    assert_eq!(ctx.reputation_store.get_reputation(&issuer), 0);
+    host_verify_zk_proof(&ctx, &proof_json).await.unwrap();
+    assert_eq!(ctx.reputation_store.get_reputation(&issuer), 1);
+}
+
+#[tokio::test]
+async fn verify_invalid_proof_penalizes() {
+    let ctx =
+        RuntimeContext::new_with_stubs_and_mana("did:key:zBad", ZK_VERIFY_COST_MANA * 2).unwrap();
+    let issuer = Did::from_str("did:key:zBadIss").unwrap();
+    // Give issuer some reputation
+    ctx.reputation_store.record_execution(&issuer, true, 0);
+    ctx.reputation_store.record_execution(&issuer, true, 0);
+    assert_eq!(ctx.reputation_store.get_reputation(&issuer), 2);
+    let proof = ZkCredentialProof {
+        issuer: issuer.clone(),
+        holder: Did::from_str("did:key:zBadHolder").unwrap(),
+        claim_type: "test".into(),
+        proof: vec![1, 2, 3],
+        schema: Cid::new_v1_sha256(0x55, b"s"),
+        vk_cid: None,
+        disclosed_fields: Vec::new(),
+        challenge: None,
+        backend: ZkProofType::Groth16,
+        verification_key: None,
+        public_inputs: None,
+    };
+    let json = serde_json::to_string(&proof).unwrap();
+    assert!(host_verify_zk_proof(&ctx, &json).await.is_err());
+    assert_eq!(ctx.reputation_store.get_reputation(&issuer), 1);
+}
+
+#[tokio::test]
 async fn verify_invalid_proof_fails() {
     let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zProof2", ZK_VERIFY_COST_MANA * 2)
         .unwrap();

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -95,7 +95,9 @@ of guest memory.
 
 Both operations charge mana according to the complexity of the circuit. The
 runtime refunds this mana automatically if proof generation or verification
-fails, so callers only pay when a proof succeeds.
+fails, so callers only pay when a proof succeeds. The runtime also records a
+reputation event for the proof issuer: successful verifications increase the
+issuer's reputation while failed attempts decrease it.
 
 ### Example: Generate and Verify
 


### PR DESCRIPTION
## Summary
- extend `ReputationStore` with `record_proof_attempt`
- implement new method for memory, sled, sqlite and rocksdb backends
- update runtime ZK proof verification to record attempts
- document new behaviour in reputation README and zk_disclosure guide
- test reputation updates for proof attempts

## Testing
- `cargo test -p icn-reputation --no-default-features`
- *(failed: cargo test -p icn-runtime --no-default-features --lib)*

------
https://chatgpt.com/codex/tasks/task_e_68741931ce5c8324a614fd0fb6d3989a