### PR TITLE
Add batch zk proof generation

### DIFF
--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -470,7 +470,9 @@ impl ZkProver for Groth16Prover {
 pub struct Groth16Verifier {
     vk: ark_groth16::PreparedVerifyingKey<ark_bn254::Bn254>,
     public_inputs: Vec<ark_bn254::Fr>,
+    #[allow(dead_code)]
     reputation_store: std::sync::Arc<dyn icn_reputation::ReputationStore>,
+    #[allow(dead_code)]
     thresholds: icn_zk::ReputationThresholds,
 }
 

--- a/crates/icn-zk/src/tests.rs
+++ b/crates/icn-zk/src/tests.rs
@@ -144,6 +144,28 @@ fn batch_verify_multiple_proofs() {
 }
 
 #[test]
+fn prove_batch_multiple() {
+    let circuits = vec![
+        AgeOver18Circuit {
+            birth_year: 1990,
+            current_year: 2020,
+        },
+        AgeOver18Circuit {
+            birth_year: 1995,
+            current_year: 2020,
+        },
+    ];
+    let mut rng = StdRng::seed_from_u64(42);
+    let pk = setup(circuits[0].clone(), &mut rng).unwrap();
+    let proofs = prove_batch(&pk, &circuits).unwrap();
+    let vk = prepare_vk(&pk);
+    let inputs1 = [Fr::from(2020u64)];
+    let inputs2 = [Fr::from(2020u64)];
+    let batch = [(&proofs[0], &inputs1[..]), (&proofs[1], &inputs2[..])];
+    assert!(verify_batch(&vk, &batch).unwrap());
+}
+
+#[test]
 fn batch_verify_detects_invalid() {
     let circuit = AgeOver18Circuit {
         birth_year: 2000,


### PR DESCRIPTION
## Summary
- add `prove_batch` helper to generate proofs in parallel
- allow unused verifier fields in `icn-identity`
- test batch proof generation

## Testing
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68742e1b25508324bd0919a1bdbf9d8f