### PR TITLE
Add mutual aid token type and emergency tools

### DIFF
--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -38,6 +38,8 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
 *   **Miscellaneous:**
     *   `icn-cli hello`: A simple command to check if the CLI is responsive.
     *   `icn-cli help` or `icn-cli --help`: Displays usage information.
+*   **Emergency Coordination:**
+    *   `icn-cli emergency match <REQUESTS_JSON> <TEMPLATES_JSON>`: Suggest job templates for unfilled aid requests.
 
 ### Example: Generate and Verify a Proof
 

--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -13,6 +13,7 @@ The `icn-dag` crate is responsible for:
 *   **Content Addressing:** Ensuring data integrity and retrievability using cryptographic hashes (e.g., CIDs - Content Identifiers).
 *   **Storage Abstraction:** Potentially providing interfaces for various backing stores (e.g., in-memory, disk-based, distributed).
 *   **Serialization Formats:** Defining how DAGs are serialized and deserialized (e.g., CBOR, IPLD codecs).
+*   **Mutual Aid Registry:** Schema definitions for cooperative resource sharing.
 
 This forms a foundational layer for data representation and exchange within the ICN.
 

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -23,6 +23,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 /// Helper crate for encoding/decoding root hashes
 pub mod index;
 pub mod metrics;
+pub mod mutual_aid;
+pub use mutual_aid::{MutualAidRegistry, MutualAidResource};
 #[cfg(feature = "persist-postgres")]
 pub mod postgres_store;
 #[cfg(feature = "persist-rocksdb")]
