### PR TITLE
[runtime] default production context

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ cargo build --no-default-features --features "with-libp2p persist-sqlite"
 # Build using the RocksDB backend
 cargo build --no-default-features --features "with-libp2p persist-rocksdb"
 
+### Production vs Test Modes
+
+`icn-node` defaults to **production** mode, using persistent services and a real
+`Ed25519Signer`.  To run with in-memory storage and stub networking pass
+`--test-mode` on the CLI or set `ICN_TEST_MODE=true`.
+
+Persistent DAG paths and signing keys can be configured via CLI flags or
+`ICN_*` environment variables as described in the [deployment guide](docs/deployment-guide.md).
+
 # Start a node with persistent storage, P2P, and TLS enabled
 ./target/debug/icn-node \
   --enable-p2p \

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1029,7 +1029,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         RuntimeContext::new_testing(node_did.clone(), Some(1000))
             .expect("Failed to create RuntimeContext for testing")
     } else {
-        RuntimeContext::new_production(
+        RuntimeContext::new(
             node_did.clone(),
             network_service,
             signer,

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -127,7 +127,7 @@ let dag_store = Arc::new(Mutex::new(icn_dag::TokioFileDagStore::new("./dag".into
 #[cfg(not(feature = "async"))]
 let dag_store = Arc::new(Mutex::new(icn_dag::FileDagStore::new("./dag".into()).unwrap()));
 
-let ctx = RuntimeContext::new(
+let ctx = RuntimeContext::new_with_services(
     Did::new("key", "node"),
     Arc::new(StubMeshNetworkService::new()),
     Arc::new(Ed25519Signer::new(generate_ed25519_keypair().0)),

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -269,10 +269,10 @@ impl RuntimeContext {
     /// Create a new context with ledger path (convenience method for tests).
     ///
     /// **⚠️ DEPRECATED**: This method uses stub services and should not be used in production.
-    /// Use `RuntimeContext::new_production()` or `RuntimeContext::from_service_config()` instead.
+    /// Use [`RuntimeContext::new()`] or [`RuntimeContext::from_service_config()`] instead.
     #[deprecated(
         since = "0.1.0",
-        note = "Use `new_production()` or `from_service_config()` instead. This method uses stub services."
+        note = "Use `new()` or `from_service_config()` instead. This method uses stub services."
     )]
     pub fn new_with_ledger_path(
         current_identity_str: &str,
@@ -318,10 +318,10 @@ impl RuntimeContext {
     /// Create a new context with ledger path and time provider (convenience method for tests).
     ///
     /// **⚠️ DEPRECATED**: This method uses stub services and should not be used in production.
-    /// Use `RuntimeContext::new_production()` or `RuntimeContext::from_service_config()` instead.
+    /// Use [`RuntimeContext::new()`] or [`RuntimeContext::from_service_config()`] instead.
     #[deprecated(
         since = "0.1.0",
-        note = "Use `new_production()` or `from_service_config()` instead. This method uses stub services."
+        note = "Use `new()` or `from_service_config()` instead. This method uses stub services."
     )]
     pub fn new_with_ledger_path_and_time(
         current_identity_str: &str,
@@ -435,9 +435,9 @@ impl RuntimeContext {
         }))
     }
 
-    /// Create a production RuntimeContext with all production services.
-    /// This method ensures no stub services are used.
-    pub fn new_production(
+    /// Create a production `RuntimeContext` with all production services.
+    /// This is the recommended constructor for real deployments.
+    pub fn new(
         current_identity: Did,
         network_service: Arc<dyn icn_network::NetworkService>,
         signer: Arc<dyn Signer>,
@@ -460,7 +460,7 @@ impl RuntimeContext {
         Self::from_service_config(config)
     }
 
-    /// Create a development RuntimeContext with mixed services.
+    /// Create a development `RuntimeContext` with mixed services.
     pub fn new_development(
         current_identity: Did,
         signer: Arc<dyn Signer>,
@@ -535,8 +535,9 @@ impl RuntimeContext {
         Ok(ctx)
     }
 
-    /// Create a new context with proper services.
-    pub fn new(
+    /// Create a context with custom services.
+    /// Primarily used for tests or embedding ICN components.
+    pub fn new_with_services(
         current_identity: Did,
         mesh_network_service: Arc<MeshNetworkServiceType>,
         signer: Arc<dyn Signer>,

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -4,6 +4,13 @@ This guide provides minimal examples for launching `icn-node` in common scenario
 
 For details on the HTTP API exposed by the node see [API.md](API.md).
 
+### Production vs Test Modes
+
+`icn-node` starts in production mode unless `--test-mode` or the
+`ICN_TEST_MODE=true` environment variable is supplied. Production mode requires
+persistent DAG storage and an `Ed25519Signer` (configured via CLI or ENV). Test
+mode uses in-memory storage and stub networking for local experimentation.
+
 ## Single Node Local
 
 This mode runs a standalone node for development or testing.


### PR DESCRIPTION
## Summary
- rename `RuntimeContext::new_production` as the default constructor
- move old `new` to `new_with_services`
- update icn-node to default to production services unless `--test-mode`
- document production vs test modes

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not finish within time)*
- `cargo test --all-features --workspace` *(failed: build errors)*
- `cargo test -p icn-ccl` *(failed: build errors)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68748ea69a34832488a926a35c73472c