### PR TITLE
[cli] federation init wizard and monitoring

### DIFF
--- a/configs/federation_template.toml
+++ b/configs/federation_template.toml
@@ -1,0 +1,12 @@
+# Template configuration for a federated ICN node
+# Fill in your API key and peer addresses.
+http_listen_addr = "0.0.0.0:7845"
+storage_backend = "sqlite"
+storage_path = "./icn_data/node.sqlite"
+api_key = "CHANGE_ME"
+open_rate_limit = 0
+federation_peers = ["/ip4/1.2.3.4/tcp/7000/p2p/QmPeer"]
+bootstrap_peers = ["/ip4/1.2.3.4/tcp/7000/p2p/QmPeer"]
+# Optionally embed the node identity
+node_did = "did:key:zExample"
+node_private_key_bs58 = "BASE58_PRIVATE_KEY"

--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -32,6 +32,9 @@ env_logger = "0.10"
 fastrand = "2"
 hex = "0.4"
 icn-templates = { path = "../icn-templates" }
+bs58 = "0.5"
+prometheus-parse = "0.2"
+toml = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -24,13 +24,17 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
     *   `icn-cli network send-message <PEER_ID> <MESSAGE_JSON>`: Send a `ProtocolMessage` (encoded as JSON) to a specified peer. Requires the node to run with libp2p networking.
     *   `icn-cli network peers`: Display this node's peer ID and the currently discovered peer list.
 *   **Federation Operations:**
+    *   `icn-cli federation init`: Initialize a new federation on this node.
     *   `icn-cli federation join <PEER_ID>`: Join a federation by adding the given peer.
     *   `icn-cli federation leave <PEER_ID>`: Leave a federation or remove the peer.
     *   `icn-cli federation list-peers`: List peers known to the node.
     *   `icn-cli federation status`: Display federation status including peer count.
+    *   `icn-cli federation sync`: Synchronize federation state with peers.
 *   **Identity Operations:**
     *   `icn-cli identity generate-proof <PROOF_REQUEST_JSON>`: Produce a zero-knowledge proof from the supplied request JSON.
     *   `icn-cli identity verify-proof <PROOF_JSON>`: Verify a proof and print whether it is valid.
+*   **Monitoring:**
+    *   `icn-cli monitor uptime`: Display node uptime using the metrics endpoint.
 *   **Zero-Knowledge Operations:**
     *   `icn-cli zk generate-key`: Generate a Groth16 proving key and output the verifying key signature.
     *   `icn-cli zk analyze <CIRCUIT>`: Count constraints for a circuit.
@@ -38,6 +42,7 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
 *   **Miscellaneous:**
     *   `icn-cli hello`: A simple command to check if the CLI is responsive.
     *   `icn-cli help` or `icn-cli --help`: Displays usage information.
+    *   `icn-cli wizard setup --config <FILE>`: Interactive node setup wizard.
 
 ### Example: Generate and Verify a Proof
 

--- a/crates/icn-cli/tests/federation.rs
+++ b/crates/icn-cli/tests/federation.rs
@@ -20,6 +20,17 @@ async fn federation_commands_work() {
     let base = format!("http://{addr}");
     tokio::task::spawn_blocking(move || {
         Command::new(bin)
+            .args(["--api-url", &base, "federation", "init"])
+            .assert()
+            .success();
+    })
+    .await
+    .unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{addr}");
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
             .args(["--api-url", &base, "federation", "join", "peerA"])
             .assert()
             .success();
@@ -58,6 +69,17 @@ async fn federation_commands_work() {
             .assert()
             .success()
             .stdout(predicates::str::contains("peerA").not());
+    })
+    .await
+    .unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{addr}");
+    tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "federation", "sync"])
+            .assert()
+            .success();
     })
     .await
     .unwrap();

--- a/crates/icn-cli/tests/monitoring.rs
+++ b/crates/icn-cli/tests/monitoring.rs
@@ -1,0 +1,32 @@
+use assert_cmd::prelude::*;
+use icn_node::app_router;
+use std::process::Command;
+use tokio::task;
+
+#[tokio::test]
+#[serial_test::serial]
+async fn monitor_uptime_reports_value() {
+    let _ = std::fs::remove_dir_all("./mana_ledger.sled");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, app_router().await).await.unwrap();
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let bin = env!("CARGO_BIN_EXE_icn-cli");
+    let base = format!("http://{addr}");
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["--api-url", &base, "monitor", "uptime"])
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert!(output.status.success());
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("Uptime"));
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- extend `icn-cli` federation commands with `init` and `sync`
- add monitoring subcommand and setup wizard
- provide federation config template
- expose federation init/sync endpoints in node
- tests for new CLI behaviour

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: command interrupted)*
- `cargo test -p icn-ccl` *(failed)*
- `cargo test --all-features --workspace` *(failed)*
- `just test-ccl-contracts` *(failed: command not found)*
- `just test-covm-execution` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68753cbba12c83249f0f57dff329be24