### PR TITLE
[tests] update federation lock usage

### DIFF
--- a/tests/integration/federation.rs
+++ b/tests/integration/federation.rs
@@ -18,7 +18,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(3);
 static DEVNET_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
 
 pub struct DevnetGuard {
-    _guard: tokio::sync::OwnedMutexGuard<()>,
+    _guard: tokio::sync::MutexGuard<'static, ()>,
 }
 
 impl Drop for DevnetGuard {
@@ -41,7 +41,7 @@ pub async fn ensure_devnet() -> Option<DevnetGuard> {
         return None;
     }
     let lock = DEVNET_LOCK.get_or_init(|| Mutex::new(()));
-    let guard = lock.lock_owned().await;
+    let guard = lock.lock().await;
 
     Command::new("bash")
         .arg("./icn-devnet/launch_federation.sh")


### PR DESCRIPTION
## Summary
- switch to `lock()` when holding federation test mutex
- adjust `DevnetGuard` to store `MutexGuard`

## Testing
- `cargo fmt -- tests/integration/federation.rs`
- `rustfmt --edition 2021 tests/integration/federation.rs`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: process interrupted)*
- `cargo test --all-features --workspace` *(failed: process interrupted)*
- `cargo test -p icn-ccl` *(failed: couldn't compile `icn-ccl`)*
- `just test-ccl-contracts` *(failed: recipe not found)*
- `just test-covm-execution` *(failed: recipe not found)*

------
https://chatgpt.com/codex/tasks/task_e_68742c3c3054832496254923ebad6a3d