### PR TITLE
Update proving key storage type

### DIFF
--- a/crates/icn-zk/src/params.rs
+++ b/crates/icn-zk/src/params.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct CircuitParameters {
     /// Compressed Groth16 proving key bytes.
     #[serde(with = "serde_bytes")]
-    pub proving_key: Vec<u8>,
+    pub proving_key: Box<[u8]>,
 }
 
 impl CircuitParameters {
@@ -31,7 +31,9 @@ impl CircuitParameters {
     ) -> Result<Self, ark_serialize::SerializationError> {
         let mut bytes = Vec::new();
         pk.serialize_compressed(&mut bytes)?;
-        Ok(Self { proving_key: bytes })
+        Ok(Self {
+            proving_key: bytes.into_boxed_slice(),
+        })
     }
 }
 


### PR DESCRIPTION
## Summary
- use `Box<[u8]>` for `CircuitParameters.proving_key`
- convert Vec into boxed slice in `from_proving_key`

## Testing
- `cargo clippy -p icn-zk --all-targets --all-features -- -D warnings`
- `cargo test -p icn-zk`

------
https://chatgpt.com/codex/tasks/task_e_68742e1a75608324975586e5a8e320e9