### PR TITLE
Add proof verification caching

### DIFF
--- a/crates/icn-identity/Cargo.toml
+++ b/crates/icn-identity/Cargo.toml
@@ -34,6 +34,7 @@ directories-next = "2"
 serde_json = "1.0"
 once_cell = "1.21"
 lru = "0.16"
+sha2 = "0.10"
 icn-reputation = { path = "../icn-reputation" }
 
 # Ensure old ones are removed if they conflict or are replaced

--- a/crates/icn-identity/src/zk/proof_cache.rs
+++ b/crates/icn-identity/src/zk/proof_cache.rs
@@ -1,0 +1,56 @@
+use ark_bn254::Fr;
+use ark_serialize::CanonicalSerialize;
+use lru::LruCache;
+use once_cell::sync::Lazy;
+use sha2::{Digest, Sha256};
+use std::num::NonZeroUsize;
+use std::sync::Mutex;
+
+use super::ZkError;
+
+pub(crate) struct ProofCache;
+
+static CACHE: Lazy<Mutex<LruCache<[u8; 32], bool>>> =
+    Lazy::new(|| Mutex::new(LruCache::new(NonZeroUsize::new(128).unwrap())));
+
+impl ProofCache {
+    pub fn get_or_insert<F>(
+        proof: &[u8],
+        vk: &[u8],
+        inputs: &[Fr],
+        verify_fn: F,
+    ) -> Result<bool, ZkError>
+    where
+        F: FnOnce() -> Result<bool, ZkError>,
+    {
+        let mut hasher = Sha256::new();
+        hasher.update(proof);
+        hasher.update(vk);
+        for input in inputs {
+            let mut buf = Vec::new();
+            input
+                .serialize_compressed(&mut buf)
+                .map_err(|_| ZkError::InvalidProof)?;
+            hasher.update(&buf);
+        }
+        let key: [u8; 32] = hasher.finalize().into();
+
+        {
+            let mut cache = CACHE.lock().expect("cache mutex poisoned");
+            if let Some(v) = cache.get(&key) {
+                return Ok(*v);
+            }
+        }
+
+        let result = verify_fn()?;
+
+        let mut cache = CACHE.lock().expect("cache mutex poisoned");
+        cache.put(key, result);
+        Ok(result)
+    }
+
+    #[cfg(test)]
+    pub fn len() -> usize {
+        CACHE.lock().unwrap().len()
+    }
+}


### PR DESCRIPTION
## Summary
- add `proof_cache.rs` implementing an LRU cache for Groth16 results
- integrate proof cache into `Groth16Verifier::verify_proof`
- expose cache via new module and add sha2 dependency
- add unit test confirming repeated verification uses the cache

## Testing
- `cargo test -p icn-identity --lib proof_result_cache_hit -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68742e1bb0088324b85d35f3820ff0e7