### PR TITLE
[scripts] add federation deployment and load test

### DIFF
--- a/docs/large_scale_testing.md
+++ b/docs/large_scale_testing.md
@@ -1,0 +1,54 @@
+# Large Federation Scale Testing
+
+This guide explains how to deploy a multi‑node federation and run load testing
+against it. These scripts build on the devnet tooling found in this repository
+and are intended for local experimentation.
+
+## Deploying a Large Federation
+
+Use the `deploy_large_federation.sh` script to spin up a federation with ten or
+more nodes. Monitoring (Prometheus/Grafana) and a shared Postgres instance can be
+enabled via flags.
+
+```bash
+# Start a 12 node federation with monitoring and persistence
+scripts/deploy_large_federation.sh \
+  --nodes 12 \
+  --network-mode distributed \
+  --monitoring-enabled \
+  --persistence-enabled
+```
+
+The script relies on Docker Compose definitions under `icn-devnet/`. Once the
+containers are running, each node exposes its HTTP API on ports `5001` through
+`5010` (and higher for additional nodes).
+
+## Running a Load Test
+
+After the federation is online, run the load test utility to generate concurrent
+mesh jobs across the cluster:
+
+```bash
+scripts/load_test.sh \
+  --concurrent-jobs 100 \
+  --duration 30m \
+  --job-types mixed \
+  --metrics-output ./load_test_results.json
+```
+
+The script submits random job types (`echo`, `compute`, `transform`) to random
+nodes until the duration expires. A small JSON summary is written to the file
+specified by `--metrics-output`.
+
+## Interpreting Results
+
+1. **Prometheus/Grafana** – If monitoring was enabled, open Grafana at
+   `http://localhost:3000` to view dashboards for job throughput, peer counts and
+   resource usage. Prometheus metrics are available on `http://localhost:9090`.
+2. **JSON Metrics** – The output file reports the number of jobs started. Combine
+   this with Grafana dashboards to evaluate success rates and latency.
+3. **Logs** – Container logs for each node provide detailed error information and
+   can help diagnose networking or persistence issues.
+
+Successful scale tests should show all nodes remaining healthy, jobs completing
+across the federation and peer counts recovering after any induced partitions.

--- a/scripts/deploy_large_federation.sh
+++ b/scripts/deploy_large_federation.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Deploy a large ICN federation using docker-compose
+# Options:
+#   --nodes N              Number of nodes to start (default 10)
+#   --network-mode MODE    Unused placeholder for future distributed/local modes
+#   --monitoring-enabled   Start Prometheus and Grafana services
+#   --persistence-enabled  Start the shared Postgres service
+set -euo pipefail
+
+NODES=10
+NETWORK_MODE="distributed"
+MONITORING=0
+PERSISTENCE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --nodes)
+            NODES="$2"
+            shift 2
+            ;;
+        --network-mode)
+            NETWORK_MODE="$2"
+            shift 2
+            ;;
+        --monitoring-enabled)
+            MONITORING=1
+            shift
+            ;;
+        --persistence-enabled)
+            PERSISTENCE=1
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+SERVICES=()
+LETTERS=(a b c d e f g h i j k l m n o p)
+for i in $(seq 1 "$NODES"); do
+    idx=$((i-1))
+    letter=${LETTERS[$idx]}
+    SERVICES+=("icn-node-${letter}")
+done
+
+if [[ "$MONITORING" -eq 1 ]]; then
+    SERVICES+=(prometheus grafana)
+fi
+if [[ "$PERSISTENCE" -eq 1 ]]; then
+    SERVICES+=(postgres)
+fi
+
+COMPOSE_FILE="$(dirname "$0")/../icn-devnet/docker-compose.yml"
+DOCKER_COMPOSE="docker-compose"
+if docker compose version &>/dev/null; then
+    DOCKER_COMPOSE="docker compose"
+fi
+
+$DOCKER_COMPOSE -f "$COMPOSE_FILE" up -d "${SERVICES[@]}"
+
+echo "Federation started with $NODES nodes (mode: $NETWORK_MODE)"

