### PR TITLE
[economics] add mutual aid token and registry

### DIFF
--- a/crates/icn-dag/README.md
+++ b/crates/icn-dag/README.md
@@ -93,6 +93,12 @@ the following deterministic rules when reconciling forks:
 Nodes exchange `DagSyncStatus` information to detect divergence and converge on
 a single history without complex reorganization.
 
+## Mutual Aid Resource Registry
+
+`AidResource` structs can be stored as DAG blocks to advertise resources
+available for community sharing. Each record includes a provider DID, quantity,
+description, and classification tags to support matching.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -23,8 +23,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 /// Helper crate for encoding/decoding root hashes
 pub mod index;
 pub mod metrics;
+pub mod mutual_aid;
 #[cfg(feature = "persist-postgres")]
 pub mod postgres_store;
+pub mod recognition;
 #[cfg(feature = "persist-rocksdb")]
 pub mod rocksdb_store;
 #[cfg(feature = "persist-sled")]

--- a/crates/icn-dag/src/mutual_aid.rs
+++ b/crates/icn-dag/src/mutual_aid.rs
@@ -1,0 +1,18 @@
+use icn_common::Did;
+use serde::{Deserialize, Serialize};
+
+/// Record describing a resource available for mutual aid.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AidResource {
+    /// Unique identifier for the resource record.
+    pub id: String,
+    /// Human readable description.
+    pub description: String,
+    /// DID of the entity offering the resource.
+    pub provider: Did,
+    /// Quantity available, if applicable.
+    pub quantity: u64,
+    /// Arbitrary classification tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}

--- a/crates/icn-economics/README.md
+++ b/crates/icn-economics/README.md
@@ -46,6 +46,13 @@ cargo build --features persist-rocksdb
 When using RocksDB at runtime, pass `--mana-ledger-backend rocksdb` and a path
 ending in `.rocks` to the node binary.
 
+## Mutual Aid Tokens
+
+This crate provides helper functions `grant_mutual_aid` and `use_mutual_aid` for
+minting and burning non-transferable credits under the `mutual_aid` token class.
+These credits facilitate community support but cannot be transferred between
+accounts.
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-economics/src/lib.rs
+++ b/crates/icn-economics/src/lib.rs
@@ -12,10 +12,11 @@ use icn_common::{
 use icn_dag::StorageService;
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
+pub mod explorer;
 pub mod ledger;
 pub mod metrics;
-pub mod explorer;
-pub use explorer::{LedgerExplorer, FlowStats};
+pub mod mutual_aid;
+pub use explorer::{FlowStats, LedgerExplorer};
 pub use ledger::FileManaLedger;
 #[cfg(feature = "persist-rocksdb")]
 pub use ledger::RocksdbManaLedger;
@@ -23,6 +24,7 @@ pub use ledger::RocksdbManaLedger;
 pub use ledger::SledManaLedger;
 #[cfg(feature = "persist-sqlite")]
 pub use ledger::SqliteManaLedger;
+pub use mutual_aid::{grant_mutual_aid, use_mutual_aid, MUTUAL_AID_CLASS};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LedgerEvent {

--- a/crates/icn-economics/src/mutual_aid.rs
+++ b/crates/icn-economics/src/mutual_aid.rs
@@ -1,0 +1,51 @@
+use crate::{
+    burn_tokens, mint_tokens, ManaLedger, NodeScope, ResourceLedger, ResourceRepositoryAdapter,
+};
+use icn_common::{CommonError, Did};
+
+/// Resource class identifier for mutual aid tokens.
+pub const MUTUAL_AID_CLASS: &str = "mutual_aid";
+
+/// Grant non-transferable mutual aid tokens to a recipient.
+///
+/// These tokens represent community support and cannot be transferred between
+/// accounts. They may be minted by authorized issuers and burned when
+/// consumed. The caller is expected to enforce any relevant policies.
+pub fn grant_mutual_aid<L: ResourceLedger, M: ManaLedger>(
+    repo: &ResourceRepositoryAdapter<L>,
+    mana_ledger: &M,
+    issuer: &Did,
+    recipient: &Did,
+    amount: u64,
+    scope: Option<NodeScope>,
+) -> Result<(), CommonError> {
+    mint_tokens(
+        repo,
+        mana_ledger,
+        issuer,
+        MUTUAL_AID_CLASS,
+        amount,
+        recipient,
+        scope,
+    )
+}
+
+/// Consume mutual aid tokens from the owner's balance.
+pub fn use_mutual_aid<L: ResourceLedger, M: ManaLedger>(
+    repo: &ResourceRepositoryAdapter<L>,
+    mana_ledger: &M,
+    issuer: &Did,
+    owner: &Did,
+    amount: u64,
+    scope: Option<NodeScope>,
+) -> Result<(), CommonError> {
+    burn_tokens(
+        repo,
+        mana_ledger,
+        issuer,
+        MUTUAL_AID_CLASS,
+        amount,
+        owner,
+        scope,
+    )
+}

--- a/crates/icn-mesh/src/aid.rs
+++ b/crates/icn-mesh/src/aid.rs
@@ -1,0 +1,40 @@
+use crate::JobSpec;
+use icn_common::Did;
+use serde::{Deserialize, Serialize};
+
+/// Request for community aid.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AidRequest {
+    /// Unique request identifier.
+    pub id: String,
+    /// DID of the requester.
+    pub requester: Did,
+    /// Tags describing needed resources.
+    pub tags: Vec<String>,
+}
+
+/// Template describing a standard aid job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AidJobTemplate {
+    /// Tags covered by this template.
+    pub tags: Vec<String>,
+    /// Job specification to execute when matched.
+    pub job: JobSpec,
+}
+
+/// Match aid requests with job templates.
+pub fn match_aid_requests<'a>(
+    requests: &'a [AidRequest],
+    templates: &'a [AidJobTemplate],
+) -> Vec<(&'a AidRequest, &'a AidJobTemplate)> {
+    let mut matches = Vec::new();
+    for req in requests {
+        for tmpl in templates {
+            if tmpl.tags.iter().any(|t| req.tags.contains(t)) {
+                matches.push((req, tmpl));
+                break;
+            }
+        }
+    }
+    matches
+}

