### PR TITLE
[docs] update zk circuit storage docs

### DIFF
--- a/docs/dynamic_circuits.md
+++ b/docs/dynamic_circuits.md
@@ -43,3 +43,23 @@ The node stores the parameters and returns a content identifier (CID) for later 
 
 Parameters registered via the API are saved as [`CircuitParameters`](../crates/icn-zk/src/params.rs) within the registry database. Prepared verifying keys are cached in memory to speed up verification.
 
+## Database-Backed Registry
+
+Circuit metadata and parameter bytes now persist in an embedded database located
+under `~/.icn/zk/registry.sqlite`. Storing circuits in a database means they
+survive node restarts and can be synchronized across deployments. Each entry is
+keyed by the circuit slug and semantic version.
+
+### Backup and Restore
+
+Use `icn-cli` to export or re-import the circuit registry. This works with any
+database backend:
+
+```bash
+# Backup circuit registry
+icn-cli zk backup --path ./backups/circuits
+
+# Restore from a backup
+icn-cli zk restore --path ./backups/circuits
+```
+

--- a/docs/zk_disclosure.md
+++ b/docs/zk_disclosure.md
@@ -212,3 +212,21 @@ curl -X POST http://localhost:7845/dag/put \
 
 Nodes can enforce proof submission by creating the
 `InMemoryPolicyEnforcer` with `require_proof` set to `true`.
+
+## Proof Archival and Retrieval
+
+Every successful credential verification is archived in the node's identity
+database. Proof entries are keyed by CID so that auditors can reference them at
+a later date. Verifiers may list or fetch archived proofs through the HTTP API or
+via `icn-cli`:
+
+```bash
+# List archived proofs
+icn-cli identity list-proofs
+
+# Fetch a specific proof by CID
+icn-cli identity fetch-proof --cid <CID>
+```
+
+The same data can be accessed programmatically using
+`GET /identity/proofs` and `GET /identity/proofs/{cid}`.


### PR DESCRIPTION
## Summary
- document new database-backed circuit registry and CLI backup commands
- note proof archival & retrieval API for verifiers

## Testing
- `cargo fmt --all -- --check` *(fails: exit code 1)*
- `timeout 20s cargo test --all-features --workspace` *(terminated: timeout)*
- `timeout 20s cargo clippy --all-targets --all-features -- -D warnings` *(terminated: timeout)*
- `timeout 20s cargo test -p icn-ccl` *(terminated: timeout)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742c2e63308324a22c0279a0693626