### PR TITLE
[runtime] verify receipt signatures

### DIFF
--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -814,7 +814,10 @@ impl RuntimeContext {
         let ctx = Arc::clone(self);
         let job_id_for_task = job_id.clone();
         tokio::spawn(async move {
-            log::info!("[handle_submit_job] Spawning lifecycle management task for job: {}", job_id_for_task);
+            log::info!(
+                "[handle_submit_job] Spawning lifecycle management task for job: {}",
+                job_id_for_task
+            );
             if let Err(e) = ctx.manage_job_lifecycle(job_id_for_task).await {
                 log::error!("[handle_submit_job] Job lifecycle management failed: {}", e);
             } else {
@@ -996,7 +999,10 @@ impl RuntimeContext {
         );
 
         // 0. Check if this is a CCL WASM job that should auto-execute
-        log::debug!("[manage_job_lifecycle] Retrieving job status for: {}", job_id);
+        log::debug!(
+            "[manage_job_lifecycle] Retrieving job status for: {}",
+            job_id
+        );
         match self.get_job_status(&job_id).await {
             Ok(Some(_lifecycle)) => {
                 log::debug!(
@@ -1019,7 +1025,7 @@ impl RuntimeContext {
                 return Err(e);
             }
         }
-        
+
         if let Ok(Some(lifecycle)) = self.get_job_status(&job_id).await {
             let job_spec = lifecycle.job.decode_spec().map_err(|e| {
                 HostAbiError::DagOperationFailed(format!("Failed to decode job spec: {}", e))
@@ -1049,10 +1055,8 @@ impl RuntimeContext {
                             "[manage_job_lifecycle] CCL WASM job {} completed successfully",
                             job_id
                         );
-                        self.job_states.insert(
-                            job_id.clone(),
-                            JobState::Completed { receipt },
-                        );
+                        self.job_states
+                            .insert(job_id.clone(), JobState::Completed { receipt });
                         return Ok(());
                     }
                     Err(e) => {
@@ -1531,14 +1535,10 @@ impl RuntimeContext {
             return Err(HostAbiError::InvalidParameters("Job not found".to_string()));
         }
 
-        // 2. Verify the receipt signature
-        // Note: In a full implementation, we would resolve the executor's verifying key
-        // and verify the signature. For now, we just check that a signature exists.
-        if receipt.sig.0.is_empty() {
-            return Err(HostAbiError::PermissionDenied(
-                "Receipt signature is required".to_string(),
-            ));
-        }
+        // 2. Verify the receipt signature against the executor's DID
+        receipt
+            .verify_with_resolver(&*self.did_resolver)
+            .map_err(|e| HostAbiError::SignatureError(format!("{e}")))?;
 
         // Create a DAG block for the receipt
         let receipt_bytes = bincode::serialize(receipt).map_err(|e| {

--- a/crates/icn-runtime/tests/receipt_signature.rs
+++ b/crates/icn-runtime/tests/receipt_signature.rs
@@ -1,0 +1,78 @@
+use icn_common::{Cid, Did};
+use icn_identity::{
+    did_key_from_verifying_key, generate_ed25519_keypair, ExecutionReceipt, SignatureBytes,
+};
+use icn_runtime::context::{HostAbiError, RuntimeContext, StubSigner};
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn anchor_receipt_valid_signature() {
+    let (sk, vk) = generate_ed25519_keypair();
+    let did_str = did_key_from_verifying_key(&vk);
+    let did = Did::from_str(&did_str).unwrap();
+    let signer = Arc::new(StubSigner::new_with_keys(sk.clone(), vk));
+    let ctx = RuntimeContext::new_with_ledger_path(
+        &did_str,
+        std::path::PathBuf::from("./mana_ledger.sled"),
+        signer.clone(),
+    )
+    .unwrap();
+
+    let job_id = Cid::new_v1_sha256(0x55, b"sig_job");
+    ctx.job_states.insert(
+        icn_mesh::JobId(job_id.clone()),
+        icn_mesh::JobState::Assigned {
+            executor: did.clone(),
+        },
+    );
+
+    let receipt = ExecutionReceipt {
+        job_id: job_id.clone(),
+        executor_did: did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"res"),
+        cpu_ms: 10,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    };
+    let signed = receipt.sign_with_key(&sk).unwrap();
+
+    let cid = ctx.anchor_receipt(&signed).await.unwrap();
+    assert_eq!(cid, signed.result_cid);
+}
+
+#[tokio::test]
+async fn anchor_receipt_invalid_signature() {
+    let (sk, vk) = generate_ed25519_keypair();
+    let did_str = did_key_from_verifying_key(&vk);
+    let did = Did::from_str(&did_str).unwrap();
+    let signer = Arc::new(StubSigner::new_with_keys(sk.clone(), vk));
+    let ctx = RuntimeContext::new_with_ledger_path(
+        &did_str,
+        std::path::PathBuf::from("./mana_ledger.sled"),
+        signer.clone(),
+    )
+    .unwrap();
+
+    let job_id = Cid::new_v1_sha256(0x55, b"sig_job_bad");
+    ctx.job_states.insert(
+        icn_mesh::JobId(job_id.clone()),
+        icn_mesh::JobState::Assigned {
+            executor: did.clone(),
+        },
+    );
+
+    let receipt = ExecutionReceipt {
+        job_id: job_id.clone(),
+        executor_did: did.clone(),
+        result_cid: Cid::new_v1_sha256(0x55, b"res_bad"),
+        cpu_ms: 10,
+        success: true,
+        sig: SignatureBytes(Vec::new()),
+    };
+    let mut signed = receipt.sign_with_key(&sk).unwrap();
+    signed.sig.0[0] ^= 0xFF;
+
+    let err = ctx.anchor_receipt(&signed).await.err().unwrap();
+    assert!(matches!(err, HostAbiError::SignatureError(_)));
+}


### PR DESCRIPTION
## Summary
- verify incoming receipt signatures using the executor DID
- reject invalid signatures in `RuntimeContext::anchor_receipt`
- add tests for valid and invalid receipt handling

## Testing
- `cargo fmt --all -- --check` *(fails: shows diff for unrelated files)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(interrupted: build took too long)*
- `cargo test --all-features --workspace` *(interrupted: build took too long)*

------
https://chatgpt.com/codex/tasks/task_e_68751400cb3c83249a6335a5ec5afd3d