@@ -584,12 +586,12 @@ impl StorageService<DagBlock> for FileDagStore {
                 let entry =
                     entry.map_err(|e| CommonError::IoError(format!("Dir entry error: {}", e)))?;
                 let path = entry.path();
-                
+
                 // Skip the dag.root file
                 if path.file_name() == Some(std::ffi::OsStr::new("dag.root")) {
                     continue;
                 }
-                
+
                 if entry
                     .file_type()
                     .map_err(|e| {

--- a/crates/icn-dag/src/mutual_aid.rs
+++ b/crates/icn-dag/src/mutual_aid.rs
@@ -1,0 +1,33 @@
+use crate::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MutualAidResource {
+    pub id: String,
+    pub description: String,
+    pub quantity: u64,
+    pub provider: Did,
+    pub location: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct MutualAidRegistry {
+    pub resources: HashMap<String, MutualAidResource>,
+}
+
+impl MutualAidRegistry {
+    pub fn new() -> Self {
+        Self {
+            resources: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, resource: MutualAidResource) {
+        self.resources.insert(resource.id.clone(), resource);
+    }
+
+    pub fn get(&self, id: &str) -> Option<&MutualAidResource> {
+        self.resources.get(id)
+    }
+}

--- a/crates/icn-economics/README.md
+++ b/crates/icn-economics/README.md
@@ -10,6 +10,7 @@ See [docs/ASYNC_OVERVIEW.md](../../docs/ASYNC_OVERVIEW.md) for async API guideli
 The `icn-economics` crate is responsible for:
 
 *   **Token Models:** Defining and managing the native digital assets of the ICN (e.g., Mana or other utility tokens).
+*   **Mutual Aid Tokens:** Non-transferable tokens scoped for community aid.
 *   **Ledger Management:** Implementing or interfacing with the distributed ledger that records transactions and account balances.
 *   **Transaction Logic:** Defining the rules for valid transactions, including transfers, fees, and CCL contract interactions related to economic activity.
 *   **Incentive Mechanisms:** Potentially including staking, rewards, and other economic incentives for network participation.

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -421,6 +421,9 @@ impl<L: ResourceLedger> ResourceRepositoryAdapter<L> {
 
 const TOKEN_FEE: u64 = 1;
 
+/// Class ID reserved for non-transferable mutual aid tokens.
+pub const MUTUAL_AID_CLASS_ID: &str = "mutual_aid";
+
 pub fn mint_tokens<L: ResourceLedger, M: ManaLedger>(
     repo: &ResourceRepositoryAdapter<L>,
     mana_ledger: &M,
@@ -458,6 +461,11 @@ pub fn transfer_tokens<L: ResourceLedger, M: ManaLedger>(
     to: &Did,
     scope: Option<NodeScope>,
 ) -> Result<(), CommonError> {
+    if class_id == MUTUAL_AID_CLASS_ID {
+        return Err(CommonError::PolicyDenied(
+            "mutual aid tokens are non-transferable".into(),
+        ));
+    }
     charge_mana(mana_ledger, issuer, TOKEN_FEE)?;
     repo.transfer(issuer, class_id, amount, from, to, scope)
 }

--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -13,7 +13,9 @@ use icn_identity::{
     VerifyingKey as IdentityVerifyingKey,
 };
 use serde::{Deserialize, Serialize};
+pub mod matcher;
 pub mod metrics;
+pub use matcher::{match_unfilled_requests, AidRequest, JobTemplate};
 
 /// Unique identifier for a mesh job.
 ///

--- a/crates/icn-mesh/src/matcher.rs
+++ b/crates/icn-mesh/src/matcher.rs
@@ -1,0 +1,33 @@
+use crate::Resources;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AidRequest {
+    pub id: String,
+    pub description: String,
+    pub required_resources: Resources,
+    pub filled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobTemplate {
+    pub id: String,
+    pub description: String,
+    pub resources: Resources,
+}
+
+pub fn match_unfilled_requests<'a>(
+    requests: &'a [AidRequest],
+    templates: &'a [JobTemplate],
+) -> Vec<(&'a AidRequest, &'a JobTemplate)> {
+    let mut matches = Vec::new();
+    for req in requests.iter().filter(|r| !r.filled) {
+        if let Some(tmpl) = templates.iter().find(|t| {
+            t.resources.cpu_cores >= req.required_resources.cpu_cores
+                && t.resources.memory_mb >= req.required_resources.memory_mb
+        }) {
+            matches.push((req, tmpl));
+        }
+    }
+    matches
+}

--- a/crates/icn-mesh/tests/matcher.rs
+++ b/crates/icn-mesh/tests/matcher.rs
@@ -1,0 +1,21 @@
+use icn_mesh::{match_unfilled_requests, AidRequest, JobTemplate, Resources};
+
+#[test]
+fn basic_matching_works() {
+    let requests = vec![AidRequest {
+        id: "r1".into(),
+        description: "need help".into(),
+        required_resources: Resources { cpu_cores: 1, memory_mb: 1 },
+        filled: false,
+    }];
+    let templates = vec![JobTemplate {
+        id: "t1".into(),
+        description: "generic".into(),
+        resources: Resources { cpu_cores: 2, memory_mb: 2 },
+    }];
+
+    let m = match_unfilled_requests(&requests, &templates);
+    assert_eq!(m.len(), 1);
+    assert_eq!(m[0].0.id, "r1");
+    assert_eq!(m[0].1.id, "t1");
+}

--- a/scripts/emergency-coord.sh
+++ b/scripts/emergency-coord.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Simple helper to match aid requests with job templates using icn-cli
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <requests.json> <templates.json>"
+    exit 1
+fi
+
+cargo run -p icn-cli --quiet -- emergency match "$1" "$2"


### PR DESCRIPTION
## Summary
- add a non-transferable `MUTUAL_AID_CLASS_ID` constant to `icn-economics`
- prevent transfers of mutual-aid tokens
- expose a `MutualAidRegistry` data schema in `icn-dag`
- implement simple aid-request matcher in `icn-mesh`
- extend `icn-cli` with `emergency` command
- add helper script for matching aid requests
- document new features

## Testing
- `rustfmt --edition 2021 crates/icn-dag/src/mutual_aid.rs crates/icn-dag/src/lib.rs crates/icn-mesh/src/matcher.rs crates/icn-mesh/src/lib.rs crates/icn-cli/src/main.rs crates/icn-economics/src/lib.rs crates/icn-economics/tests/resource_tokens.rs`

------
https://chatgpt.com/codex/tasks/task_e_687529bcd3dc8324830800ff4a7036b0