--- a/crates/icn-mesh/tests/aid_match.rs
+++ b/crates/icn-mesh/tests/aid_match.rs
@@ -1,0 +1,27 @@
+use icn_common::Did;
+use icn_mesh::aid::{match_aid_requests, AidJobTemplate, AidRequest};
+use icn_mesh::{JobKind, JobSpec};
+
+#[test]
+fn basic_matching() {
+    let request = AidRequest {
+        id: "req1".into(),
+        requester: Did::default(),
+        tags: vec!["medical".into()],
+    };
+
+    let template = AidJobTemplate {
+        tags: vec!["medical".into(), "supply".into()],
+        job: JobSpec {
+            kind: JobKind::Echo {
+                payload: "hi".into(),
+            },
+            ..Default::default()
+        },
+    };
+
+    let matches = match_aid_requests(&[request.clone()], &[template.clone()]);
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].0.id, request.id);
+    assert_eq!(matches[0].1.tags[0], template.tags[0]);
+}

--- a/scripts/emergency-response.sh
+++ b/scripts/emergency-response.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Simple helper for coordinating emergency aid via the ICN CLI
+
+set -euo pipefail
+
+CMD=${1:-help}
+API_URL=${ICN_API_URL:-"http://127.0.0.1:7845"}
+
+case "$CMD" in
+  list)
+    icn-cli --api-url "$API_URL" emergency list
+    ;;
+  request)
+    shift
+    PAYLOAD=${1:-"-"}
+    icn-cli --api-url "$API_URL" emergency request "$PAYLOAD"
+    ;;
+  *)
+    echo "Usage: $0 [list|request <json-or-'-'>]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- create mutual aid token helpers in `icn-economics`
- record aid resources via new DAG schema
- match aid requests to templates in `icn-mesh`
- expose emergency commands in CLI
- provide helper script for coordination

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: could not compile `icn-network`)*
- `cargo test --all-features --workspace` *(aborted: took too long)*


------
https://chatgpt.com/codex/tasks/task_e_687566e9e1348324b1eb5fcec8558e0e