### PR TITLE
[monitoring] add example dashboards and alerts

### DIFF
--- a/docker-compose-monitoring.yml
+++ b/docker-compose-monitoring.yml
@@ -14,6 +14,7 @@ services:
       - "3000:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
     volumes:
       - ./monitoring/dashboards:/var/lib/grafana/dashboards
       - ./monitoring/provisioning:/etc/grafana/provisioning

--- a/monitoring/dashboards/icn_metrics.json
+++ b/monitoring/dashboards/icn_metrics.json
@@ -1,0 +1,36 @@
+{
+  "uid": "icn-metrics",
+  "title": "ICN Metrics",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Job Throughput",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "rate(jobs_processed_total[5m])"}],
+      "gridPos": {"h":6,"w":12,"x":0,"y":0}
+    },
+    {
+      "type": "stat",
+      "title": "Network Peers",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "network_peer_count"}],
+      "gridPos": {"h":4,"w":6,"x":0,"y":6}
+    },
+    {
+      "type": "timeseries",
+      "title": "Mana Balances",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "mana_balance"}],
+      "gridPos": {"h":6,"w":12,"x":0,"y":10}
+    },
+    {
+      "type": "timeseries",
+      "title": "Proposal Activity",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "governance_submit_proposal_calls"}],
+      "gridPos": {"h":6,"w":12,"x":0,"y":16}
+    }
+  ]
+}

--- a/monitoring/rules/alert.rules.yml
+++ b/monitoring/rules/alert.rules.yml
@@ -9,3 +9,27 @@ groups:
         annotations:
           summary: "ICN node down"
           description: "The node {{ $labels.instance }} is not responding."
+      - alert: JobFailures
+        expr: increase(mesh_job_failures_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Mesh job failures"
+          description: "Jobs have failed within the last 5 minutes."
+      - alert: LowPeerCount
+        expr: network_peer_count < 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Low peer count"
+          description: "Peer count below 3 for more than 5 minutes."
+      - alert: LowManaBalance
+        expr: mana_balance < 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Low mana balance"
+          description: "Mana balance dropped below 10."


### PR DESCRIPTION
## Summary
- add an ICN Metrics Grafana dashboard with job, peer, mana and proposal graphs
- expand Prometheus alert rules for job failures, low peers and mana balance
- load Grafana dashboards via provisioning in docker-compose

## Testing
- `cargo fmt --all -- --check` *(fails: some files would be reformatted)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to complete)*
- `cargo test --all-features --workspace` *(failed to complete)*
- `just test-ccl-contracts` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68748eab66dc8324be975b1d1e89e529