### PR TITLE
Implement executor queue introspection trait

### DIFF
--- a/crates/icn-api/src/executor_trait.rs
+++ b/crates/icn-api/src/executor_trait.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+use icn_common::CommonError;
+use serde::{Deserialize, Serialize};
+
+/// Information about an executor's pending queue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutorQueueInfo {
+    pub queued: usize,
+    pub capacity: usize,
+}
+
+#[async_trait]
+pub trait ExecutorIntrospectionApi {
+    async fn get_executor_queue(&self, did: &str) -> Result<ExecutorQueueInfo, CommonError>;
+}


### PR DESCRIPTION
## Summary
- add `ExecutorIntrospectionApi` trait to `icn-api`

## Testing
- `cargo fmt --all`

------
https://chatgpt.com/codex/tasks/task_e_687529b4451c8324813ce4bccbae80a0