### PR TITLE
[identity] parameterize Groth16KeyManager

### DIFF
--- a/crates/icn-identity/src/credential.rs
+++ b/crates/icn-identity/src/credential.rs
@@ -273,7 +273,15 @@ mod tests {
         let mut claims = HashMap::new();
         claims.insert("birth_year".to_string(), "2000".to_string());
 
-        let km = Groth16KeyManager::new(&sk).unwrap();
+        let km = Groth16KeyManager::new(
+            &sk,
+            "age_over_18",
+            icn_zk::AgeOver18Circuit {
+                birth_year: 2000,
+                current_year: 2020,
+            },
+        )
+        .unwrap();
         let prover = Groth16Prover::new(
             km.clone(),
             std::sync::Arc::new(icn_reputation::InMemoryReputationStore::new()),

--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -355,7 +355,15 @@ impl Default for Groth16Prover {
         use crate::generate_ed25519_keypair;
 
         let (sk, _) = generate_ed25519_keypair();
-        let km = Groth16KeyManager::new(&sk).expect("key manager setup");
+        let km = Groth16KeyManager::new(
+            &sk,
+            "age_over_18",
+            icn_zk::AgeOver18Circuit {
+                birth_year: 2000,
+                current_year: 2020,
+            },
+        )
+        .expect("key manager setup");
         Self {
             km,
             reputation_store: std::sync::Arc::new(icn_reputation::InMemoryReputationStore::new()),
@@ -802,7 +810,15 @@ mod tests {
         let mut claims = HashMap::new();
         claims.insert("birth_year".to_string(), "2000".to_string());
 
-        let km = Groth16KeyManager::new(&sk).unwrap();
+        let km = Groth16KeyManager::new(
+            &sk,
+            "age_over_18",
+            icn_zk::AgeOver18Circuit {
+                birth_year: 2000,
+                current_year: 2020,
+            },
+        )
+        .unwrap();
         let verifier_vk = icn_zk::prepare_vk(km.proving_key());
         let issuer =
             CredentialIssuer::new(issuer_did, sk).with_prover(Box::new(Groth16Prover::new(
@@ -882,7 +898,15 @@ mod tests {
         use crate::generate_ed25519_keypair;
 
         let (sk, pk1) = generate_ed25519_keypair();
-        let km = Groth16KeyManager::new(&sk).unwrap();
+        let km = Groth16KeyManager::new(
+            &sk,
+            "age_over_18",
+            icn_zk::AgeOver18Circuit {
+                birth_year: 2000,
+                current_year: 2020,
+            },
+        )
+        .unwrap();
         assert!(km.verify_key_signature(&pk1).unwrap());
         // Verification with a different key should fail
         let (_, pk2) = generate_ed25519_keypair();

--- a/crates/icn-identity/tests/groth16.rs
+++ b/crates/icn-identity/tests/groth16.rs
@@ -145,7 +145,15 @@ fn prover_rejects_low_reputation() {
     let store = icn_reputation::InMemoryReputationStore::new();
     store.set_score(issuer_did.clone(), 0);
     let thresholds = icn_zk::ReputationThresholds::default();
-    let km = icn_identity::zk::Groth16KeyManager::new(&sk).unwrap();
+    let km = icn_identity::zk::Groth16KeyManager::new(
+        &sk,
+        "age_over_18",
+        icn_zk::AgeOver18Circuit {
+            birth_year: 2000,
+            current_year: 2020,
+        },
+    )
+    .unwrap();
     let prover =
         icn_identity::zk::Groth16Prover::new(km, std::sync::Arc::new(store), thresholds.clone());
 


### PR DESCRIPTION
## Summary
- allow Groth16KeyManager::new to take circuit name and circuit parameters
- sign verifying keys per circuit
- adjust credential prover tests and default prover

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build timeout)*
- `cargo test --all-features --workspace` *(failed: build timeout)*


------
https://chatgpt.com/codex/tasks/task_e_68742c334a388324bdd602cca3733fbb