### PR TITLE
Default production runtime context

### DIFF
--- a/ICN_CORE_CURRENT_STATE_2025.md
+++ b/ICN_CORE_CURRENT_STATE_2025.md
@@ -112,7 +112,7 @@ Based on codebase analysis, the following stub services exist primarily for test
 #### **Week 1: Service Configuration Audit**
 - [ ] **Enable governance tests** (immediate - 5 minutes)
 - [ ] **Audit stub usage** in production code paths
-- [ ] **Update RuntimeContext::new()** to default to production services
+- [x] **RuntimeContext::new()** defaults to production services
 - [ ] **Ensure icn-node uses production configuration**
 
 #### **Week 2: Production Service Integration**

--- a/ICN_IMPLEMENTATION_STATUS_MATRIX.md
+++ b/ICN_IMPLEMENTATION_STATUS_MATRIX.md
@@ -203,7 +203,7 @@ The main problem is that some contexts default to stub services instead of produ
 
 - [ ] **Enable governance tests** (5 minutes): Remove `#[ignore]` from all governance tests
 - [ ] **Audit service usage**: Identify where stub services are used in production contexts
-- [ ] **Update RuntimeContext::new()** to be `new_for_production()` by default
+- [x] **RuntimeContext::new()** now provides production services by default
 - [ ] **Update icn-node** to use production services unless `--test-mode` flag is set
 - [ ] **Clear configuration separation**: Production vs test vs development configs
 

--- a/PHASE_5_EXECUTION_PLAN.md
+++ b/PHASE_5_EXECUTION_PLAN.md
@@ -103,9 +103,9 @@ let mesh_network_service = if config.test_mode {
 };
 ```
 
-**Deliverables:**
-- [ ] Update `RuntimeContext::new()` to be `new_for_production()` by default
-- [ ] Ensure `icn-node` uses production services unless `--test-mode` flag is set
+-**Deliverables:**
+- [x] `RuntimeContext::new()` now provides production services by default
+ - [ ] Ensure `icn-node` uses production services unless `--test-mode` flag is set
 - [ ] Configure persistent DAG storage for all production deployments
 - [ ] Use `Ed25519Signer` for all production cryptographic operations
 - [ ] Update all documentation to reflect production vs test configurations

--- a/README.md
+++ b/README.md
@@ -213,6 +213,20 @@ cargo build --no-default-features --features "with-libp2p persist-rocksdb"
 ./target/debug/icn-cli federation list-peers
 ```
 
