### PR TITLE
Add credential proofs to governance API requests

### DIFF
--- a/crates/icn-api/src/governance_trait.rs
+++ b/crates/icn-api/src/governance_trait.rs
@@ -1,4 +1,4 @@
-use icn_common::CommonError;
+use icn_common::{CommonError, ZkCredentialProof, ZkRevocationProof};
 use icn_governance::{Proposal, ProposalId};
 use serde::{Deserialize, Serialize}; // Added for ProposalInputType later
 
@@ -10,6 +10,10 @@ pub struct CastVoteRequest {
     pub voter_did: String, // Assuming DID is represented as a String for the API layer
     pub proposal_id: String, // ProposalId represented as String for API layer
     pub vote_option: String, // e.g., "Yes", "No", "Abstain" - will map to VoteOption enum
+    #[serde(default)]
+    pub credential_proof: Option<ZkCredentialProof>,
+    #[serde(default)]
+    pub revocation_proof: Option<ZkRevocationProof>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -56,6 +60,10 @@ pub struct SubmitProposalRequest {
     pub quorum: Option<usize>,
     pub threshold: Option<f32>,
     pub body: Option<Vec<u8>>,
+    #[serde(default)]
+    pub credential_proof: Option<ZkCredentialProof>,
+    #[serde(default)]
+    pub revocation_proof: Option<ZkRevocationProof>,
 }
 
 pub trait GovernanceApi {

--- a/tests/integration/governance_proofs.rs
+++ b/tests/integration/governance_proofs.rs
@@ -1,0 +1,92 @@
+use icn_api::governance_trait::{CastVoteRequest, GovernanceApi, GovernanceApiImpl, ProposalInputType, SubmitProposalRequest};
+use icn_common::{Cid, Did, ZkCredentialProof, ZkProofType};
+use icn_governance::GovernanceModule;
+use std::sync::{Arc, Mutex};
+
+fn dummy_proof(valid: bool) -> ZkCredentialProof {
+    ZkCredentialProof {
+        issuer: Did::new("key", "issuer"),
+        holder: Did::new("key", "holder"),
+        claim_type: "test".into(),
+        proof: if valid { vec![1, 2, 3] } else { Vec::new() },
+        schema: Cid::new_v1_sha256(0x55, b"schema"),
+        vk_cid: None,
+        disclosed_fields: Vec::new(),
+        challenge: None,
+        backend: ZkProofType::Other("dummy".into()),
+        verification_key: None,
+        public_inputs: None,
+    }
+}
+
+#[test]
+fn proposal_submission_proof_validation() {
+    let gov = Arc::new(Mutex::new(GovernanceModule::new()));
+    let api = GovernanceApiImpl::new(gov.clone());
+
+    let ok_req = SubmitProposalRequest {
+        proposer_did: "did:example:alice".into(),
+        proposal: ProposalInputType::GenericText { text: "hi".into() },
+        description: "test".into(),
+        duration_secs: 60,
+        quorum: None,
+        threshold: None,
+        body: None,
+        credential_proof: Some(dummy_proof(true)),
+        revocation_proof: None,
+    };
+    assert!(api.submit_proposal(ok_req).is_ok());
+
+    let bad_req = SubmitProposalRequest {
+        proposer_did: "did:example:alice".into(),
+        proposal: ProposalInputType::GenericText { text: "bye".into() },
+        description: "bad".into(),
+        duration_secs: 60,
+        quorum: None,
+        threshold: None,
+        body: None,
+        credential_proof: Some(dummy_proof(false)),
+        revocation_proof: None,
+    };
+    assert!(api.submit_proposal(bad_req).is_err());
+}
+
+#[test]
+fn vote_proof_validation() {
+    let gov = Arc::new(Mutex::new(GovernanceModule::new()));
+    let api = GovernanceApiImpl::new(gov.clone());
+    let submit = SubmitProposalRequest {
+        proposer_did: "did:example:alice".into(),
+        proposal: ProposalInputType::GenericText { text: "hi".into() },
+        description: "test".into(),
+        duration_secs: 60,
+        quorum: None,
+        threshold: None,
+        body: None,
+        credential_proof: Some(dummy_proof(true)),
+        revocation_proof: None,
+    };
+    let pid = api.submit_proposal(submit).unwrap();
+    {
+        let mut gm = gov.lock().unwrap();
+        gm.open_voting(&pid).unwrap();
+    }
+
+    let ok_vote = CastVoteRequest {
+        voter_did: "did:example:bob".into(),
+        proposal_id: pid.0.clone(),
+        vote_option: "yes".into(),
+        credential_proof: Some(dummy_proof(true)),
+        revocation_proof: None,
+    };
+    assert!(api.cast_vote(ok_vote).is_ok());
+
+    let bad_vote = CastVoteRequest {
+        voter_did: "did:example:bob".into(),
+        proposal_id: pid.0.clone(),
+        vote_option: "yes".into(),
+        credential_proof: Some(dummy_proof(false)),
+        revocation_proof: None,
+    };
+    assert!(api.cast_vote(bad_vote).is_err());
+}


### PR DESCRIPTION
## Summary
- extend `SubmitProposalRequest` and `CastVoteRequest` with optional `credential_proof` and `revocation_proof`
- provide minimal proof validation in `GovernanceApiImpl`
- update unit tests using these requests
- add new integration test exercising proof handling

## Testing
- `cargo test --workspace --all-features` *(fails: could not compile `icn-identity`)*

------
https://chatgpt.com/codex/tasks/task_e_687423cca2548324913984cfd98b3d76