### PR TITLE
Add circuit benchmarks

### DIFF
--- a/crates/icn-zk/Cargo.toml
+++ b/crates/icn-zk/Cargo.toml
@@ -20,3 +20,4 @@ rayon = "1"
 
 [dev-dependencies]
 ark-std = { version = "0.4", features = ["std"] }
+criterion = { version = "0.5" }

--- a/crates/icn-zk/benches/circuit_perf.rs
+++ b/crates/icn-zk/benches/circuit_perf.rs
@@ -1,0 +1,164 @@
+use ark_bn254::Fr;
+use ark_std::rand::{rngs::StdRng, SeedableRng};
+use criterion::{criterion_group, criterion_main, Criterion};
+use icn_zk::{
+    prove, prepare_vk, setup, verify,
+    AgeOver18Circuit, AgeRepMembershipCircuit, BalanceRangeCircuit,
+    MembershipCircuit, MembershipProofCircuit, ReputationCircuit,
+    TimestampValidityCircuit,
+};
+
+fn bench_age_over_18(c: &mut Criterion) {
+    let circuit = AgeOver18Circuit { birth_year: 2000, current_year: 2020 };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    c.bench_function("prove_age_over_18", |b| {
+        b.iter(|| {
+            let mut r = StdRng::seed_from_u64(42);
+            prove(&pk, circuit.clone(), &mut r).unwrap();
+        });
+    });
+    let mut rng2 = StdRng::seed_from_u64(42);
+    let proof = prove(&pk, circuit.clone(), &mut rng2).unwrap();
+    let inputs = [Fr::from(2020u64)];
+    c.bench_function("verify_age_over_18", |b| {
+        b.iter(|| verify(&vk, &proof, &inputs).unwrap());
+    });
+}
+
+fn bench_membership(c: &mut Criterion) {
+    let circuit = MembershipCircuit { is_member: true };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    c.bench_function("prove_membership", |b| {
+        b.iter(|| {
+            let mut r = StdRng::seed_from_u64(42);
+            prove(&pk, circuit.clone(), &mut r).unwrap();
+        });
+    });
+    let mut rng2 = StdRng::seed_from_u64(42);
+    let proof = prove(&pk, circuit.clone(), &mut rng2).unwrap();
+    let inputs = [Fr::from(1u64)];
+    c.bench_function("verify_membership", |b| {
+        b.iter(|| verify(&vk, &proof, &inputs).unwrap());
+    });
+}
+
+fn bench_membership_proof(c: &mut Criterion) {
+    let circuit = MembershipProofCircuit { membership_flag: true, expected: true };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    c.bench_function("prove_membership_proof", |b| {
+        b.iter(|| {
+            let mut r = StdRng::seed_from_u64(42);
+            prove(&pk, circuit.clone(), &mut r).unwrap();
+        });
+    });
+    let mut rng2 = StdRng::seed_from_u64(42);
+    let proof = prove(&pk, circuit.clone(), &mut rng2).unwrap();
+    let inputs = [Fr::from(1u64)];
+    c.bench_function("verify_membership_proof", |b| {
+        b.iter(|| verify(&vk, &proof, &inputs).unwrap());
+    });
+}
+
+fn bench_reputation(c: &mut Criterion) {
+    let circuit = ReputationCircuit { reputation: 10, threshold: 5 };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    c.bench_function("prove_reputation", |b| {
+        b.iter(|| {
+            let mut r = StdRng::seed_from_u64(42);
+            prove(&pk, circuit.clone(), &mut r).unwrap();
+        });
+    });
+    let mut rng2 = StdRng::seed_from_u64(42);
+    let proof = prove(&pk, circuit.clone(), &mut rng2).unwrap();
+    let inputs = [Fr::from(10u64)];
+    c.bench_function("verify_reputation", |b| {
+        b.iter(|| verify(&vk, &proof, &inputs).unwrap());
+    });
+}
+
+fn bench_timestamp_validity(c: &mut Criterion) {
+    let circuit = TimestampValidityCircuit {
+        timestamp: 1_650_000_000,
+        not_before: 1_600_000_000,
+        not_after: 1_700_000_000,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    c.bench_function("prove_timestamp_validity", |b| {
+        b.iter(|| {
+            let mut r = StdRng::seed_from_u64(42);
+            prove(&pk, circuit.clone(), &mut r).unwrap();
+        });
+    });
+    let mut rng2 = StdRng::seed_from_u64(42);
+    let proof = prove(&pk, circuit.clone(), &mut rng2).unwrap();
+    let inputs = [Fr::from(1_600_000_000u64), Fr::from(1_700_000_000u64)];
+    c.bench_function("verify_timestamp_validity", |b| {
+        b.iter(|| verify(&vk, &proof, &inputs).unwrap());
+    });
+}
+
+fn bench_balance_range(c: &mut Criterion) {
+    let circuit = BalanceRangeCircuit { balance: 75, min: 50, max: 100 };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    c.bench_function("prove_balance_range", |b| {
+        b.iter(|| {
+            let mut r = StdRng::seed_from_u64(42);
+            prove(&pk, circuit.clone(), &mut r).unwrap();
+        });
+    });
+    let mut rng2 = StdRng::seed_from_u64(42);
+    let proof = prove(&pk, circuit.clone(), &mut rng2).unwrap();
+    let inputs = [Fr::from(50u64), Fr::from(100u64)];
+    c.bench_function("verify_balance_range", |b| {
+        b.iter(|| verify(&vk, &proof, &inputs).unwrap());
+    });
+}
+
+fn bench_age_rep_membership(c: &mut Criterion) {
+    let circuit = AgeRepMembershipCircuit {
+        birth_year: 2000,
+        current_year: 2020,
+        reputation: 10,
+        threshold: 5,
+        is_member: true,
+    };
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuit.clone(), &mut rng).unwrap();
+    let vk = prepare_vk(&pk);
+    c.bench_function("prove_age_rep_membership", |b| {
+        b.iter(|| {
+            let mut r = StdRng::seed_from_u64(42);
+            prove(&pk, circuit.clone(), &mut r).unwrap();
+        });
+    });
+    let mut rng2 = StdRng::seed_from_u64(42);
+    let proof = prove(&pk, circuit.clone(), &mut rng2).unwrap();
+    let inputs = [Fr::from(2020u64), Fr::from(10u64), Fr::from(1u64)];
+    c.bench_function("verify_age_rep_membership", |b| {
+        b.iter(|| verify(&vk, &proof, &inputs).unwrap());
+    });
+}
+
+criterion_group!(benches,
+    bench_age_over_18,
+    bench_membership,
+    bench_membership_proof,
+    bench_reputation,
+    bench_timestamp_validity,
+    bench_balance_range,
+    bench_age_rep_membership,
+);
+criterion_main!(benches);
+

--- a/justfile
+++ b/justfile
@@ -33,6 +33,10 @@ validate:
 bench:
     cargo bench --workspace --all-features
 
+# Run zero-knowledge circuit benchmarks
+bench-zk:
+    cargo bench -p icn-zk
+
 # Run federation health checks
 health-check:
     cargo test --test federation -- --exact test_federation_node_health --nocapture


### PR DESCRIPTION
## Summary
- benchmark proving and verifying ZK circuits via Criterion
- add criterion dev-dependency
- expose `just bench-zk` command to run the benches

## Testing
- `cargo test -p icn-zk`
- `cargo bench -p icn-zk --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68742dbd5730832483e1d74f2248d516