### PR TITLE
Add chaos testing script, docs, and automation

### DIFF
--- a/deployment/ansible/playbook.yml
+++ b/deployment/ansible/playbook.yml
@@ -1,0 +1,20 @@
+- hosts: icn_nodes
+  become: yes
+  tasks:
+    - name: Ensure Docker is installed
+      package:
+        name: docker.io
+        state: present
+
+    - name: Start ICN node containers
+      docker_container:
+        name: "{{ item.name }}"
+        image: intercooperative/icn-node:latest
+        state: started
+        restart_policy: always
+        published_ports:
+          - "{{ item.port }}:7845"
+      loop:
+        - { name: "icn-node-a", port: 5001 }
+        - { name: "icn-node-b", port: 5002 }
+        - { name: "icn-node-c", port: 5003 }

--- a/deployment/terraform/main.tf
+++ b/deployment/terraform/main.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.0.0"
+}
+
+variable "node_count" {
+  type    = number
+  default = 3
+}
+
+provider "docker" {}
+
+resource "docker_network" "icn" {
+  name = "icn-federation"
+}
+
+resource "docker_image" "icn" {
+  name         = "intercooperative/icn-node:latest"
+  keep_locally = true
+}
+
+resource "docker_container" "icn_node" {
+  count  = var.node_count
+  name   = "icn-node-${count.index}"
+  image  = docker_image.icn.name
+  networks_advanced {
+    name = docker_network.icn.name
+  }
+  ports {
+    internal = 7845
+    external = 5001 + count.index
+  }
+  restart = "always"
+  command = ["icn-node", "--bootstrap-peers", ""]
+}

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -230,3 +230,25 @@ For more advanced composition patterns, see
 [`config_builder.rs`](../crates/icn-runtime/examples/config_builder.rs).
 
 
+
+## Automated Federation Deployment
+
+For repeatable production deployments, example Terraform and Ansible configurations are provided in the `deployment/` directory.
+
+### Terraform
+
+```
+cd deployment/terraform
+terraform init
+terraform apply -auto-approve
+```
+
+This will launch a Docker-based federation defined in `main.tf`.
+
+### Ansible
+
+```
+ansible-playbook -i hosts deployment/ansible/playbook.yml
+```
+
+The playbook installs Docker and starts three ICN nodes using the latest container image.

--- a/docs/runbooks/federation_recovery.md
+++ b/docs/runbooks/federation_recovery.md
@@ -1,0 +1,28 @@
+# Federation Recovery Runbook
+
+This runbook describes procedures for recovering an ICN federation from common failures.
+
+## Network Partition
+
+1. Detect unreachable nodes using `icn-cli status`.
+2. Restore connectivity or restart affected containers.
+3. Verify recovery with `just health-check`.
+
+## Node Crash
+
+1. Restart the crashed node container:
+   ```bash
+   docker-compose -f icn-devnet/docker-compose.yml up -d <node-name>
+   ```
+2. Wait for the node to rejoin the federation using `just health-check`.
+
+## Chaos Testing
+
+Use `scripts/chaos_test.sh` to simulate failures during testing:
+
+```bash
+./scripts/chaos_test.sh --scenario network_partition --duration 5
+./scripts/chaos_test.sh --scenario node_crash --duration 10
+```
+
+After running the script, ensure all nodes are healthy and that job submission works across the federation.

--- a/scripts/chaos_test.sh
+++ b/scripts/chaos_test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Basic chaos testing script for ICN devnet
-# Usage: chaos_test.sh --scenario <network_partition|node_failure> [--duration SECONDS] [--failure-rate PERCENT]
+# Usage: chaos_test.sh --scenario <network_partition|node_failure|node_crash> \
+#                        [--duration SECONDS] [--failure-rate SECONDS]
 set -euo pipefail
 
 SCENARIO=""
@@ -51,6 +52,18 @@ case "$SCENARIO" in
             node=${NODES[$RANDOM % ${#NODES[@]}]}
             echo "Restarting $node"
             docker-compose -f "$COMPOSE_FILE" restart "$node"
+            sleep $((FAILURE_RATE))
+        done
+        ;;
+    node_crash)
+        echo "Simulating node crashes for ${DURATION}s"
+        end=$((SECONDS + DURATION))
+        while [[ $SECONDS -lt $end ]]; do
+            node=${NODES[$RANDOM % ${#NODES[@]}]}
+            echo "Killing $node"
+            docker-compose -f "$COMPOSE_FILE" kill "$node"
+            sleep 1
+            docker-compose -f "$COMPOSE_FILE" up -d "$node"
             sleep $((FAILURE_RATE))
         done
         ;;

--- a/tests/integration/chaos_recovery.rs
+++ b/tests/integration/chaos_recovery.rs
@@ -1,0 +1,71 @@
+#[path = "federation.rs"]
+mod federation;
+
+use federation::{ensure_devnet, wait_for_federation_ready, NODE_A_URL, NODE_B_URL};
+use reqwest::Client;
+use serde_json::Value;
+use std::process::Command;
+use tokio::time::{sleep, Duration};
+
+const RETRY_DELAY: Duration = Duration::from_secs(3);
+const MAX_RETRIES: u32 = 20;
+
+#[tokio::test]
+async fn test_chaos_recovery() {
+    let _devnet = ensure_devnet().await;
+
+    Command::new("bash")
+        .args([
+            "./scripts/chaos_test.sh",
+            "--scenario",
+            "network_partition",
+            "--duration",
+            "5",
+        ])
+        .status()
+        .expect("failed to run chaos test");
+
+    wait_for_federation_ready()
+        .await
+        .expect("federation not ready after chaos");
+
+    let client = Client::new();
+    let job_request = serde_json::json!({
+        "manifest_cid": "cidv1-chaos-test-manifest",
+        "spec_json": { "Echo": { "payload": "Chaos test" } },
+        "cost_mana": 25
+    });
+
+    let submit_res: Value = client
+        .post(&format!("{}/mesh/submit", NODE_A_URL))
+        .header("Content-Type", "application/json")
+        .json(&job_request)
+        .send()
+        .await
+        .expect("submit job")
+        .json()
+        .await
+        .expect("submit json");
+
+    let job_id = submit_res["job_id"].as_str().expect("job_id").to_string();
+
+    let mut completed = false;
+    for _ in 0..MAX_RETRIES {
+        if let Ok(resp) = client
+            .get(&format!("{}/mesh/jobs/{}", NODE_B_URL, job_id))
+            .send()
+            .await
+        {
+            if resp.status().is_success() {
+                let status: Value = resp.json().await.expect("status json");
+                if status["status"]["status"] == "completed" {
+                    completed = true;
+                    break;
+                }
+            }
+        }
+        sleep(RETRY_DELAY).await;
+    }
+
+    assert!(completed, "job did not complete after chaos test");
+}


### PR DESCRIPTION
## Summary
- extend `scripts/chaos_test.sh` with `node_crash` scenario
- add integration test covering chaos recovery
- provide Terraform and Ansible examples in `deployment/`
- document federation recovery runbook
- finalize deployment guide with automation section

## Testing
- `just test` *(failed: build took too long and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68748eaff9388324baafa11663fb6405