### PR TITLE
Add bounty and recognition utilities

### DIFF
--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -584,12 +584,12 @@ impl StorageService<DagBlock> for FileDagStore {
                 let entry =
                     entry.map_err(|e| CommonError::IoError(format!("Dir entry error: {}", e)))?;
                 let path = entry.path();
-                
+
                 // Skip the dag.root file
                 if path.file_name() == Some(std::ffi::OsStr::new("dag.root")) {
                     continue;
                 }
-                
+
                 if entry
                     .file_type()
                     .map_err(|e| {

--- a/crates/icn-dag/src/recognition.rs
+++ b/crates/icn-dag/src/recognition.rs
@@ -1,0 +1,48 @@
+use crate::{DagBlock, StorageService};
+use icn_common::TimeProvider;
+use icn_common::{compute_merkle_cid, CommonError, Did, NodeScope, SystemTimeProvider};
+use serde::{Deserialize, Serialize};
+
+/// Record describing a contributor action.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContributionRecord {
+    pub contributor: Did,
+    pub message: String,
+    pub timestamp: u64,
+}
+
+/// Append a contribution record to the DAG and return its CID.
+pub fn log_contribution(
+    store: &mut dyn StorageService<DagBlock>,
+    contributor: Did,
+    message: String,
+    scope: Option<NodeScope>,
+) -> Result<icn_common::Cid, CommonError> {
+    let record = ContributionRecord {
+        contributor: contributor.clone(),
+        message,
+        timestamp: SystemTimeProvider.unix_seconds(),
+    };
+    let data =
+        serde_json::to_vec(&record).map_err(|e| CommonError::SerializationError(e.to_string()))?;
+    let cid = compute_merkle_cid(
+        0x71,
+        &data,
+        &[],
+        record.timestamp,
+        &contributor,
+        &None,
+        &scope,
+    );
+    let block = DagBlock {
+        cid: cid.clone(),
+        data,
+        links: vec![],
+        timestamp: record.timestamp,
+        author_did: contributor,
+        signature: None,
+        scope,
+    };
+    store.put(&block)?;
+    Ok(cid)
+}

--- a/crates/icn-dag/tests/recognition.rs
+++ b/crates/icn-dag/tests/recognition.rs
@@ -1,0 +1,69 @@
+use icn_common::{Cid, CommonError, DagBlock, Did, NodeScope};
+use icn_dag::{recognition::log_contribution, StorageService};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+struct MemStore {
+    map: HashMap<Cid, DagBlock>,
+}
+impl MemStore {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+}
+impl StorageService<DagBlock> for MemStore {
+    fn put(&mut self, block: &DagBlock) -> Result<(), CommonError> {
+        self.map.insert(block.cid.clone(), block.clone());
+        Ok(())
+    }
+    fn get(&self, cid: &Cid) -> Result<Option<DagBlock>, CommonError> {
+        Ok(self.map.get(cid).cloned())
+    }
+    fn delete(&mut self, cid: &Cid) -> Result<(), CommonError> {
+        self.map.remove(cid);
+        Ok(())
+    }
+    fn contains(&self, cid: &Cid) -> Result<bool, CommonError> {
+        Ok(self.map.contains_key(cid))
+    }
+    fn list_blocks(&self) -> Result<Vec<DagBlock>, CommonError> {
+        Ok(self.map.values().cloned().collect())
+    }
+    fn pin_block(&mut self, _cid: &Cid) -> Result<(), CommonError> {
+        Ok(())
+    }
+    fn unpin_block(&mut self, _cid: &Cid) -> Result<(), CommonError> {
+        Ok(())
+    }
+    fn prune_expired(&mut self, _now: u64) -> Result<Vec<Cid>, CommonError> {
+        Ok(vec![])
+    }
+    fn set_ttl(&mut self, _cid: &Cid, _ttl: Option<u64>) -> Result<(), CommonError> {
+        Ok(())
+    }
+    fn get_metadata(&self, _cid: &Cid) -> Result<Option<icn_dag::BlockMetadata>, CommonError> {
+        Ok(None)
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+#[test]
+fn log_contribution_stores_block() {
+    let mut store = MemStore::new();
+    let did = Did::from_str("did:example:alice").unwrap();
+    let cid = log_contribution(
+        &mut store,
+        did,
+        "fixed".into(),
+        Some(NodeScope("coop".into())),
+    )
+    .unwrap();
+    assert!(store.contains(&cid).unwrap());
+}

--- a/crates/icn-economics/src/bounty.rs
+++ b/crates/icn-economics/src/bounty.rs
@@ -1,0 +1,100 @@
+use crate::{mint_tokens_with_reputation, ManaLedger, ResourceLedger, ResourceRepositoryAdapter};
+use icn_common::{CommonError, Did, NodeScope};
+use icn_reputation::ReputationStore;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct Bounty {
+    pub id: u64,
+    pub description: String,
+    pub amount: u64,
+    pub class_id: String,
+    pub issuer: Did,
+    pub claimant: Option<Did>,
+    pub paid: bool,
+}
+
+pub struct BountyManager<L: ManaLedger, R: ResourceLedger> {
+    pub bounties: HashMap<u64, Bounty>,
+    pub repo: ResourceRepositoryAdapter<R>,
+    pub mana: L,
+    next_id: u64,
+}
+
+impl<L: ManaLedger, R: ResourceLedger> BountyManager<L, R> {
+    pub fn new(mana: L, repo: ResourceRepositoryAdapter<R>) -> Self {
+        Self {
+            bounties: HashMap::new(),
+            repo,
+            mana,
+            next_id: 0,
+        }
+    }
+
+    pub fn create_bounty(
+        &mut self,
+        issuer: Did,
+        class_id: &str,
+        amount: u64,
+        description: &str,
+    ) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.bounties.insert(
+            id,
+            Bounty {
+                id,
+                description: description.into(),
+                amount,
+                class_id: class_id.into(),
+                issuer,
+                claimant: None,
+                paid: false,
+            },
+        );
+        id
+    }
+
+    pub fn claim_bounty(&mut self, id: u64, claimant: Did) -> Result<(), CommonError> {
+        let b = self
+            .bounties
+            .get_mut(&id)
+            .ok_or_else(|| CommonError::ResourceNotFound("bounty".into()))?;
+        if b.paid {
+            return Err(CommonError::PolicyDenied("already paid".into()));
+        }
+        b.claimant = Some(claimant);
+        Ok(())
+    }
+
+    pub fn payout_bounty(
+        &mut self,
+        id: u64,
+        rep: &dyn ReputationStore,
+        scope: Option<NodeScope>,
+    ) -> Result<(), CommonError> {
+        let b = self
+            .bounties
+            .get_mut(&id)
+            .ok_or_else(|| CommonError::ResourceNotFound("bounty".into()))?;
+        let claimant = b
+            .claimant
+            .clone()
+            .ok_or_else(|| CommonError::InvalidInputError("no claimant".into()))?;
+        if b.paid {
+            return Err(CommonError::PolicyDenied("already paid".into()));
+        }
+        mint_tokens_with_reputation(
+            &self.repo,
+            &self.mana,
+            rep,
+            &b.issuer,
+            &b.class_id,
+            b.amount,
+            &claimant,
+            scope,
+        )?;
+        b.paid = true;
+        Ok(())
+    }
+}

--- a/crates/icn-economics/tests/bounty.rs
+++ b/crates/icn-economics/tests/bounty.rs
@@ -1,0 +1,93 @@
+use icn_common::{Did, NodeScope};
+use icn_economics::bounty::BountyManager;
+use icn_economics::{ManaLedger, ResourceLedger, ResourceRepositoryAdapter};
+use icn_reputation::InMemoryReputationStore;
+use icn_runtime::context::StubDagStore;
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Mutex;
+
+#[derive(Default)]
+struct InMemResLedger {
+    balances: Mutex<HashMap<(Did, String), u64>>,
+}
+impl ResourceLedger for InMemResLedger {
+    fn get_balance(&self, d: &Did, c: &str) -> u64 {
+        *self
+            .balances
+            .lock()
+            .unwrap()
+            .get(&(d.clone(), c.to_string()))
+            .unwrap_or(&0)
+    }
+    fn set_balance(&self, d: &Did, c: &str, a: u64) -> Result<(), icn_common::CommonError> {
+        self.balances
+            .lock()
+            .unwrap()
+            .insert((d.clone(), c.to_string()), a);
+        Ok(())
+    }
+    fn credit(&self, d: &Did, c: &str, a: u64) -> Result<(), icn_common::CommonError> {
+        let mut m = self.balances.lock().unwrap();
+        *m.entry((d.clone(), c.to_string())).or_insert(0) += a;
+        Ok(())
+    }
+    fn debit(&self, d: &Did, c: &str, a: u64) -> Result<(), icn_common::CommonError> {
+        let mut m = self.balances.lock().unwrap();
+        let bal = m.entry((d.clone(), c.to_string())).or_insert(0);
+        if *bal < a {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= a;
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct InMemoryManaLedger {
+    balances: Mutex<HashMap<Did, u64>>,
+}
+impl ManaLedger for InMemoryManaLedger {
+    fn get_balance(&self, d: &Did) -> u64 {
+        *self.balances.lock().unwrap().get(d).unwrap_or(&0)
+    }
+    fn set_balance(&self, d: &Did, a: u64) -> Result<(), icn_common::CommonError> {
+        self.balances.lock().unwrap().insert(d.clone(), a);
+        Ok(())
+    }
+    fn spend(&self, d: &Did, a: u64) -> Result<(), icn_common::CommonError> {
+        let mut m = self.balances.lock().unwrap();
+        let bal = m.entry(d.clone()).or_insert(0);
+        if *bal < a {
+            return Err(icn_common::CommonError::PolicyDenied("insufficient".into()));
+        }
+        *bal -= a;
+        Ok(())
+    }
+    fn credit(&self, d: &Did, a: u64) -> Result<(), icn_common::CommonError> {
+        let mut m = self.balances.lock().unwrap();
+        *m.entry(d.clone()).or_insert(0) += a;
+        Ok(())
+    }
+}
+
+#[test]
+fn bounty_flow() {
+    let mana = InMemoryManaLedger::default();
+    let ledger = InMemResLedger::default();
+    let mut repo = ResourceRepositoryAdapter::with_dag_store(ledger, Box::new(StubDagStore::new()));
+    let issuer = Did::from_str("did:example:issuer").unwrap();
+    let scope = NodeScope("coop".into());
+    repo.add_issuer(scope.clone(), issuer.clone());
+    let mut manager = BountyManager::new(mana, repo);
+    manager.mana.set_balance(&issuer, 10).unwrap();
+    let id = manager.create_bounty(issuer.clone(), "token", 5, "fix bug");
+    manager
+        .claim_bounty(id, Did::from_str("did:example:bob").unwrap())
+        .unwrap();
+    let rep = InMemoryReputationStore::new();
+    manager
+        .payout_bounty(id, &rep, Some(NodeScope("coop".into())))
+        .unwrap();
+    assert!(manager.bounties.get(&id).unwrap().paid);
+}

--- a/crates/icn-governance/README.md
+++ b/crates/icn-governance/README.md
@@ -34,6 +34,12 @@ When built with the `federation` feature, this crate exposes
 `NetworkService` to request state from another peer. It sends a
 `FederationSyncRequest` message via the network layer and returns a
 `CommonError` if the underlying send fails.
+## DAO Reward Templates
+
+Reusable CCL snippets for rewarding contributors live in `templates/`. Examples:
+- `reward_member.ccl` — grant scoped tokens to a specific member.
+- `community_bonus.ccl` — distribute a bonus to all members.
+
 
 ## Contributing
 

--- a/crates/icn-governance/templates/community_bonus.ccl
+++ b/crates/icn-governance/templates/community_bonus.ccl
@@ -1,0 +1,7 @@
+// Proposal template: distribute bonus to all members
+fn distribute(bonus: Integer) -> Integer {
+    return bonus;
+}
+fn run() -> Integer {
+    return distribute(50);
+}

--- a/crates/icn-governance/templates/reward_member.ccl
+++ b/crates/icn-governance/templates/reward_member.ccl
@@ -1,0 +1,7 @@
+// Proposal template: reward a contributor with scoped tokens
+fn reward(member: Did, amount: Integer) -> Integer {
+    return amount;
+}
+fn run() -> Integer {
+    return reward(member, 10);
+}

--- a/docs/reputation_integration.md
+++ b/docs/reputation_integration.md
@@ -1,0 +1,17 @@
+# Reputation Influence on Mana & Token Issuance
+
+This document summarizes how the ICN core links participant reputation to economic capabilities.
+
+## Mana Regeneration
+
+`icn-runtime` periodically regenerates mana for all accounts. The amount granted is scaled by each account's reputation score.
+
+Relevant code:
+- `RuntimeContext` mana regenerator calculates `regeneration_amount` as `base_regeneration * reputation_multiplier` where `reputation_multiplier` is derived from the score.
+- The `icn-economics` crate exposes `credit_by_reputation` to credit mana directly based on reputation.
+
+## Scoped Token Issuance
+
+When minting scoped tokens, issuers pay mana. The `price_by_reputation` helper reduces this cost based on the issuer's reputation, enabling trusted contributors to create resources more cheaply.
+
+The new `mint_tokens_with_reputation` function demonstrates this linkage.


### PR DESCRIPTION
## Summary
- link reputation to token minting via `mint_tokens_with_reputation`
- prototype bounty payout manager
- log contributor recognition in the DAG
- add DAO reward templates
- document reputation integration

## Testing
- `cargo test -p icn-economics --tests`
- `cargo test -p icn-dag --test recognition`

------
https://chatgpt.com/codex/tasks/task_e_687529c477488324bd9dfffb14a0e9f0