### PR TITLE
Add proof store for credential proofs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/icn-governance",
     "crates/icn-economics",
     "crates/icn-eventstore",
+    "crates/icn-proofstore",
     "crates/icn-reputation",
     "crates/icn-network",
     "crates/icn-api",

--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = "1.0"
 once_cell = "1.21"
 lru = "0.16"
 icn-reputation = { path = "../icn-reputation" }
+icn-proofstore = { path = "../icn-proofstore" }
 
 # Ensure old ones are removed if they conflict or are replaced
 # ed25519-dalek = { version = "2.0", features = ["serde"] } # Old, replaced by specific version
@@ -50,3 +51,4 @@ curve25519-dalek = "4"
 merlin = "3"
 icn-zk = { path = "../icn-zk" }
 ark-std = "0.4"
+tempfile = "3"

--- a/crates/icn-identity/tests/credential_store.rs
+++ b/crates/icn-identity/tests/credential_store.rs
@@ -18,6 +18,7 @@ fn store_insert_get_revoke() {
             Some(Cid::new_v1_sha256(0x55, b"schema")),
             None,
             None,
+            None,
         )
         .unwrap();
     let cid = Cid::new_v1_sha256(0x55, b"cred");

--- a/crates/icn-proofstore/Cargo.toml
+++ b/crates/icn-proofstore/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "icn-proofstore"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+icn-common = { path = "../icn-common" }
+
+[dev-dependencies]
+tempfile = "3"
+

--- a/crates/icn-proofstore/src/lib.rs
+++ b/crates/icn-proofstore/src/lib.rs
@@ -1,0 +1,141 @@
+//! Storage traits for zero-knowledge credential proofs.
+#![forbid(unsafe_code)]
+
+use icn_common::{Cid, CommonError, ZkCredentialProof};
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// Trait for archiving and retrieving [`ZkCredentialProof`]s.
+pub trait ProofStore: Send + Sync {
+    /// Persist the supplied proof and return its content ID.
+    fn put(&self, proof: &ZkCredentialProof) -> Result<Cid, CommonError>;
+
+    /// Fetch a proof by its content ID.
+    fn get(&self, cid: &Cid) -> Result<Option<ZkCredentialProof>, CommonError>;
+
+    /// List all stored proofs.
+    fn list(&self) -> Result<Vec<ZkCredentialProof>, CommonError>;
+}
+
+impl std::fmt::Debug for dyn ProofStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ProofStore")
+    }
+}
+
+/// Simple file-based proof store using JSON Lines format.
+#[derive(Debug)]
+pub struct FileProofStore {
+    path: PathBuf,
+    lock: Mutex<()>,
+}
+
+impl FileProofStore {
+    /// Create a new store writing to the given path.
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            lock: Mutex::new(()),
+        }
+    }
+}
+
+impl ProofStore for FileProofStore {
+    fn put(&self, proof: &ZkCredentialProof) -> Result<Cid, CommonError> {
+        let json = serde_json::to_vec(proof)
+            .map_err(|e| CommonError::SerializationError(e.to_string()))?;
+        let cid = Cid::new_v1_sha256(0x55, &json);
+        let _g = self.lock.lock().unwrap();
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(|e| CommonError::IoError(e.to_string()))?;
+        let mut w = BufWriter::new(file);
+        w.write_all(&json)
+            .and_then(|_| w.write_all(b"\n"))
+            .map_err(|e| CommonError::IoError(e.to_string()))?;
+        w.flush()
+            .map_err(|e| CommonError::IoError(e.to_string()))?;
+        Ok(cid)
+    }
+
+    fn get(&self, cid: &Cid) -> Result<Option<ZkCredentialProof>, CommonError> {
+        if !self.path.exists() {
+            return Ok(None);
+        }
+        let _g = self.lock.lock().unwrap();
+        let file = OpenOptions::new()
+            .read(true)
+            .open(&self.path)
+            .map_err(|e| CommonError::IoError(e.to_string()))?;
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let line = line.map_err(|e| CommonError::IoError(e.to_string()))?;
+            let bytes = line.as_bytes();
+            let current_cid = Cid::new_v1_sha256(0x55, bytes);
+            if &current_cid == cid {
+                let proof: ZkCredentialProof = serde_json::from_slice(bytes)
+                    .map_err(|e| CommonError::DeserializationError(e.to_string()))?;
+                return Ok(Some(proof));
+            }
+        }
+        Ok(None)
+    }
+
+    fn list(&self) -> Result<Vec<ZkCredentialProof>, CommonError> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let _g = self.lock.lock().unwrap();
+        let file = OpenOptions::new()
+            .read(true)
+            .open(&self.path)
+            .map_err(|e| CommonError::IoError(e.to_string()))?;
+        let reader = BufReader::new(file);
+        let mut proofs = Vec::new();
+        for line in reader.lines() {
+            let line = line.map_err(|e| CommonError::IoError(e.to_string()))?;
+            let proof: ZkCredentialProof = serde_json::from_str(&line)
+                .map_err(|e| CommonError::DeserializationError(e.to_string()))?;
+            proofs.push(proof);
+        }
+        Ok(proofs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use icn_common::{Did, ZkProofType};
+    use tempfile::tempdir;
+
+    #[test]
+    fn file_round_trip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("proofs.jsonl");
+        let store = FileProofStore::new(path.clone());
+
+        let proof = ZkCredentialProof {
+            issuer: Did::new("key", "iss"),
+            holder: Did::new("key", "holder"),
+            claim_type: "age_over_18".into(),
+            proof: vec![1, 2, 3],
+            schema: Cid::new_v1_sha256(0x55, b"schema"),
+            vk_cid: None,
+            disclosed_fields: vec![],
+            challenge: None,
+            backend: ZkProofType::Groth16,
+            verification_key: None,
+            public_inputs: None,
+        };
+
+        let cid = store.put(&proof).unwrap();
+        let fetched = store.get(&cid).unwrap().expect("stored");
+        assert_eq!(fetched.issuer, proof.issuer);
+        let all = store.list().unwrap();
+        assert_eq!(all.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add `icn-proofstore` crate implementing a `ProofStore` trait and a JSONL-based `FileProofStore`
- allow Groth16 prover and verifier to accept an optional proof store
- archive proofs when generated and provide retrieval tests

## Testing
- `cargo test -p icn-proofstore`
- `cargo test -p icn-identity`

------
https://chatgpt.com/codex/tasks/task_e_68742c30121883249f62f7c15f6aafd3