### PR TITLE
[api] add executor queue trait

### DIFF
--- a/crates/icn-api/src/mesh_trait.rs
+++ b/crates/icn-api/src/mesh_trait.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+use icn_common::{CommonError, Did};
+use icn_mesh::JobId;
+
+/// Information about jobs queued for a specific executor.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ExecutorQueueInfo {
+    /// Executor DID the queue belongs to.
+    pub executor: Did,
+    /// Jobs currently awaiting execution by this executor.
+    pub jobs: Vec<JobId>,
+}
+
+/// Mesh network related API operations.
+#[async_trait]
+pub trait MeshApi {
+    /// Retrieve the current queue of jobs for the local executor.
+    async fn executor_queue(&self) -> Result<ExecutorQueueInfo, CommonError>;
+}

--- a/crates/icn-dag/src/analytics.rs
+++ b/crates/icn-dag/src/analytics.rs
@@ -1,0 +1,55 @@
+use crate::{DagBlock, StorageService};
+use icn_common::{CommonError, Did};
+use icn_mesh::JobAssignment;
+
+/// Compute the average final price for jobs executed by the given executor.
+/// Returns `None` if no assignments are found.
+pub fn average_executor_price<S: StorageService<DagBlock>>(
+    store: &S,
+    executor: &Did,
+) -> Result<Option<u64>, CommonError> {
+    let mut total = 0u64;
+    let mut count = 0u64;
+    for block in store.list_blocks()? {
+        if let Ok(assignment) = serde_json::from_slice::<JobAssignment>(&block.data) {
+            if assignment.assigned_executor_did == *executor {
+                total += assignment.final_price_mana;
+                count += 1;
+            }
+        }
+    }
+    if count > 0 {
+        Ok(Some(total / count))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "async")]
+use crate::AsyncStorageService;
+#[cfg(feature = "async")]
+/// Asynchronous variant of [`average_executor_price`].
+pub async fn average_executor_price_async<S>(
+    store: &mut S,
+    executor: &Did,
+) -> Result<Option<u64>, CommonError>
+where
+    S: AsyncStorageService<DagBlock> + ?Sized,
+{
+    let blocks = store.list_blocks().await?;
+    let mut total = 0u64;
+    let mut count = 0u64;
+    for block in blocks {
+        if let Ok(assign) = serde_json::from_slice::<JobAssignment>(&block.data) {
+            if assign.assigned_executor_did == *executor {
+                total += assign.final_price_mana;
+                count += 1;
+            }
+        }
+    }
+    if count > 0 {
+        Ok(Some(total / count))
+    } else {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
## Summary
- add executor queue API trait
- add DAG analytics helper for average executor price

## Testing
- `cargo fmt --all -- --check`

------
https://chatgpt.com/codex/tasks/task_e_687529b3b770832489d8dd9d6c863bc1