### PR TITLE
Implement DAG status updates

### DIFF
--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -631,6 +631,17 @@ pub struct JobReceipt {
     pub signature: SignatureBytes,
 }
 
+/// Records a job lifecycle status change in the DAG.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobStatusUpdate {
+    /// Identifier of the job being updated.
+    pub job_id: JobId,
+    /// New status for the job.
+    pub status: JobLifecycleStatus,
+    /// Timestamp when the status change occurred.
+    pub updated_at: u64,
+}
+
 /// Status of a job in its lifecycle.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum JobLifecycleStatus {


### PR DESCRIPTION
## Summary
- store job status change blocks in the DAG
- track status changes via `JobStatusUpdate`
- test job status persistence

## Testing
- `cargo test -p icn-runtime status_updates_are_persisted --no-run` *(fails: could not compile `icn-economics`)*

------
https://chatgpt.com/codex/tasks/task_e_68748ea00ce88324892ef35b53b98b07