### PR TITLE
Fix federation integration test compile

### DIFF
--- a/tests/integration/federation.rs
+++ b/tests/integration/federation.rs
@@ -18,7 +18,7 @@ const RETRY_DELAY: Duration = Duration::from_secs(3);
 static DEVNET_LOCK: OnceCell<Mutex<()>> = OnceCell::new();
 
 pub struct DevnetGuard {
-    _guard: tokio::sync::OwnedMutexGuard<()>,
+    _guard: tokio::sync::MutexGuard<'static, ()>,
 }
 
 impl Drop for DevnetGuard {
@@ -41,7 +41,7 @@ pub async fn ensure_devnet() -> Option<DevnetGuard> {
         return None;
     }
     let lock = DEVNET_LOCK.get_or_init(|| Mutex::new(()));
-    let guard = lock.lock_owned().await;
+    let guard = lock.lock().await;
 
     Command::new("bash")
         .arg("./icn-devnet/launch_federation.sh")
@@ -294,10 +294,10 @@ async fn test_federation_complete_workflow() {
     println!("🎯 Testing complete federation workflow...");
 
     // Run all tests in sequence to validate the complete workflow
-    test_federation_node_health().await;
-    test_federation_p2p_convergence().await;
-    test_federation_mesh_job_lifecycle().await;
-    test_federation_cross_node_api_consistency().await;
+    test_federation_node_health();
+    test_federation_p2p_convergence();
+    test_federation_mesh_job_lifecycle();
+    test_federation_cross_node_api_consistency();
 
     println!("🎉 Complete federation workflow test PASSED!");
 }
@@ -343,8 +343,10 @@ pub async fn wait_for_federation_ready() -> Result<(), Box<dyn std::error::Error
 
 #[tokio::test]
 async fn join_and_leave_federation_via_http() {
-    let (router, _ctx) =
-        icn_node::app_router_with_options(None, None, None, None, None, None, None).await;
+    let (router, _ctx) = icn_node::app_router_with_options(
+        None, None, None, None, None, None, None, None, None, None,
+    )
+    .await;
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {


### PR DESCRIPTION
## Summary
- update federation test to use `MutexGuard` and call `lock()`
- remove awaits when calling `#[tokio::test]` functions
- provide missing parameters to `app_router_with_options`

## Testing
- `cargo test --test federation --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68742e13cf30832493254d5132fd9efa