--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Simple ICN federation load test utility
+# Options:
+#   --concurrent-jobs N   Number of jobs to submit in parallel
+#   --duration D          Test duration (e.g. 30m, 60s)
+#   --job-types LIST      Comma separated job types (echo,compute,transform or mixed)
+#   --metrics-output FILE Path to write JSON summary
+set -euo pipefail
+
+CONCURRENT=20
+DURATION="5m"
+JOB_TYPES="mixed"
+METRICS_OUT="load_test_results.json"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --concurrent-jobs)
+            CONCURRENT="$2"
+            shift 2
+            ;;
+        --duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        --job-types)
+            JOB_TYPES="$2"
+            shift 2
+            ;;
+        --metrics-output)
+            METRICS_OUT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+parse_duration() {
+    case "$1" in
+        *s) echo "${1%s}" ;;
+        *m) echo $(( ${1%m} * 60 )) ;;
+        *h) echo $(( ${1%h} * 3600 )) ;;
+        *) echo "$1" ;;
+    esac
+}
+
+DURATION_SEC=$(parse_duration "$DURATION")
+
+NODES=(5001 5002 5003 5004 5005 5006 5007 5008 5009 5010)
+API_KEYS=(devnet-a-key devnet-b-key devnet-c-key devnet-d-key devnet-e-key devnet-f-key devnet-g-key devnet-h-key devnet-i-key devnet-j-key)
+JOB_TYPES_ARR=(echo compute transform)
+if [[ "$JOB_TYPES" != "mixed" ]]; then
+    IFS=',' read -ra JOB_TYPES_ARR <<< "$JOB_TYPES"
+fi
+
+JOB_ECHO='{ "manifest_cid": "cidv1-echo", "spec_json": { "kind": { "Echo": { "payload": "load" } } }, "cost_mana": 1 }'
+JOB_COMPUTE='{ "manifest_cid": "cidv1-compute", "spec_json": { "kind": { "Compute": { "program": "fibonacci", "args": ["5"] } } }, "cost_mana": 2 }'
+JOB_TRANSFORM='{ "manifest_cid": "cidv1-transform", "spec_json": { "kind": { "Transform": { "input_format": "json", "output_format": "json" } }, "inputs": [], "outputs": [] }, "cost_mana": 2 }'
+
+submit_job() {
+    local node=$1
+    local key=$2
+    local spec=$3
+    curl -s -X POST "http://localhost:${node}/mesh/submit" \
+        -H 'Content-Type: application/json' \
+        -H "x-api-key: ${key}" \
+        -d "$spec" >/dev/null
+}
+
+start_time=$(date +%s)
+end_time=$((start_time + DURATION_SEC))
+started=0
+
+while (( $(date +%s) < end_time )); do
+    for ((i=0;i<CONCURRENT;i++)); do
+        idx=$((RANDOM % ${#NODES[@]}))
+        key=${API_KEYS[$idx]}
+        node=${NODES[$idx]}
+        case "${JOB_TYPES_ARR[$((RANDOM % ${#JOB_TYPES_ARR[@]}))]}" in
+            echo) spec="$JOB_ECHO";;
+            compute) spec="$JOB_COMPUTE";;
+            transform) spec="$JOB_TRANSFORM";;
+        esac
+        submit_job "$node" "$key" "$spec" &
+        ((started++))
+    done
+    wait
+done
+
+cat > "$METRICS_OUT" <<JSON
+{ "jobs_started": $started }
+JSON
+
+echo "Load test complete: $started jobs started"

--- a/tests/integration/network_partition_recovery.rs
+++ b/tests/integration/network_partition_recovery.rs
@@ -1,0 +1,88 @@
+#[path = "ten_node_scale.rs"]
+mod ten;
+use ten::{ensure_10node_devnet, wait_for_10node_ready};
+
+use reqwest::Client;
+use serde_json::Value;
+use std::process::Command;
+use tokio::time::{sleep, Duration};
+
+const RETRY_DELAY: Duration = Duration::from_secs(3);
+const MAX_RETRIES: u32 = 20;
+
+#[tokio::test]
+async fn test_network_partition_recovery() {
+    let _devnet = ensure_10node_devnet().await;
+
+    Command::new("docker-compose")
+        .args(["-f", "icn-devnet/docker-compose.yml", "pause", "icn-node-c"])
+        .status()
+        .expect("pause c");
+    Command::new("docker-compose")
+        .args(["-f", "icn-devnet/docker-compose.yml", "pause", "icn-node-d"])
+        .status()
+        .expect("pause d");
+
+    let client = Client::new();
+    let job: Value = client
+        .post("http://localhost:5001/mesh/submit")
+        .json(&serde_json::json!({
+            "manifest_cid": "cidv1-partition-test", 
+            "spec_json": {"Echo": {"payload": "partition"}},
+            "cost_mana": 10
+        }))
+        .send()
+        .await
+        .expect("submit")
+        .json()
+        .await
+        .expect("json");
+    let job_id = job["job_id"].as_str().unwrap().to_string();
+
+    Command::new("docker-compose")
+        .args(["-f", "icn-devnet/docker-compose.yml", "unpause", "icn-node-c"])
+        .status()
+        .expect("unpause c");
+    Command::new("docker-compose")
+        .args(["-f", "icn-devnet/docker-compose.yml", "unpause", "icn-node-d"])
+        .status()
+        .expect("unpause d");
+
+    wait_for_10node_ready().await.expect("devnet ready");
+
+    for _ in 0..MAX_RETRIES {
+        let resp = client
+            .get(&format!("http://localhost:5001/mesh/jobs/{}", job_id))
+            .send()
+            .await
+            .expect("status");
+        if resp.status().is_success() {
+            let v: Value = resp.json().await.expect("json");
+            if v["status"]["status"] == "completed" {
+                break;
+            }
+        }
+        sleep(RETRY_DELAY).await;
+    }
+
+    for port in [5003u16, 5004u16] {
+        let mut synced = false;
+        for _ in 0..MAX_RETRIES {
+            if let Ok(resp) = client
+                .get(&format!("http://localhost:{}/mesh/jobs/{}", port, job_id))
+                .send()
+                .await
+            {
+                if resp.status().is_success() {
+                    let v: Value = resp.json().await.expect("json");
+                    if v["status"]["status"] == "completed" {
+                        synced = true;
+                        break;
+                    }
+                }
+            }
+            sleep(RETRY_DELAY).await;
+        }
+        assert!(synced, "node {} did not sync receipt", port);
+    }
+}


### PR DESCRIPTION
## Summary
- add helper script to deploy multi-node federation
- add basic load testing script
- document running large scale tests
- add network partition recovery test

## Testing
- `cargo fmt --all -- --check` *(fails: diffs shown)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails to compile icn-network)*
- `cargo test --all-features --workspace` *(fails to compile icn-network)*
- `cargo test -p icn-ccl` *(fails: dependency build error)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68748ead54248324aa2255fa02ad8a29