### PR TITLE
[identity] support storing multiple circuit keys

### DIFF
--- a/crates/icn-identity/src/credential.rs
+++ b/crates/icn-identity/src/credential.rs
@@ -273,14 +273,15 @@ mod tests {
         let mut claims = HashMap::new();
         claims.insert("birth_year".to_string(), "2000".to_string());
 
+        use crate::zk::Groth16KeySource;
         use icn_zk::AgeOver18Circuit;
 
         let km = Groth16KeyManager::new(
             "age_over_18",
-            AgeOver18Circuit {
+            Groth16KeySource::Circuit(AgeOver18Circuit {
                 birth_year: 0,
                 current_year: 0,
-            },
+            }),
             &sk,
         )
         .unwrap();

--- a/crates/icn-identity/src/zk/mod.rs
+++ b/crates/icn-identity/src/zk/mod.rs
@@ -354,15 +354,16 @@ impl Default for Groth16Prover {
     fn default() -> Self {
         use crate::generate_ed25519_keypair;
 
+        use super::Groth16KeySource;
         use icn_zk::AgeOver18Circuit;
 
         let (sk, _) = generate_ed25519_keypair();
         let km = Groth16KeyManager::new(
             "age_over_18",
-            AgeOver18Circuit {
+            Groth16KeySource::Circuit(AgeOver18Circuit {
                 birth_year: 0,
                 current_year: 0,
-            },
+            }),
             &sk,
         )
         .expect("key manager setup");
@@ -817,10 +818,10 @@ mod tests {
 
         let km = Groth16KeyManager::new(
             "age_over_18",
-            AgeOver18Circuit {
+            Groth16KeySource::Circuit(AgeOver18Circuit {
                 birth_year: 0,
                 current_year: 0,
-            },
+            }),
             &sk,
         )
         .unwrap();
@@ -907,10 +908,10 @@ mod tests {
         let (sk, pk1) = generate_ed25519_keypair();
         let km = Groth16KeyManager::new(
             "age_over_18",
-            AgeOver18Circuit {
+            Groth16KeySource::Circuit(AgeOver18Circuit {
                 birth_year: 0,
                 current_year: 0,
-            },
+            }),
             &sk,
         )
         .unwrap();

--- a/crates/icn-identity/tests/groth16.rs
+++ b/crates/icn-identity/tests/groth16.rs
@@ -147,10 +147,10 @@ fn prover_rejects_low_reputation() {
     let thresholds = icn_zk::ReputationThresholds::default();
     let km = icn_identity::zk::Groth16KeyManager::new(
         "age_over_18",
-        icn_zk::AgeOver18Circuit {
+        icn_identity::zk::Groth16KeySource::Circuit(icn_zk::AgeOver18Circuit {
             birth_year: 0,
             current_year: 0,
-        },
+        }),
         &sk,
     )
     .unwrap();


### PR DESCRIPTION
## Summary
- let Groth16KeyManager accept either a circuit or existing parameters
- sign verifying keys for each circuit
- update call sites and tests for Groth16KeySource

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: compilation timed out)*
- `cargo test --all-features --workspace` *(failed: compilation timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687430dd2a7083248c62d78034a5c8f3