### PR TITLE
Add zk analyze and profile CLI commands

### DIFF
--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -33,6 +33,8 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
     *   `icn-cli identity verify-proof <PROOF_JSON>`: Verify a proof and print whether it is valid.
 *   **Zero-Knowledge Operations:**
     *   `icn-cli zk generate-key`: Generate a Groth16 proving key and output the verifying key signature.
+    *   `icn-cli zk analyze <CIRCUIT>`: Count constraints for a circuit.
+    *   `icn-cli zk profile <CIRCUIT>`: Run Criterion benchmarks for a circuit.
 *   **Miscellaneous:**
     *   `icn-cli hello`: A simple command to check if the CLI is responsive.
     *   `icn-cli help` or `icn-cli --help`: Displays usage information.
@@ -55,6 +57,20 @@ cargo run -p icn-cli -- identity verify-proof '{"proof":"base64string","backend"
 # Generate a proving key and verifying key signature
 cargo run -p icn-cli -- zk generate-key
 # => '{"proving_key_path":"./groth16_proving_key.bin","verifying_key_signature_hex":"abc..."}'
+```
+
+### Example: Analyze a Circuit
+
+```bash
+cargo run -p icn-cli -- zk analyze age_over_18
+# => 'constraints: 3'
+```
+
+### Example: Profile a Circuit
+
+```bash
+cargo run -p icn-cli -- zk profile age_over_18
+# Runs `cargo bench` for the specified circuit
 ```
 
 ## Error Handling

--- a/crates/icn-zk/src/devtools.rs
+++ b/crates/icn-zk/src/devtools.rs
@@ -1,0 +1,11 @@
+use super::Fr;
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
+
+/// Count the number of constraints for the given circuit.
+pub fn count_constraints<C: ConstraintSynthesizer<Fr>>(
+    circuit: C,
+) -> Result<usize, SynthesisError> {
+    let cs = ConstraintSystem::<Fr>::new_ref();
+    circuit.generate_constraints(cs.clone())?;
+    Ok(cs.num_constraints())
+}

--- a/crates/icn-zk/src/lib.rs
+++ b/crates/icn-zk/src/lib.rs
@@ -8,11 +8,12 @@ use ark_std::rand::{CryptoRng, RngCore};
 use rayon::prelude::*;
 
 mod circuits;
+pub mod devtools;
 mod params;
 
 pub use circuits::{
-    AgeOver18Circuit, AgeRepMembershipCircuit, BalanceRangeCircuit, MembershipCircuit,
-    MembershipProofCircuit, ReputationCircuit, TimestampValidityCircuit, CircuitCost,
+    AgeOver18Circuit, AgeRepMembershipCircuit, BalanceRangeCircuit, CircuitCost, MembershipCircuit,
+    MembershipProofCircuit, ReputationCircuit, TimestampValidityCircuit,
 };
 pub use params::{CircuitParameters, CircuitParametersStorage, MemoryParametersStorage};
 


### PR DESCRIPTION
## Summary
- expose new `devtools::count_constraints` helper in `icn-zk`
- add `analyze` and `profile` subcommands under `zk` in `icn-cli`
- implement handlers that count constraints or run `cargo bench`
- document usage in CLI README

## Testing
- `cargo clippy -p icn-zk -- -D warnings`
- `cargo clippy -p icn-cli --no-deps -- -D warnings`
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68742dbed2e483248682a8ef735e2f0c