+## Production vs Test Modes
+
+`icn-node` runs with production services by default. Use `--test-mode` or set
+`ICN_TEST_MODE=true` to launch with stub networking and in-memory storage.
+Persistent DAG paths and the signing key are configured via CLI or environment
+variables:
+
+```bash
+ICN_STORAGE_PATH=./icn_data/dag.sqlite \
+ICN_NODE_DID_PATH=./icn_data/node.did \
+ICN_NODE_PRIVATE_KEY_PATH=./icn_data/node.key \
+icn-node --storage-backend sqlite
+```
+
 ## 🌐 Quick Start: Devnet Testing
 
 For the fastest way to test ICN features, use the containerized devnet that launches a 3-node federation:

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -1142,7 +1142,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         RuntimeContext::new_testing(node_did.clone(), Some(1000))
             .expect("Failed to create RuntimeContext for testing")
     } else {
-        RuntimeContext::new_production(
+        RuntimeContext::new(
             node_did.clone(),
             network_service,
             signer.clone(),

--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -139,7 +139,7 @@ let dag_store = Arc::new(Mutex::new(icn_dag::TokioFileDagStore::new("./dag".into
 #[cfg(not(feature = "async"))]
 let dag_store = Arc::new(Mutex::new(icn_dag::FileDagStore::new("./dag".into()).unwrap()));
 
-let ctx = RuntimeContext::new(
+let ctx = RuntimeContext::new_with_services(
     Did::new("key", "node"),
     Arc::new(StubMeshNetworkService::new()),
     Arc::new(Ed25519Signer::new(generate_ed25519_keypair().0)),

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -283,10 +283,10 @@ impl RuntimeContext {
     /// Create a new context with ledger path (convenience method for tests).
     ///
     /// **⚠️ DEPRECATED**: This method uses stub services and should not be used in production.
-    /// Use `RuntimeContext::new_production()` or `RuntimeContext::from_service_config()` instead.
+    /// Use [`RuntimeContext::new`] or `RuntimeContext::from_service_config()` instead.
     #[deprecated(
         since = "0.1.0",
-        note = "Use `new_production()` or `from_service_config()` instead. This method uses stub services."
+        note = "Use `new` or `from_service_config()` instead. This method uses stub services."
     )]
     pub fn new_with_ledger_path(
         current_identity_str: &str,
@@ -333,10 +333,10 @@ impl RuntimeContext {
     /// Create a new context with ledger path and time provider (convenience method for tests).
     ///
     /// **⚠️ DEPRECATED**: This method uses stub services and should not be used in production.
-    /// Use `RuntimeContext::new_production()` or `RuntimeContext::from_service_config()` instead.
+    /// Use [`RuntimeContext::new`] or `RuntimeContext::from_service_config()` instead.
     #[deprecated(
         since = "0.1.0",
-        note = "Use `new_production()` or `from_service_config()` instead. This method uses stub services."
+        note = "Use `new` or `from_service_config()` instead. This method uses stub services."
     )]
     pub fn new_with_ledger_path_and_time(
         current_identity_str: &str,
@@ -452,10 +452,11 @@ impl RuntimeContext {
         }))
     }
 
-    /// Create a production RuntimeContext with all production services.
-    /// This method ensures no stub services are used.
+    /// Create a new `RuntimeContext` with all production services.
+    /// This method ensures no stub services are used and should be used
+    /// whenever running an ICN node outside of test mode.
     #[allow(clippy::too_many_arguments)]
-    pub fn new_production(
+    pub fn new(
         current_identity: Did,
         network_service: Arc<dyn icn_network::NetworkService>,
         signer: Arc<dyn Signer>,
@@ -553,8 +554,11 @@ impl RuntimeContext {
         Ok(ctx)
     }
 
-    /// Create a new context with proper services.
-    pub fn new(
+    /// Create a new context using explicitly provided services.
+    /// This constructor is primarily for advanced embedding scenarios. Most
+    /// callers should use [`RuntimeContext::new`] for a production-ready
+    /// context.
+    pub fn new_with_services(
         current_identity: Did,
         mesh_network_service: Arc<MeshNetworkServiceType>,
         signer: Arc<dyn Signer>,

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -6,12 +6,23 @@ For details on the HTTP API exposed by the node see [API.md](API.md).
 
 ## Single Node Local
 
-This mode runs a standalone node for development or testing.
+This mode runs a standalone node for development or testing. By default the node
+starts in **production mode** with persistent storage and Ed25519 signing. Use
+`--test-mode` or set `ICN_TEST_MODE=true` to launch with stub services and
+in-memory storage.
 
 ```bash
 icn-node --storage-backend memory --http-listen-addr 127.0.0.1:7845 \
          --api-key mylocalkey \
          --tls-cert-path ./cert.pem --tls-key-path ./key.pem
+```
+
+Set `ICN_STORAGE_PATH` and related variables to control where persistent DAG
+data is written:
+
+```bash
+ICN_STORAGE_PATH=./icn_data/node.sled ICN_MANA_LEDGER_PATH=./icn_data/mana.sled \
+icn-node --storage-backend sled
 ```
 
 Providing certificate and key paths makes the server listen on HTTPS instead of HTTP.
@@ -31,8 +42,9 @@ To use RocksDB as the persistence layer, build `icn-node` with the
 
 ## Identity
 
-ICN nodes generate a new DID and key on first launch. To supply an encrypted
-key, set the path and passphrase environment variable name:
+ICN nodes generate a new DID and Ed25519 key on first launch. To supply an
+existing key, set the path and passphrase environment variable name or provide
+`ICN_NODE_DID_PATH` and `ICN_NODE_PRIVATE_KEY_PATH`:
 
 ```toml
 [identity]
@@ -41,7 +53,8 @@ key_passphrase_env = "ICN_KEY_PASSPHRASE"
 ```
 
 The passphrase is read from the environment variable referenced by
-`key_passphrase_env`.
+`key_passphrase_env`. When the plain-text paths are provided the node loads the
+DID and private key instead of generating new ones.
 
 ## Small Federation
 


### PR DESCRIPTION
## Summary
- make `RuntimeContext::new` the production constructor
- update icn-node to call new default constructor
- document production vs test modes in README and deployment guide
- update planning docs to mark RuntimeContext change complete

## Testing
- `cargo check -q`

------
https://chatgpt.com/codex/tasks/task_e_6875145473f48324b8711ad67adad144