### PR TITLE
[runtime] add execution metrics

### DIFF
--- a/crates/icn-runtime/Cargo.toml
+++ b/crates/icn-runtime/Cargo.toml
@@ -38,6 +38,7 @@ clap = { version = "4.0", features = ["derive"], optional = true }
 icn-ccl = { path = "../../icn-ccl" }
 sha2 = "0.10"
 anyhow = "1.0"
+procfs = "0.17"
 dashmap = "5"
 aes-gcm = "0.10"
 pbkdf2 = "0.12"

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -206,6 +206,7 @@ impl RuntimeContext {
 
     /// Create a new context with stubs for testing.
     pub fn new_with_stubs(current_identity_str: &str) -> Result<Arc<Self>, CommonError> {
+        crate::execution_monitor::init_logger();
         let current_identity = Did::from_str(current_identity_str)
             .map_err(|e| CommonError::InternalError(format!("Invalid DID: {}", e)))?;
 
@@ -408,6 +409,7 @@ impl RuntimeContext {
     /// Create a new RuntimeContext from a service configuration.
     /// This is the preferred method as it ensures type-safe service mapping.
     pub fn from_service_config(config: ServiceConfig) -> Result<Arc<Self>, CommonError> {
+        crate::execution_monitor::init_logger();
         // Validate the configuration before using it
         config.validate()?;
 
@@ -2728,6 +2730,7 @@ impl RuntimeContext {
         job: &ActualMeshJob,
         _agreed_cost: u64, // Marked as unused for now
     ) -> Result<icn_identity::ExecutionReceipt, HostAbiError> {
+        crate::execution_monitor::clear_logs();
         let job_id = &job.id;
         let executor_did = ctx.current_identity.clone();
 

--- a/crates/icn-runtime/src/execution_monitor.rs
+++ b/crates/icn-runtime/src/execution_monitor.rs
@@ -1,0 +1,75 @@
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use log::{LevelFilter, Metadata, Record};
+
+/// Simple logger that stores log lines in memory for later retrieval.
+pub struct ExecutionLogger {
+    logs: Mutex<Vec<String>>,
+}
+
+impl ExecutionLogger {
+    const fn new() -> Self {
+        Self { logs: Mutex::new(Vec::new()) }
+    }
+
+    fn take(&self) -> String {
+        let mut logs = self.logs.lock().unwrap();
+        let out = logs.join("\n");
+        logs.clear();
+        out
+    }
+
+    fn clear(&self) {
+        self.logs.lock().unwrap().clear();
+    }
+}
+
+impl log::Log for ExecutionLogger {
+    fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record<'_>) {
+        let mut logs = self.logs.lock().unwrap();
+        logs.push(format!("{} - {}", record.level(), record.args()));
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: Lazy<ExecutionLogger> = Lazy::new(|| ExecutionLogger::new());
+
+/// Initialize the global execution logger if not already set.
+pub fn init_logger() {
+    let _ = log::set_logger(&*LOGGER).map(|()| log::set_max_level(LevelFilter::Info));
+}
+
+/// Clear any stored logs.
+pub fn clear_logs() {
+    LOGGER.clear();
+}
+
+/// Retrieve and clear logs collected since the last call.
+pub fn take_logs() -> String {
+    LOGGER.take()
+}
+
+/// Returns the process high water mark (peak RSS) in megabytes on Linux.
+#[cfg(target_os = "linux")]
+pub fn current_peak_memory_mb() -> u32 {
+    use procfs::process::Process;
+    if let Ok(proc) = Process::myself() {
+        if let Ok(status) = proc.status() {
+            if let Some(kb) = status.vmhwm {
+                return (kb / 1024) as u32;
+            }
+        }
+    }
+    0
+}
+
+/// Fallback for non-Linux targets.
+#[cfg(not(target_os = "linux"))]
+pub fn current_peak_memory_mb() -> u32 {
+    0
+}

--- a/crates/icn-runtime/tests/mesh.rs
+++ b/crates/icn-runtime/tests/mesh.rs
@@ -17,8 +17,8 @@ use icn_network::libp2p_service::NetworkConfig;
 use icn_network::NetworkService;
 use icn_runtime::context::{
     DefaultMeshNetworkService, HostAbiError, JobAssignmentNotice, LocalMeshSubmitReceiptMessage,
-    MeshNetworkService, RuntimeContext, StubDagStore, StubMeshNetworkService, StubSigner,
-    MeshNetworkServiceType,
+    MeshNetworkService, MeshNetworkServiceType, RuntimeContext, StubDagStore,
+    StubMeshNetworkService, StubSigner,
 };
 use icn_runtime::{host_get_pending_mesh_jobs, host_submit_mesh_job};
 #[cfg(feature = "enable-libp2p")]
@@ -298,7 +298,9 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     let receipt_msg = LocalMeshSubmitReceiptMessage {
         receipt: signed_receipt.clone(),
     };
-    job_manager_network_stub.stage_receipt(submitted_job_id.clone(), receipt_msg).await;
+    job_manager_network_stub
+        .stage_receipt(submitted_job_id.clone(), receipt_msg)
+        .await;
 
     // Test receipt retrieval
     let retrieved_receipt = job_manager_network_stub
@@ -338,7 +340,10 @@ async fn test_mesh_job_full_lifecycle_happy_path() {
     };
     {
         let mut store = dag_store.lock().await;
-        store.put(&block).await.expect("Failed to store receipt in DAG");
+        store
+            .put(&block)
+            .await
+            .expect("Failed to store receipt in DAG");
     }
     let stored_cid = block.cid.clone();
 
@@ -456,7 +461,9 @@ async fn test_invalid_receipt_wrong_executor() {
     let correct_executor_did = Did::from_str(correct_executor_did_str).unwrap();
     ctx_submitter.job_states.insert(
         submitted_job_id.clone(),
-        JobState::Assigned { executor: correct_executor_did.clone() }
+        JobState::Assigned {
+            executor: correct_executor_did.clone(),
+        },
     );
 
     // 2. Test receipt verification directly by creating a forged receipt
@@ -563,10 +570,13 @@ fn new_mesh_test_context_with_two_executors() -> (
     Arc<RuntimeContext>,
     Arc<TokioMutex<dyn AsyncStorageService<DagBlock> + Send>>,
 ) {
-    let submitter_ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:submitter_multi_exec", 200).unwrap();
-    let executor1_ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:executor1_multi_exec", 100).unwrap();
-    let executor2_ctx = RuntimeContext::new_with_stubs_and_mana("did:icn:test:executor2_multi_exec", 100).unwrap();
-    
+    let submitter_ctx =
+        RuntimeContext::new_with_stubs_and_mana("did:icn:test:submitter_multi_exec", 200).unwrap();
+    let executor1_ctx =
+        RuntimeContext::new_with_stubs_and_mana("did:icn:test:executor1_multi_exec", 100).unwrap();
+    let executor2_ctx =
+        RuntimeContext::new_with_stubs_and_mana("did:icn:test:executor2_multi_exec", 100).unwrap();
+
     // Return the shared dag store from one of the contexts
     let dag_store = submitter_ctx.dag_store.clone();
 
@@ -720,7 +730,10 @@ async fn test_submit_mesh_job_with_custom_timeout() {
     let job_status = ctx.get_job_status(&job_id).await.unwrap();
     if let Some(lifecycle) = job_status {
         // Check that the timeout was preserved in the job data
-        println!("Job stored with timeout field preserved: {:?}", lifecycle.job);
+        println!(
+            "Job stored with timeout field preserved: {:?}",
+            lifecycle.job
+        );
         assert_eq!(lifecycle.job.submitter_did, submitter_did);
         // The test is really checking that the job was processed correctly
     } else {
@@ -924,14 +937,15 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
     let receipt = executor.execute_job(&test_job).await?;
     assert!(receipt.verify_against_key(&pk).is_ok());
 
+    let logs = icn_runtime::execution_monitor::take_logs();
     let receipt_msg = ProtocolMessage::new(
         MessagePayload::MeshReceiptSubmission(MeshReceiptSubmissionMessage {
             receipt: receipt.clone(),
             execution_metadata: ExecutionMetadata {
-                wall_time_ms: 0,
-                peak_memory_mb: 0,
+                wall_time_ms: receipt.cpu_ms,
+                peak_memory_mb: icn_runtime::execution_monitor::current_peak_memory_mb(),
                 exit_code: 0,
-                execution_logs: None,
+                execution_logs: Some(logs),
             },
         }),
         executor_did.clone(),
@@ -951,6 +965,9 @@ async fn test_full_mesh_job_cycle_libp2p() -> Result<(), anyhow::Error> {
         }
     })
     .await?;
+
+    assert!(final_receipt.execution_metadata.peak_memory_mb > 0);
+    assert!(final_receipt.execution_metadata.execution_logs.is_some());
 
     let rep_before = node_a.reputation_store.get_reputation(&executor_did);
     let receipt_json = serde_json::to_string(&final_receipt)?;


### PR DESCRIPTION
## Summary
- log runtime execution details with new `execution_monitor`
- capture peak memory and execution logs when submitting receipts
- validate new metadata fields in mesh tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: build hang)*
- `cargo test --all-features --workspace` *(failed: build hang)*

------
https://chatgpt.com/codex/tasks/task_e_68748ea495608324a72f6834ac71001a