### PR TITLE
[runtime] include storage requirements in mesh bids

### DIFF
--- a/crates/icn-mesh/benches/select_executor.rs
+++ b/crates/icn-mesh/benches/select_executor.rs
@@ -2,7 +2,9 @@ use criterion::{black_box, criterion_group, criterion_main, BatchSize, Benchmark
 use icn_common::{Cid, Did};
 use icn_economics::ManaLedger;
 use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
-use icn_mesh::{select_executor, JobId, JobSpec, MeshJobBid, Resources, SelectionPolicy, LatencyStore};
+use icn_mesh::{
+    select_executor, JobId, JobSpec, LatencyStore, MeshJobBid, Resources, SelectionPolicy,
+};
 use icn_reputation::InMemoryReputationStore;
 use std::str::FromStr;
 
@@ -19,7 +21,9 @@ struct BenchLatency {
 
 impl BenchLatency {
     fn new() -> Self {
-        Self { inner: std::sync::RwLock::new(std::collections::HashMap::new()) }
+        Self {
+            inner: std::sync::RwLock::new(std::collections::HashMap::new()),
+        }
     }
     fn set_latency(&self, did: Did, latency: u64) {
         self.inner.write().unwrap().insert(did, latency);
@@ -91,6 +95,7 @@ fn bench_select_executor(c: &mut Criterion) {
                     resources: Resources {
                         cpu_cores: 1,
                         memory_mb: 512,
+                        storage_mb: 0,
                     },
                     signature: SignatureBytes(Vec::new()),
                 });
@@ -99,13 +104,7 @@ fn bench_select_executor(c: &mut Criterion) {
                 || bids.clone(),
                 |bids_vec| {
                     black_box(select_executor(
-                        &job_id,
-                        &spec,
-                        bids_vec,
-                        &policy,
-                        &rep_store,
-                        &ledger,
-                        &latency,
+                        &job_id, &spec, bids_vec, &policy, &rep_store, &ledger, &latency,
                     ));
                 },
                 BatchSize::SmallInput,

--- a/crates/icn-mesh/src/lib.rs
+++ b/crates/icn-mesh/src/lib.rs
@@ -45,6 +45,9 @@ pub struct Resources {
     pub cpu_cores: u32,
     /// Amount of memory in megabytes available for the job.
     pub memory_mb: u32,
+    /// Amount of storage in megabytes required or offered for the job.
+    #[serde(default)]
+    pub storage_mb: u32,
 }
 
 /// Represents a job submitted to the ICN mesh computing network.
@@ -193,6 +196,7 @@ impl MeshJobBid {
         bytes.extend_from_slice(&self.price_mana.to_le_bytes());
         bytes.extend_from_slice(&self.resources.cpu_cores.to_le_bytes());
         bytes.extend_from_slice(&self.resources.memory_mb.to_le_bytes());
+        bytes.extend_from_slice(&self.resources.storage_mb.to_le_bytes());
         Ok(bytes)
     }
 

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -2602,6 +2602,7 @@ async fn mesh_stub_bid_handler(
         resources: icn_mesh::Resources {
             cpu_cores: 1,
             memory_mb: 128,
+            storage_mb: 0,
         },
         signature: icn_identity::SignatureBytes(vec![0; 64]), // Dummy signature for testing
     };

--- a/crates/icn-node/tests/stub_endpoints_test.rs
+++ b/crates/icn-node/tests/stub_endpoints_test.rs
@@ -41,7 +41,7 @@ async fn test_stub_endpoints_full_lifecycle() {
                 kind: icn_mesh::JobKind::Echo { payload: "testing".into() },
                 inputs: vec![],
                 outputs: vec!["result".into()],
-                required_resources: icn_mesh::Resources { cpu_cores: 1, memory_mb: 128 },
+                required_resources: icn_mesh::Resources { cpu_cores: 1, memory_mb: 128, storage_mb: 0 },
             }).unwrap()),
             "spec_json": null,
             "cost_mana": 10

--- a/crates/icn-runtime/src/context/mesh_network.rs
+++ b/crates/icn-runtime/src/context/mesh_network.rs
@@ -170,7 +170,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             required_resources: icn_protocol::ResourceRequirements {
                 cpu_cores: job.spec.required_resources.cpu_cores,
                 memory_mb: job.spec.required_resources.memory_mb,
-                storage_mb: 0,                // TODO: Add storage to job spec
+                storage_mb: job.spec.required_resources.storage_mb,
                 max_execution_time_secs: 300, // 5 minutes default
             },
         };
@@ -299,6 +299,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
                                 resources: icn_mesh::Resources {
                                     cpu_cores: bid_message.offered_resources.cpu_cores,
                                     memory_mb: bid_message.offered_resources.memory_mb,
+                                    storage_mb: bid_message.offered_resources.storage_mb,
                                 },
                                 signature: icn_identity::SignatureBytes(vec![]), // TODO: Extract from message signature
                             };
@@ -346,7 +347,7 @@ impl MeshNetworkService for DefaultMeshNetworkService {
             offered_resources: icn_protocol::ResourceRequirements {
                 cpu_cores: bid.resources.cpu_cores,
                 memory_mb: bid.resources.memory_mb,
-                storage_mb: 0,                // TODO: Add storage to Resources
+                storage_mb: bid.resources.storage_mb,
                 max_execution_time_secs: 300, // 5 minutes default
             },
             reputation_score: 100, // TODO: Get actual reputation score

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -12,9 +12,8 @@ use super::{DagStorageService, DagStoreMutexType};
 use crate::metrics::{JOBS_ACTIVE_GAUGE, JOBS_COMPLETED, JOBS_FAILED, JOBS_SUBMITTED};
 use bincode;
 use dashmap::DashMap;
-use icn_common::{Cid, CommonError, DagBlock, Did, compute_merkle_cid};
-use icn_economics::{ManaLedger, LedgerEvent};
-use serde_json;
+use icn_common::{compute_merkle_cid, Cid, CommonError, DagBlock, Did};
+use icn_economics::{LedgerEvent, ManaLedger};
 use icn_governance::GovernanceModule;
 use icn_identity::ExecutionReceipt as IdentityExecutionReceipt;
 use icn_mesh::metrics::{
@@ -26,6 +25,7 @@ use icn_mesh::{
     ActualMeshJob, Job, JobAssignment, JobBid, JobId, JobLifecycle, JobLifecycleStatus, JobReceipt,
     JobState,
 };
+use serde_json;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
@@ -2696,6 +2696,7 @@ impl RuntimeContext {
             resources: icn_mesh::Resources {
                 cpu_cores: available_cpu,
                 memory_mb: available_memory,
+                storage_mb: 0,
             },
             signature: icn_identity::SignatureBytes(vec![]), // Will be filled by sign()
         };
@@ -2778,6 +2779,7 @@ impl RuntimeContext {
                 required_resources: icn_mesh::Resources {
                     cpu_cores: 1,
                     memory_mb: 128,
+                    storage_mb: 0,
                 },
             },
             creator_did: icn_common::Did::new("key", "placeholder"), // We don't know the creator from assignment
@@ -2848,6 +2850,7 @@ impl RuntimeContext {
             resources: icn_mesh::Resources {
                 cpu_cores: available_cpu,
                 memory_mb: available_memory,
+                storage_mb: 0,
             },
             signature: icn_identity::SignatureBytes(vec![]), // Will be filled by sign()
         };

--- a/crates/icn-runtime/tests/manual_bid_injection.rs
+++ b/crates/icn-runtime/tests/manual_bid_injection.rs
@@ -1,10 +1,10 @@
-use icn_runtime::context::{
-    RuntimeContext, StubMeshNetworkService, MeshNetworkServiceType, 
-    MeshNetworkService, LocalMeshSubmitReceiptMessage
-};
-use icn_mesh::{JobId, MeshJobBid, Resources, JobSpec, JobKind, ActualMeshJob};
+use icn_common::{Cid, Did};
 use icn_identity::{ExecutionReceipt, SignatureBytes};
-use icn_common::{Did, Cid};
+use icn_mesh::{ActualMeshJob, JobId, JobKind, JobSpec, MeshJobBid, Resources};
+use icn_runtime::context::{
+    LocalMeshSubmitReceiptMessage, MeshNetworkService, MeshNetworkServiceType, RuntimeContext,
+    StubMeshNetworkService,
+};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,26 +23,26 @@ async fn test_manual_bid_injection_full_lifecycle() {
     println!("=== Manual Bid Injection Test ===");
 
     // Create a test runtime context with stub services
-    let submitter_did = Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap();
+    let submitter_did =
+        Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap();
     let mut context = RuntimeContext::new_testing(submitter_did.clone(), Some(1000))
         .expect("Failed to create test context");
 
     // Get the stub network service for manual bid injection
     let stub_service = get_stub_network_service(&context);
-    
+
     println!("✅ Test context created with StubMeshNetworkService");
 
     // Create a test job
     let test_job = create_test_echo_job(&submitter_did);
     let job_id = test_job.id.clone();
-    
+
     println!("📝 Created test job: {:?}", job_id);
 
     // Submit the job to start the lifecycle
     let job_manager = context.clone();
-    let job_handle = tokio::spawn(async move {
-        job_manager.handle_mesh_job_lifecycle(test_job).await
-    });
+    let job_handle =
+        tokio::spawn(async move { job_manager.handle_mesh_job_lifecycle(test_job).await });
 
     // Give the job manager a moment to announce the job
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -50,16 +50,23 @@ async fn test_manual_bid_injection_full_lifecycle() {
     // Verify the job was announced
     let announced_jobs = stub_service.get_announced_jobs().await;
     assert_eq!(announced_jobs.len(), 1, "Job should be announced");
-    assert_eq!(announced_jobs[0].id, job_id, "Announced job should match submitted job");
+    assert_eq!(
+        announced_jobs[0].id, job_id,
+        "Announced job should match submitted job"
+    );
     println!("📢 Job announced successfully");
 
     // Manually inject multiple bids for the job
     let test_bids = create_test_bids(&job_id);
-    
+
     for (i, bid) in test_bids.iter().enumerate() {
         stub_service.stage_bid(job_id.clone(), bid.clone()).await;
-        println!("💰 Injected bid {}: {} mana from {}", 
-                i+1, bid.price_mana, bid.executor_did);
+        println!(
+            "💰 Injected bid {}: {} mana from {}",
+            i + 1,
+            bid.price_mana,
+            bid.executor_did
+        );
     }
 
     println!("✅ Injected {} bids for job {:?}", test_bids.len(), job_id);
@@ -70,22 +77,26 @@ async fn test_manual_bid_injection_full_lifecycle() {
     // The job manager should select the best executor (lowest price)
     let best_bid = test_bids.iter().min_by_key(|bid| bid.price_mana).unwrap();
     let selected_executor = &best_bid.executor_did;
-    
-    println!("🎯 Expected selected executor: {} (price: {} mana)", 
-             selected_executor, best_bid.price_mana);
+
+    println!(
+        "🎯 Expected selected executor: {} (price: {} mana)",
+        selected_executor, best_bid.price_mana
+    );
 
     // Create and inject an execution receipt from the selected executor
     let receipt = create_test_receipt(&job_id, selected_executor);
     let receipt_message = LocalMeshSubmitReceiptMessage {
         receipt: receipt.clone(),
     };
-    
-    stub_service.stage_receipt(job_id.clone(), receipt_message).await;
+
+    stub_service
+        .stage_receipt(job_id.clone(), receipt_message)
+        .await;
     println!("📋 Injected execution receipt from {}", selected_executor);
 
     // Wait for the job lifecycle to complete
     let result = timeout(Duration::from_secs(10), job_handle).await;
-    
+
     match result {
         Ok(Ok(())) => {
             println!("✅ Job lifecycle completed successfully!");
@@ -100,30 +111,53 @@ async fn test_manual_bid_injection_full_lifecycle() {
 
     // Verify the assignment notice was sent
     let assignment_notices = stub_service.get_assignment_notices().await;
-    assert_eq!(assignment_notices.len(), 1, "Should have one assignment notice");
-    assert_eq!(assignment_notices[0].executor_did, *selected_executor, 
-               "Assignment should go to selected executor");
-    assert_eq!(assignment_notices[0].agreed_cost_mana, best_bid.price_mana,
-               "Assignment should have agreed cost");
-    
-    println!("🎯 Assignment notice verified: executor={}, cost={} mana", 
-             assignment_notices[0].executor_did, assignment_notices[0].agreed_cost_mana);
+    assert_eq!(
+        assignment_notices.len(),
+        1,
+        "Should have one assignment notice"
+    );
+    assert_eq!(
+        assignment_notices[0].executor_did, *selected_executor,
+        "Assignment should go to selected executor"
+    );
+    assert_eq!(
+        assignment_notices[0].agreed_cost_mana, best_bid.price_mana,
+        "Assignment should have agreed cost"
+    );
+
+    println!(
+        "🎯 Assignment notice verified: executor={}, cost={} mana",
+        assignment_notices[0].executor_did, assignment_notices[0].agreed_cost_mana
+    );
 
     // Check final mana balances
-    let submitter_balance = context.get_mana_balance(&submitter_did).await
+    let submitter_balance = context
+        .get_mana_balance(&submitter_did)
+        .await
         .expect("Failed to get submitter balance");
-    let executor_balance = context.get_mana_balance(selected_executor).await
+    let executor_balance = context
+        .get_mana_balance(selected_executor)
+        .await
         .expect("Failed to get executor balance");
 
     println!("💰 Final balances:");
-    println!("  Submitter ({}): {} mana", submitter_did, submitter_balance);
-    println!("  Executor ({}): {} mana", selected_executor, executor_balance);
+    println!(
+        "  Submitter ({}): {} mana",
+        submitter_did, submitter_balance
+    );
+    println!(
+        "  Executor ({}): {} mana",
+        selected_executor, executor_balance
+    );
 
     // Submitter should have been charged
     assert!(submitter_balance < 1000, "Submitter should be charged mana");
-    
+
     // Executor should have been paid (they start with 0, so should now have the agreed cost)
-    assert_eq!(executor_balance, best_bid.price_mana, "Executor should be paid agreed amount");
+    assert_eq!(
+        executor_balance, best_bid.price_mana,
+        "Executor should be paid agreed amount"
+    );
 
     println!("✅ Manual bid injection test completed successfully!");
 }
@@ -138,24 +172,24 @@ async fn test_no_bids_timeout() {
 
     println!("=== No Bids Timeout Test ===");
 
-    let submitter_did = Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap();
+    let submitter_did =
+        Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap();
     let context = RuntimeContext::new_testing(submitter_did.clone(), Some(1000))
         .expect("Failed to create test context");
 
     let test_job = create_test_echo_job(&submitter_did);
     let job_id = test_job.id.clone();
-    
+
     println!("📝 Created test job: {:?}", job_id);
 
     // Submit job but don't inject any bids
     let job_manager = context.clone();
-    let job_handle = tokio::spawn(async move {
-        job_manager.handle_mesh_job_lifecycle(test_job).await
-    });
+    let job_handle =
+        tokio::spawn(async move { job_manager.handle_mesh_job_lifecycle(test_job).await });
 
     // Wait for the job to timeout (should be quick since no bids)
     let result = timeout(Duration::from_secs(45), job_handle).await;
-    
+
     match result {
         Ok(Ok(())) => {
             // This is expected - the job should complete (fail) when no bids are received
@@ -170,12 +204,17 @@ async fn test_no_bids_timeout() {
     }
 
     // Check that submitter's mana was refunded (since job failed due to no bids)
-    let final_balance = context.get_mana_balance(&submitter_did).await
+    let final_balance = context
+        .get_mana_balance(&submitter_did)
+        .await
         .expect("Failed to get final balance");
-    
+
     println!("💰 Final submitter balance: {} mana", final_balance);
     // Balance should be close to original (may be slightly less due to announcement cost)
-    assert!(final_balance >= 990, "Submitter should get most mana back when no bids");
+    assert!(
+        final_balance >= 990,
+        "Submitter should get most mana back when no bids"
+    );
 
     println!("✅ No bids timeout test completed successfully!");
 }
@@ -190,7 +229,8 @@ async fn test_multiple_jobs_selective_bidding() {
 
     println!("=== Multiple Jobs Selective Bidding Test ===");
 
-    let submitter_did = Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap();
+    let submitter_did =
+        Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH").unwrap();
     let context = RuntimeContext::new_testing(submitter_did.clone(), Some(2000))
         .expect("Failed to create test context");
 
@@ -207,14 +247,10 @@ async fn test_multiple_jobs_selective_bidding() {
     // Start both jobs
     let context1 = context.clone();
     let context2 = context.clone();
-    
-    let job1_handle = tokio::spawn(async move {
-        context1.handle_mesh_job_lifecycle(job1).await
-    });
-    
-    let job2_handle = tokio::spawn(async move {
-        context2.handle_mesh_job_lifecycle(job2).await
-    });
+
+    let job1_handle = tokio::spawn(async move { context1.handle_mesh_job_lifecycle(job1).await });
+
+    let job2_handle = tokio::spawn(async move { context2.handle_mesh_job_lifecycle(job2).await });
 
     // Wait for announcements
     tokio::time::sleep(Duration::from_millis(500)).await;
@@ -224,13 +260,18 @@ async fn test_multiple_jobs_selective_bidding() {
     for bid in job1_bids.iter() {
         stub_service.stage_bid(job1_id.clone(), bid.clone()).await;
     }
-    
+
     // Create receipt for job1
     let best_bid = job1_bids.iter().min_by_key(|bid| bid.price_mana).unwrap();
     let receipt = create_test_receipt(&job1_id, &best_bid.executor_did);
-    stub_service.stage_receipt(job1_id.clone(), LocalMeshSubmitReceiptMessage {
-        receipt: receipt.clone(),
-    }).await;
+    stub_service
+        .stage_receipt(
+            job1_id.clone(),
+            LocalMeshSubmitReceiptMessage {
+                receipt: receipt.clone(),
+            },
+        )
+        .await;
 
     println!("💰 Injected bids and receipt for job1 only");
 
@@ -266,7 +307,8 @@ fn get_stub_network_service(context: &Arc<RuntimeContext>) -> Arc<StubMeshNetwor
 fn create_test_echo_job(submitter_did: &Did) -> ActualMeshJob {
     ActualMeshJob {
         id: JobId::new(),
-        manifest_cid: Cid::from_str("bafybeigdyrztktx5b5m2y4sogf2hf5uq3k5knv5c5k2pvx7aq5w3sh7g5e").unwrap(),
+        manifest_cid: Cid::from_str("bafybeigdyrztktx5b5m2y4sogf2hf5uq3k5knv5c5k2pvx7aq5w3sh7g5e")
+            .unwrap(),
         creator_did: submitter_did.clone(),
         cost_mana: 50,
         spec: JobSpec {
@@ -278,6 +320,7 @@ fn create_test_echo_job(submitter_did: &Did) -> ActualMeshJob {
             required_resources: icn_mesh::Resources {
                 cpu_cores: 1,
                 memory_mb: 100,
+                storage_mb: 0,
             },
         },
     }
@@ -287,31 +330,37 @@ fn create_test_bids(job_id: &JobId) -> Vec<MeshJobBid> {
     vec![
         MeshJobBid {
             job_id: job_id.clone(),
-            executor_did: Did::from_str("did:key:z6MkrJvwAfLVgFntBzYCBLXXNGMNPdpJcRw4Qc9vq8vN8oSz").unwrap(),
+            executor_did: Did::from_str("did:key:z6MkrJvwAfLVgFntBzYCBLXXNGMNPdpJcRw4Qc9vq8vN8oSz")
+                .unwrap(),
             price_mana: 30, // Lowest price - should be selected
             resources: Resources {
                 cpu_cores: 1,
                 memory_mb: 100,
+                storage_mb: 0,
             },
             signature: SignatureBytes(vec![]),
         },
         MeshJobBid {
             job_id: job_id.clone(),
-            executor_did: Did::from_str("did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM").unwrap(),
+            executor_did: Did::from_str("did:key:z6MkoTHsgNNrby8JzCNQ1iRLyW5QQ6R8Xuu6AA8igGrMVPUM")
+                .unwrap(),
             price_mana: 40,
             resources: Resources {
                 cpu_cores: 1,
                 memory_mb: 120,
+                storage_mb: 0,
             },
             signature: SignatureBytes(vec![]),
         },
         MeshJobBid {
             job_id: job_id.clone(),
-            executor_did: Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktM").unwrap(),
+            executor_did: Did::from_str("did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktM")
+                .unwrap(),
             price_mana: 35,
             resources: Resources {
                 cpu_cores: 2,
                 memory_mb: 150,
+                storage_mb: 0,
             },
             signature: SignatureBytes(vec![]),
         },
@@ -322,9 +371,10 @@ fn create_test_receipt(job_id: &JobId, executor_did: &Did) -> ExecutionReceipt {
     ExecutionReceipt {
         job_id: Cid::from(job_id.clone()),
         executor_did: executor_did.clone(),
-        result_cid: Cid::from_str("bafybeigdyrztktx5b5m2y4sogf2hf5uq3k5knv5c5k2pvx7aq5w3sh7g5e").unwrap(),
+        result_cid: Cid::from_str("bafybeigdyrztktx5b5m2y4sogf2hf5uq3k5knv5c5k2pvx7aq5w3sh7g5e")
+            .unwrap(),
         cpu_ms: 150,
         success: true,
         signature: SignatureBytes(vec![]),
     }
-} 
+}

--- a/crates/icn-runtime/tests/wasm_executor.rs
+++ b/crates/icn-runtime/tests/wasm_executor.rs
@@ -2,8 +2,8 @@ use icn_common::{compute_merkle_cid, Cid, DagBlock, Did};
 use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
 use icn_mesh::{ActualMeshJob, JobId, JobKind, JobSpec};
 use icn_runtime::context::{RuntimeContext, StubSigner};
-use icn_runtime::executor::{WasmExecutorConfig, WasmSecurityLimits};
 use icn_runtime::executor::{JobExecutor, WasmExecutor};
+use icn_runtime::executor::{WasmExecutorConfig, WasmSecurityLimits};
 use icn_runtime::host_submit_mesh_job;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -126,6 +126,7 @@ async fn wasm_executor_host_submit_mesh_job_json() {
             required_resources: Resources {
                 cpu_cores: 2,
                 memory_mb: 256,
+                storage_mb: 0,
             },
         },
         creator_did: node_did.clone(),

--- a/tests/integration/comprehensive_e2e.rs
+++ b/tests/integration/comprehensive_e2e.rs
@@ -1,836 +1,957 @@
 #[cfg(feature = "enable-libp2p")]
 mod comprehensive_e2e_test {
+    use base64::{engine::general_purpose, Engine};
     use reqwest::Client;
     use serde_json::{json, Value};
     use std::collections::HashMap;
     use std::process::Command;
     use std::time::{Duration, Instant};
     use tokio::time::sleep;
-    use base64::{Engine, engine::general_purpose};
 
-/// Comprehensive end-to-end test for ICN mesh job lifecycle
-/// 
-/// This test validates:
-/// 1. Multi-node federation setup and convergence
-/// 2. Complete mesh job lifecycle (submit → bid → execute → complete)
-/// 3. DAG receipt anchoring and queries
-/// 4. Mana balance tracking and automatic refunds
-/// 5. Prometheus metrics collection
-/// 6. Performance under load
-/// 
-/// Test Architecture:
-/// - 3-node federation (Node A: submitter, Node B/C: executors)
-/// - Real computational jobs (Echo and CclWasm)
-/// - Metrics collection via Prometheus
-/// - DAG integrity validation
-/// - Mana economics validation
-#[tokio::test]
-async fn comprehensive_mesh_job_e2e_test() {
-    // Start federation with monitoring
-    let test_harness = E2ETestHarness::new().await;
-    
-    println!("🚀 Starting comprehensive ICN mesh job E2E test");
-    
-    // Phase 1: Federation Health and Convergence
-    test_harness.validate_federation_health().await;
-    test_harness.validate_p2p_convergence().await;
-    test_harness.validate_metrics_collection().await;
-    
-    // Phase 2: Single Job Lifecycle
-    let job_result = test_harness.execute_single_job_lifecycle().await;
-    test_harness.validate_job_result(&job_result).await;
-    
-    // Phase 3: Mana Economics Validation
-    test_harness.validate_mana_economics(&job_result).await;
-    
-    // Phase 4: DAG and Receipt Validation
-    test_harness.validate_dag_integrity(&job_result).await;
-    
-    // Phase 5: Load Testing
-    test_harness.execute_load_test().await;
-    
-    // Phase 6: Performance Validation
-    test_harness.validate_performance_metrics().await;
-    
-    println!("✅ Comprehensive E2E test completed successfully");
-}
-
-/// Test harness for comprehensive end-to-end testing
-struct E2ETestHarness {
-    client: Client,
-    nodes: Vec<NodeConfig>,
-    #[allow(dead_code)]
-    start_time: Instant,
-    test_id: String,
-}
-
-#[derive(Clone)]
-struct NodeConfig {
-    name: String,
-    url: String,
-    api_key: String,
-    #[allow(dead_code)]
-    role: NodeRole,
-}
-
-#[derive(Clone)]
-enum NodeRole {
-    Bootstrap,
-    Executor,
-    #[allow(dead_code)]
-    Observer,
-}
-
-#[derive(Debug)]
-struct JobResult {
-    job_id: String,
-    #[allow(dead_code)]
-    submitter_node: String,
-    executor_node: String,
-    #[allow(dead_code)]
-    submission_time: Instant,
-    completion_time: Option<Instant>,
-    mana_spent: u64,
-    #[allow(dead_code)]
-    mana_refunded: u64,
-    receipt_cid: Option<String>,
-    execution_result: Option<Value>,
-}
-
-#[derive(Debug)]
-#[allow(dead_code)]
-struct MetricsSnapshot {
-    jobs_submitted: u64,
-    jobs_completed: u64,
-    jobs_failed: u64,
-    mana_balance_total: u64,
-    peer_count: u64,
-    dag_blocks: u64,
-    network_latency_avg: f64,
-}
-
-impl E2ETestHarness {
-    /// Initialize test harness with federation setup
-    async fn new() -> Self {
-        let test_id = format!("e2e-{}", chrono::Utc::now().timestamp());
-        
+    /// Comprehensive end-to-end test for ICN mesh job lifecycle
+    ///
+    /// This test validates:
+    /// 1. Multi-node federation setup and convergence
+    /// 2. Complete mesh job lifecycle (submit → bid → execute → complete)
+    /// 3. DAG receipt anchoring and queries
+    /// 4. Mana balance tracking and automatic refunds
+    /// 5. Prometheus metrics collection
+    /// 6. Performance under load
+    ///
+    /// Test Architecture:
+    /// - 3-node federation (Node A: submitter, Node B/C: executors)
+    /// - Real computational jobs (Echo and CclWasm)
+    /// - Metrics collection via Prometheus
+    /// - DAG integrity validation
+    /// - Mana economics validation
+    #[tokio::test]
+    async fn comprehensive_mesh_job_e2e_test() {
         // Start federation with monitoring
-        Self::start_federation_with_monitoring().await;
-        
-        let nodes = vec![
-            NodeConfig {
-                name: "Node-A".to_string(),
-                url: "http://localhost:5001".to_string(),
-                api_key: "devnet-a-key".to_string(),
-                role: NodeRole::Bootstrap,
-            },
-            NodeConfig {
-                name: "Node-B".to_string(),
-                url: "http://localhost:5002".to_string(),
-                api_key: "devnet-b-key".to_string(),
-                role: NodeRole::Executor,
-            },
-            NodeConfig {
-                name: "Node-C".to_string(),
-                url: "http://localhost:5003".to_string(),
-                api_key: "devnet-c-key".to_string(),
-                role: NodeRole::Executor,
-            },
-        ];
-        
-        let client = Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .expect("Failed to create HTTP client");
-        
-        Self {
-            client,
-            nodes,
-            start_time: Instant::now(),
-            test_id,
-        }
+        let test_harness = E2ETestHarness::new().await;
+
+        println!("🚀 Starting comprehensive ICN mesh job E2E test");
+
+        // Phase 1: Federation Health and Convergence
+        test_harness.validate_federation_health().await;
+        test_harness.validate_p2p_convergence().await;
+        test_harness.validate_metrics_collection().await;
+
+        // Phase 2: Single Job Lifecycle
+        let job_result = test_harness.execute_single_job_lifecycle().await;
+        test_harness.validate_job_result(&job_result).await;
+
+        // Phase 3: Mana Economics Validation
+        test_harness.validate_mana_economics(&job_result).await;
+
+        // Phase 4: DAG and Receipt Validation
+        test_harness.validate_dag_integrity(&job_result).await;
+
+        // Phase 5: Load Testing
+        test_harness.execute_load_test().await;
+
+        // Phase 6: Performance Validation
+        test_harness.validate_performance_metrics().await;
+
+        println!("✅ Comprehensive E2E test completed successfully");
     }
-    
-    /// Start federation with monitoring stack
-    async fn start_federation_with_monitoring() {
-        // Check if already running
-        if std::env::var("ICN_DEVNET_RUNNING").is_ok() {
-            return;
-        }
-        
-        println!("🔧 Starting federation with monitoring stack...");
-        
-        // Start with monitoring profile
-        let status = Command::new("docker-compose")
-            .args(&[
-                "-f", "icn-devnet/docker-compose.yml",
-                "--profile", "monitoring",
-                "up", "-d"
-            ])
-            .current_dir("..") // Go up one level from tests/ to project root
-            .status()
-            .expect("Failed to start federation");
-        
-        if !status.success() {
-            panic!("Failed to start federation devnet");
-        }
-        
-          // Wait for health checks with efficient polling
-        Self::wait_for_federation_ready().await;
-        
-        println!("✅ Federation with monitoring started");
+
+    /// Test harness for comprehensive end-to-end testing
+    struct E2ETestHarness {
+        client: Client,
+        nodes: Vec<NodeConfig>,
+        #[allow(dead_code)]
+        start_time: Instant,
+        test_id: String,
     }
-    
-    /// Wait for federation to be ready by polling health endpoints
-    async fn wait_for_federation_ready() {
-        println!("⏳ Waiting for federation nodes to be ready...");
-        
-        let nodes = vec![
-            ("Node-A", "http://localhost:5001", "devnet-a-key"),
-            ("Node-B", "http://localhost:5002", "devnet-b-key"),
-            ("Node-C", "http://localhost:5003", "devnet-c-key"),
-        ];
-        
-        let client = Client::builder()
-            .timeout(Duration::from_secs(5))
-            .build()
-            .expect("Failed to create HTTP client");
-        
-        const MAX_RETRIES: u32 = 60; // Max 5 minutes
-        const RETRY_DELAY: Duration = Duration::from_secs(5);
-        
-        for attempt in 1..=MAX_RETRIES {
-            let mut all_ready = true;
-            
-            for (name, url, api_key) in &nodes {
-                match client
-                    .get(&format!("{}/info", url))
-                    .header("X-API-Key", *api_key)
-                    .send()
-                    .await
-                {
-                    Ok(response) if response.status() == 200 => {
-                        // Node is ready
-                        if attempt == 1 {
-                            println!("  ✅ {} is ready", name);
+
+    #[derive(Clone)]
+    struct NodeConfig {
+        name: String,
+        url: String,
+        api_key: String,
+        #[allow(dead_code)]
+        role: NodeRole,
+    }
+
+    #[derive(Clone)]
+    enum NodeRole {
+        Bootstrap,
+        Executor,
+        #[allow(dead_code)]
+        Observer,
+    }
+
+    #[derive(Debug)]
+    struct JobResult {
+        job_id: String,
+        #[allow(dead_code)]
+        submitter_node: String,
+        executor_node: String,
+        #[allow(dead_code)]
+        submission_time: Instant,
+        completion_time: Option<Instant>,
+        mana_spent: u64,
+        #[allow(dead_code)]
+        mana_refunded: u64,
+        receipt_cid: Option<String>,
+        execution_result: Option<Value>,
+    }
+
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct MetricsSnapshot {
+        jobs_submitted: u64,
+        jobs_completed: u64,
+        jobs_failed: u64,
+        mana_balance_total: u64,
+        peer_count: u64,
+        dag_blocks: u64,
+        network_latency_avg: f64,
+    }
+
+    impl E2ETestHarness {
+        /// Initialize test harness with federation setup
+        async fn new() -> Self {
+            let test_id = format!("e2e-{}", chrono::Utc::now().timestamp());
+
+            // Start federation with monitoring
+            Self::start_federation_with_monitoring().await;
+
+            let nodes = vec![
+                NodeConfig {
+                    name: "Node-A".to_string(),
+                    url: "http://localhost:5001".to_string(),
+                    api_key: "devnet-a-key".to_string(),
+                    role: NodeRole::Bootstrap,
+                },
+                NodeConfig {
+                    name: "Node-B".to_string(),
+                    url: "http://localhost:5002".to_string(),
+                    api_key: "devnet-b-key".to_string(),
+                    role: NodeRole::Executor,
+                },
+                NodeConfig {
+                    name: "Node-C".to_string(),
+                    url: "http://localhost:5003".to_string(),
+                    api_key: "devnet-c-key".to_string(),
+                    role: NodeRole::Executor,
+                },
+            ];
+
+            let client = Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("Failed to create HTTP client");
+
+            Self {
+                client,
+                nodes,
+                start_time: Instant::now(),
+                test_id,
+            }
+        }
+
+        /// Start federation with monitoring stack
+        async fn start_federation_with_monitoring() {
+            // Check if already running
+            if std::env::var("ICN_DEVNET_RUNNING").is_ok() {
+                return;
+            }
+
+            println!("🔧 Starting federation with monitoring stack...");
+
+            // Start with monitoring profile
+            let status = Command::new("docker-compose")
+                .args(&[
+                    "-f",
+                    "icn-devnet/docker-compose.yml",
+                    "--profile",
+                    "monitoring",
+                    "up",
+                    "-d",
+                ])
+                .current_dir("..") // Go up one level from tests/ to project root
+                .status()
+                .expect("Failed to start federation");
+
+            if !status.success() {
+                panic!("Failed to start federation devnet");
+            }
+
+            // Wait for health checks with efficient polling
+            Self::wait_for_federation_ready().await;
+
+            println!("✅ Federation with monitoring started");
+        }
+
+        /// Wait for federation to be ready by polling health endpoints
+        async fn wait_for_federation_ready() {
+            println!("⏳ Waiting for federation nodes to be ready...");
+
+            let nodes = vec![
+                ("Node-A", "http://localhost:5001", "devnet-a-key"),
+                ("Node-B", "http://localhost:5002", "devnet-b-key"),
+                ("Node-C", "http://localhost:5003", "devnet-c-key"),
+            ];
+
+            let client = Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+                .expect("Failed to create HTTP client");
+
+            const MAX_RETRIES: u32 = 60; // Max 5 minutes
+            const RETRY_DELAY: Duration = Duration::from_secs(5);
+
+            for attempt in 1..=MAX_RETRIES {
+                let mut all_ready = true;
+
+                for (name, url, api_key) in &nodes {
+                    match client
+                        .get(&format!("{}/info", url))
+                        .header("X-API-Key", *api_key)
+                        .send()
+                        .await
+                    {
+                        Ok(response) if response.status() == 200 => {
+                            // Node is ready
+                            if attempt == 1 {
+                                println!("  ✅ {} is ready", name);
+                            }
                         }
-                    }
-                    _ => {
-                        all_ready = false;
-                        if attempt == 1 || attempt % 6 == 0 {
-                            println!("  ⏳ {} not ready yet (attempt {})", name, attempt);
+                        _ => {
+                            all_ready = false;
+                            if attempt == 1 || attempt % 6 == 0 {
+                                println!("  ⏳ {} not ready yet (attempt {})", name, attempt);
+                            }
                         }
                     }
                 }
+
+                if all_ready {
+                    println!("✅ All nodes are ready after {} attempts", attempt);
+                    return;
+                }
+
+                if attempt < MAX_RETRIES {
+                    sleep(RETRY_DELAY).await;
+                }
             }
-            
-            if all_ready {
-                println!("✅ All nodes are ready after {} attempts", attempt);
-                return;
-            }
-            
-            if attempt < MAX_RETRIES {
-                sleep(RETRY_DELAY).await;
-            }
+
+            panic!(
+                "❌ Federation failed to start within {} attempts",
+                MAX_RETRIES
+            );
         }
-        
-        panic!("❌ Federation failed to start within {} attempts", MAX_RETRIES);
-    }
-    
-    /// Validate federation health across all nodes
-    async fn validate_federation_health(&self) {
-        println!("🏥 Validating federation health...");
-        
-        for node in &self.nodes {
-            let response = self.client
-                .get(&format!("{}/info", node.url))
-                .header("X-API-Key", &node.api_key)
-                .send()
-                .await
-                .expect(&format!("Failed to connect to {}", node.name));
-            
-            assert_eq!(response.status(), 200, "Node {} health check failed", node.name);
-            
-            let info: Value = response.json().await
-                .expect(&format!("Failed to parse info from {}", node.name));
-            
-            assert!(info["name"].is_string(), "Node {} missing name", node.name);
-            assert!(info["version"].is_string(), "Node {} missing version", node.name);
-            
-            println!("  ✅ {} is healthy", node.name);
-        }
-        
-        println!("✅ All nodes are healthy");
-    }
-    
-    /// Validate P2P network convergence
-    async fn validate_p2p_convergence(&self) {
-        println!("🌐 Validating P2P network convergence...");
-        
-        const MAX_RETRIES: u32 = 20;
-        const RETRY_DELAY: Duration = Duration::from_secs(3);
-        
-        for attempt in 1..=MAX_RETRIES {
-            let mut all_connected = true;
-            let mut peer_counts = Vec::new();
-            
+
+        /// Validate federation health across all nodes
+        async fn validate_federation_health(&self) {
+            println!("🏥 Validating federation health...");
+
             for node in &self.nodes {
-                let response = self.client
-                    .get(&format!("{}/status", node.url))
+                let response = self
+                    .client
+                    .get(&format!("{}/info", node.url))
                     .header("X-API-Key", &node.api_key)
                     .send()
                     .await
-                    .expect(&format!("Failed to get status from {}", node.name));
-                
-                let status: Value = response.json().await
-                    .expect(&format!("Failed to parse status from {}", node.name));
-                
-                let peer_count = status["peer_count"].as_u64().unwrap_or(0);
-                peer_counts.push((node.name.clone(), peer_count));
-                
-                // Each node should have at least 1 peer
-                if peer_count == 0 {
-                    all_connected = false;
-                }
+                    .expect(&format!("Failed to connect to {}", node.name));
+
+                assert_eq!(
+                    response.status(),
+                    200,
+                    "Node {} health check failed",
+                    node.name
+                );
+
+                let info: Value = response
+                    .json()
+                    .await
+                    .expect(&format!("Failed to parse info from {}", node.name));
+
+                assert!(info["name"].is_string(), "Node {} missing name", node.name);
+                assert!(
+                    info["version"].is_string(),
+                    "Node {} missing version",
+                    node.name
+                );
+
+                println!("  ✅ {} is healthy", node.name);
             }
-            
-            println!("  Attempt {}/{}: Peer counts: {:?}", attempt, MAX_RETRIES, peer_counts);
-            
-            if all_connected {
-                println!("✅ P2P network has converged");
-                return;
-            }
-            
-            if attempt < MAX_RETRIES {
-                sleep(RETRY_DELAY).await;
-            }
+
+            println!("✅ All nodes are healthy");
         }
-        
-        panic!("❌ P2P network failed to converge within {} attempts", MAX_RETRIES);
-    }
-    
-    /// Validate Prometheus metrics collection
-    async fn validate_metrics_collection(&self) {
-        println!("📊 Validating Prometheus metrics collection...");
-        
-        // Check Prometheus is running
-        let prometheus_url = "http://localhost:9090";
-        let response = self.client
-            .get(&format!("{}/api/v1/query", prometheus_url))
-            .query(&[("query", "up")])
-            .send()
-            .await
-            .expect("Failed to connect to Prometheus");
-        
-        assert_eq!(response.status(), 200, "Prometheus not accessible");
-        
-        // Check nodes are being scraped
-        for node in &self.nodes {
-            let metrics_response = self.client
-                .get(&format!("{}/metrics", node.url))
-                .header("X-API-Key", &node.api_key)
-                .send()
-                .await
-                .expect(&format!("Failed to get metrics from {}", node.name));
-            
-            assert_eq!(metrics_response.status(), 200, "Node {} metrics not available", node.name);
-            
-            let metrics_text = metrics_response.text().await
-                .expect(&format!("Failed to parse metrics from {}", node.name));
-            
-            // Verify key metrics are present (using actual metric names)
-            assert!(metrics_text.contains("mesh_pending_jobs"), "Missing mesh metrics");
-            assert!(metrics_text.contains("network_peer_count"), "Missing network metrics");
-            assert!(metrics_text.contains("node_uptime_seconds"), "Missing node metrics");
-            
-            println!("  ✅ {} metrics are being collected", node.name);
-        }
-        
-        println!("✅ Prometheus metrics collection validated");
-    }
-    
-    /// Execute single job lifecycle test
-    async fn execute_single_job_lifecycle(&self) -> JobResult {
-        println!("🚀 Executing single job lifecycle test...");
-        
-        let submitter_node = &self.nodes[0]; // Node A
-        let submission_time = Instant::now();
-        
-        // Skip the mana balance check for now since it's causing issues
-        println!("  📋 Skipping mana balance check - proceeding with job submission");
-        
-        // Submit a real computational job using Echo format (proven to work)
-        let job_spec = icn_mesh::JobSpec {
-            kind: icn_mesh::JobKind::Echo {
-                payload: format!("E2E test job - Fibonacci calculation simulation - {}", self.test_id),
-            },
-            inputs: vec![],
-            outputs: vec!["result".into()],
-            required_resources: icn_mesh::Resources { cpu_cores: 1, memory_mb: 128 },
-        };
-        let job_request = json!({
-            "manifest_cid": "bafybeigdyrztktx5b5m2y4sogf2hf5uq3k5knv5c5k2pvx7aq5w3sh7g5e",
-            "spec_bytes": general_purpose::STANDARD.encode(bincode::serialize(&job_spec).unwrap()),
-            "spec_json": null,
-            "cost_mana": 200
-        });
-        
-        println!("  📤 Submitting computational job...");
-        let submit_response = self.client
-            .post(&format!("{}/mesh/submit", submitter_node.url))
-            .header("Content-Type", "application/json")
-            .header("X-API-Key", &submitter_node.api_key)
-            .json(&job_request)
-            .send()
-            .await
-            .expect("Failed to submit job");
-        
-        println!("  📤 Job submission response status: {}", submit_response.status());
-        
-        if submit_response.status() != 202 {
-            let status_code = submit_response.status();
-            let error_text = submit_response.text().await.unwrap_or_default();
-            panic!("Job submission failed with status {}: {}", status_code, error_text);
-        }
-        
-        let submit_result: Value = submit_response.json().await
-            .expect("Failed to parse submit response");
-        
-        let job_id = submit_result["job_id"].as_str()
-            .expect("No job_id in response").to_string();
-        
-        println!("  ✅ Job submitted with ID: {}", job_id);
-        
-        // Track job through all lifecycle stages
-        let mut job_result = JobResult {
-            job_id: job_id.clone(),
-            submitter_node: submitter_node.name.clone(),
-            executor_node: "Unknown".to_string(),
-            submission_time,
-            completion_time: None,
-            mana_spent: 0,
-            mana_refunded: 0,
-            receipt_cid: None,
-            execution_result: None,
-        };
-        
-        // Monitor job status with detailed tracking
-        const MAX_WAIT: Duration = Duration::from_secs(120);
-        let start_wait = Instant::now();
-        
-        while start_wait.elapsed() < MAX_WAIT {
-            let status_response = self.client
-                .get(&format!("{}/mesh/jobs/{}", submitter_node.url, job_id))
-                .header("X-API-Key", &submitter_node.api_key)
-                .send()
-                .await
-                .expect("Failed to get job status");
-            
-            if status_response.status() == 200 {
-                let job_status: Value = status_response.json().await
-                    .expect("Failed to parse job status");
-                
-                let status = job_status["status"].as_str().unwrap_or("unknown");
-                println!("  📋 Job status: {} ({}s elapsed)", status, start_wait.elapsed().as_secs());
-                
-                match status {
-                    "Pending" => {
-                        // Job is waiting for bids
-                        println!("    ⏳ Job pending - waiting for executor bids");
-                    }
-                    "Assigned" => {
-                        // Job has been assigned to executor
-                        if let Some(executor) = job_status["executor"].as_str() {
-                            job_result.executor_node = executor.to_string();
-                            println!("    🎯 Job assigned to executor: {}", executor);
-                        }
-                    }
-                    "Executing" => {
-                        // Job is being executed
-                        println!("    ⚙️ Job executing");
-                    }
-                    "Completed" => {
-                        // Job completed successfully
-                        job_result.completion_time = Some(Instant::now());
-                        
-                        if let Some(_result) = job_status["result"].as_object() {
-                            job_result.execution_result = Some(job_status["result"].clone());
-                        }
-                        
-                        if let Some(receipt_cid) = job_status["result_cid"].as_str() {
-                            job_result.receipt_cid = Some(receipt_cid.to_string());
-                        }
-                        
-                        println!("    ✅ Job completed successfully");
-                        break;
-                    }
-                    "Failed" => {
-                        let error = job_status["error"].as_str().unwrap_or("Unknown error");
-                        panic!("❌ Job failed: {}", error);
-                    }
-                    "Cancelled" => {
-                        panic!("❌ Job was cancelled");
-                    }
-                    _ => {
-                        println!("    ❓ Unknown job status: {}", status);
+
+        /// Validate P2P network convergence
+        async fn validate_p2p_convergence(&self) {
+            println!("🌐 Validating P2P network convergence...");
+
+            const MAX_RETRIES: u32 = 20;
+            const RETRY_DELAY: Duration = Duration::from_secs(3);
+
+            for attempt in 1..=MAX_RETRIES {
+                let mut all_connected = true;
+                let mut peer_counts = Vec::new();
+
+                for node in &self.nodes {
+                    let response = self
+                        .client
+                        .get(&format!("{}/status", node.url))
+                        .header("X-API-Key", &node.api_key)
+                        .send()
+                        .await
+                        .expect(&format!("Failed to get status from {}", node.name));
+
+                    let status: Value = response
+                        .json()
+                        .await
+                        .expect(&format!("Failed to parse status from {}", node.name));
+
+                    let peer_count = status["peer_count"].as_u64().unwrap_or(0);
+                    peer_counts.push((node.name.clone(), peer_count));
+
+                    // Each node should have at least 1 peer
+                    if peer_count == 0 {
+                        all_connected = false;
                     }
                 }
+
+                println!(
+                    "  Attempt {}/{}: Peer counts: {:?}",
+                    attempt, MAX_RETRIES, peer_counts
+                );
+
+                if all_connected {
+                    println!("✅ P2P network has converged");
+                    return;
+                }
+
+                if attempt < MAX_RETRIES {
+                    sleep(RETRY_DELAY).await;
+                }
             }
-            
-            sleep(Duration::from_secs(2)).await;
+
+            panic!(
+                "❌ P2P network failed to converge within {} attempts",
+                MAX_RETRIES
+            );
         }
-        
-        if job_result.completion_time.is_none() {
-            panic!("❌ Job did not complete within timeout");
-        }
-        
-        // Get final mana balance to calculate spent/refunded amounts
-        println!("  📋 Skipping final mana balance check - using placeholder values");
-        job_result.mana_spent = 200; // Use the expected cost
-        
-        let execution_time = job_result.completion_time.unwrap() - submission_time;
-        println!("  ✅ Job lifecycle completed in {:.2}s", execution_time.as_secs_f64());
-        
-        job_result
-    }
-    
-    /// Validate job execution result
-    async fn validate_job_result(&self, job_result: &JobResult) {
-        println!("🔍 Validating job execution result...");
-        
-        // Validate job completed
-        assert!(job_result.completion_time.is_some(), "Job did not complete");
-        
-        // For Echo jobs, we don't expect a complex result, just verify completion
-        println!("  ✅ Echo job completed successfully");
-        
-        // Validate receipt was created
-        assert!(job_result.receipt_cid.is_some(), "Job has no receipt CID");
-        println!("  ✅ Job execution result validated");
-    }
-    
-    /// Validate mana economics (spending and refunds)
-    async fn validate_mana_economics(&self, job_result: &JobResult) {
-        println!("💰 Validating mana economics...");
-        
-        // Skip detailed mana validation for now due to API issues
-        println!("  📋 Skipping detailed mana balance validation - using basic checks");
-        
-        // Basic validation that the job had reasonable cost
-        assert!(job_result.mana_spent > 0, "Job should have cost some mana");
-        assert!(job_result.mana_spent <= 1000, "Job cost should be reasonable");
-        
-        println!("  ✅ Basic mana economics validation passed");
-        
-        // Note: Full mana validation would include:
-        // - Checking actual balance changes
-        // - Verifying refunds for failed jobs
-        // - Validating transaction history
-        
-        println!("✅ Mana economics validation completed");
-    }
-    
-    /// Validate DAG integrity and receipt anchoring
-    async fn validate_dag_integrity(&self, job_result: &JobResult) {
-        println!("🔗 Validating DAG integrity and receipt anchoring...");
-        
-        let receipt_cid = job_result.receipt_cid.as_ref()
-            .expect("No receipt CID to validate");
-        
-        // Query DAG for receipt
-        let submitter_node = &self.nodes[0];
-        let dag_response = self.client
-            .get(&format!("{}/dag/get/{}", submitter_node.url, receipt_cid))
-            .header("X-API-Key", &submitter_node.api_key)
-            .send()
-            .await
-            .expect("Failed to query DAG");
-        
-        assert_eq!(dag_response.status(), 200, "Receipt not found in DAG");
-        
-        let receipt_data: Value = dag_response.json().await
-            .expect("Failed to parse receipt data");
-        
-        // Validate receipt structure
-        assert!(receipt_data["job_id"].is_string(), "Receipt missing job_id");
-        assert!(receipt_data["executor"].is_string(), "Receipt missing executor");
-        assert!(receipt_data["signature"].is_string(), "Receipt missing signature");
-        assert!(receipt_data["result"].is_object(), "Receipt missing result");
-        
-        println!("  ✅ Receipt found in DAG with CID: {}", receipt_cid);
-        
-        // Validate receipt signature
-        let signature_valid = receipt_data["signature_valid"].as_bool().unwrap_or(false);
-        assert!(signature_valid, "Receipt signature is invalid");
-        
-        println!("  ✅ Receipt signature validated");
-        
-        // Check DAG consistency across nodes
-        for node in &self.nodes {
-            let node_dag_response = self.client
-                .get(&format!("{}/dag/get/{}", node.url, receipt_cid))
-                .header("X-API-Key", &node.api_key)
+
+        /// Validate Prometheus metrics collection
+        async fn validate_metrics_collection(&self) {
+            println!("📊 Validating Prometheus metrics collection...");
+
+            // Check Prometheus is running
+            let prometheus_url = "http://localhost:9090";
+            let response = self
+                .client
+                .get(&format!("{}/api/v1/query", prometheus_url))
+                .query(&[("query", "up")])
                 .send()
-                .await;
-            
-            if node_dag_response.is_ok() && node_dag_response.as_ref().unwrap().status() == 200 {
-                println!("  ✅ Receipt replicated to {}", node.name);
-            }
-        }
-        
-        println!("✅ DAG integrity validated");
-    }
-    
-    /// Execute load test with multiple jobs
-    async fn execute_load_test(&self) {
-        println!("🚀 Executing load test with multiple jobs...");
-        
-        const NUM_JOBS: usize = 5;
-        const CONCURRENT_JOBS: usize = 3;
-        
-        let mut job_handles = Vec::new();
-        let submitter_node = &self.nodes[0];
-        
-        // Submit multiple jobs concurrently
-        for i in 0..NUM_JOBS {
-            let client = self.client.clone();
-            let url = submitter_node.url.clone();
-            let api_key = submitter_node.api_key.clone();
-            let test_id = format!("{}-load-{}", self.test_id, i);
-            
-            let handle = tokio::spawn(async move {
-                // Use Echo jobs for load testing (proven to work)
-                let spec = icn_mesh::JobSpec {
-                    kind: icn_mesh::JobKind::Echo {
-                        payload: format!("Load test job #{} - {}", i, test_id),
-                    },
-                    ..Default::default()
-                };
-                let job_request = json!({
-                    "manifest_cid": format!("cidv1-load-test-{}", test_id),
-                    "spec_bytes": general_purpose::STANDARD.encode(bincode::serialize(&spec).unwrap()),
-                    "spec_json": null,
-                    "cost_mana": 100
-                });
-                
-                let submit_response = client
-                    .post(&format!("{}/mesh/submit", url))
-                    .header("Content-Type", "application/json")
-                    .header("X-API-Key", &api_key)
-                    .json(&job_request)
+                .await
+                .expect("Failed to connect to Prometheus");
+
+            assert_eq!(response.status(), 200, "Prometheus not accessible");
+
+            // Check nodes are being scraped
+            for node in &self.nodes {
+                let metrics_response = self
+                    .client
+                    .get(&format!("{}/metrics", node.url))
+                    .header("X-API-Key", &node.api_key)
                     .send()
                     .await
-                    .expect("Failed to submit load test job");
-                
-                if submit_response.status() == 202 {
-                    let submit_result: Value = submit_response.json().await
-                        .expect("Failed to parse submit response");
-                    submit_result["job_id"].as_str().unwrap().to_string()
-                } else {
-                    panic!("Failed to submit load test job {}", i);
-                }
-            });
-            
-            job_handles.push(handle);
-            
-            // Stagger submissions to avoid overwhelming the system
-            if job_handles.len() >= CONCURRENT_JOBS {
-                sleep(Duration::from_millis(500)).await;
+                    .expect(&format!("Failed to get metrics from {}", node.name));
+
+                assert_eq!(
+                    metrics_response.status(),
+                    200,
+                    "Node {} metrics not available",
+                    node.name
+                );
+
+                let metrics_text = metrics_response
+                    .text()
+                    .await
+                    .expect(&format!("Failed to parse metrics from {}", node.name));
+
+                // Verify key metrics are present (using actual metric names)
+                assert!(
+                    metrics_text.contains("mesh_pending_jobs"),
+                    "Missing mesh metrics"
+                );
+                assert!(
+                    metrics_text.contains("network_peer_count"),
+                    "Missing network metrics"
+                );
+                assert!(
+                    metrics_text.contains("node_uptime_seconds"),
+                    "Missing node metrics"
+                );
+
+                println!("  ✅ {} metrics are being collected", node.name);
             }
+
+            println!("✅ Prometheus metrics collection validated");
         }
-        
-        // Wait for all jobs to be submitted
-        let mut job_ids = Vec::new();
-        for handle in job_handles {
-            let job_id = handle.await.expect("Failed to submit job");
-            job_ids.push(job_id);
-        }
-        
-        println!("  ✅ {} jobs submitted successfully", job_ids.len());
-        
-        // Monitor job completions
-        const LOAD_TEST_TIMEOUT: Duration = Duration::from_secs(180);
-        let start_wait = Instant::now();
-        let mut completed_jobs = 0;
-        let mut failed_jobs = 0;
-        
-        while start_wait.elapsed() < LOAD_TEST_TIMEOUT && completed_jobs + failed_jobs < job_ids.len() {
-            let mut current_completed = 0;
-            let mut current_failed = 0;
-            
-            for job_id in &job_ids {
-                let status_response = self.client
+
+        /// Execute single job lifecycle test
+        async fn execute_single_job_lifecycle(&self) -> JobResult {
+            println!("🚀 Executing single job lifecycle test...");
+
+            let submitter_node = &self.nodes[0]; // Node A
+            let submission_time = Instant::now();
+
+            // Skip the mana balance check for now since it's causing issues
+            println!("  📋 Skipping mana balance check - proceeding with job submission");
+
+            // Submit a real computational job using Echo format (proven to work)
+            let job_spec = icn_mesh::JobSpec {
+                kind: icn_mesh::JobKind::Echo {
+                    payload: format!(
+                        "E2E test job - Fibonacci calculation simulation - {}",
+                        self.test_id
+                    ),
+                },
+                inputs: vec![],
+                outputs: vec!["result".into()],
+                required_resources: icn_mesh::Resources {
+                    cpu_cores: 1,
+                    memory_mb: 128,
+                    storage_mb: 0,
+                },
+            };
+            let job_request = json!({
+                "manifest_cid": "bafybeigdyrztktx5b5m2y4sogf2hf5uq3k5knv5c5k2pvx7aq5w3sh7g5e",
+                "spec_bytes": general_purpose::STANDARD.encode(bincode::serialize(&job_spec).unwrap()),
+                "spec_json": null,
+                "cost_mana": 200
+            });
+
+            println!("  📤 Submitting computational job...");
+            let submit_response = self
+                .client
+                .post(&format!("{}/mesh/submit", submitter_node.url))
+                .header("Content-Type", "application/json")
+                .header("X-API-Key", &submitter_node.api_key)
+                .json(&job_request)
+                .send()
+                .await
+                .expect("Failed to submit job");
+
+            println!(
+                "  📤 Job submission response status: {}",
+                submit_response.status()
+            );
+
+            if submit_response.status() != 202 {
+                let status_code = submit_response.status();
+                let error_text = submit_response.text().await.unwrap_or_default();
+                panic!(
+                    "Job submission failed with status {}: {}",
+                    status_code, error_text
+                );
+            }
+
+            let submit_result: Value = submit_response
+                .json()
+                .await
+                .expect("Failed to parse submit response");
+
+            let job_id = submit_result["job_id"]
+                .as_str()
+                .expect("No job_id in response")
+                .to_string();
+
+            println!("  ✅ Job submitted with ID: {}", job_id);
+
+            // Track job through all lifecycle stages
+            let mut job_result = JobResult {
+                job_id: job_id.clone(),
+                submitter_node: submitter_node.name.clone(),
+                executor_node: "Unknown".to_string(),
+                submission_time,
+                completion_time: None,
+                mana_spent: 0,
+                mana_refunded: 0,
+                receipt_cid: None,
+                execution_result: None,
+            };
+
+            // Monitor job status with detailed tracking
+            const MAX_WAIT: Duration = Duration::from_secs(120);
+            let start_wait = Instant::now();
+
+            while start_wait.elapsed() < MAX_WAIT {
+                let status_response = self
+                    .client
                     .get(&format!("{}/mesh/jobs/{}", submitter_node.url, job_id))
                     .header("X-API-Key", &submitter_node.api_key)
                     .send()
+                    .await
+                    .expect("Failed to get job status");
+
+                if status_response.status() == 200 {
+                    let job_status: Value = status_response
+                        .json()
+                        .await
+                        .expect("Failed to parse job status");
+
+                    let status = job_status["status"].as_str().unwrap_or("unknown");
+                    println!(
+                        "  📋 Job status: {} ({}s elapsed)",
+                        status,
+                        start_wait.elapsed().as_secs()
+                    );
+
+                    match status {
+                        "Pending" => {
+                            // Job is waiting for bids
+                            println!("    ⏳ Job pending - waiting for executor bids");
+                        }
+                        "Assigned" => {
+                            // Job has been assigned to executor
+                            if let Some(executor) = job_status["executor"].as_str() {
+                                job_result.executor_node = executor.to_string();
+                                println!("    🎯 Job assigned to executor: {}", executor);
+                            }
+                        }
+                        "Executing" => {
+                            // Job is being executed
+                            println!("    ⚙️ Job executing");
+                        }
+                        "Completed" => {
+                            // Job completed successfully
+                            job_result.completion_time = Some(Instant::now());
+
+                            if let Some(_result) = job_status["result"].as_object() {
+                                job_result.execution_result = Some(job_status["result"].clone());
+                            }
+
+                            if let Some(receipt_cid) = job_status["result_cid"].as_str() {
+                                job_result.receipt_cid = Some(receipt_cid.to_string());
+                            }
+
+                            println!("    ✅ Job completed successfully");
+                            break;
+                        }
+                        "Failed" => {
+                            let error = job_status["error"].as_str().unwrap_or("Unknown error");
+                            panic!("❌ Job failed: {}", error);
+                        }
+                        "Cancelled" => {
+                            panic!("❌ Job was cancelled");
+                        }
+                        _ => {
+                            println!("    ❓ Unknown job status: {}", status);
+                        }
+                    }
+                }
+
+                sleep(Duration::from_secs(2)).await;
+            }
+
+            if job_result.completion_time.is_none() {
+                panic!("❌ Job did not complete within timeout");
+            }
+
+            // Get final mana balance to calculate spent/refunded amounts
+            println!("  📋 Skipping final mana balance check - using placeholder values");
+            job_result.mana_spent = 200; // Use the expected cost
+
+            let execution_time = job_result.completion_time.unwrap() - submission_time;
+            println!(
+                "  ✅ Job lifecycle completed in {:.2}s",
+                execution_time.as_secs_f64()
+            );
+
+            job_result
+        }
+
+        /// Validate job execution result
+        async fn validate_job_result(&self, job_result: &JobResult) {
+            println!("🔍 Validating job execution result...");
+
+            // Validate job completed
+            assert!(job_result.completion_time.is_some(), "Job did not complete");
+
+            // For Echo jobs, we don't expect a complex result, just verify completion
+            println!("  ✅ Echo job completed successfully");
+
+            // Validate receipt was created
+            assert!(job_result.receipt_cid.is_some(), "Job has no receipt CID");
+            println!("  ✅ Job execution result validated");
+        }
+
+        /// Validate mana economics (spending and refunds)
+        async fn validate_mana_economics(&self, job_result: &JobResult) {
+            println!("💰 Validating mana economics...");
+
+            // Skip detailed mana validation for now due to API issues
+            println!("  📋 Skipping detailed mana balance validation - using basic checks");
+
+            // Basic validation that the job had reasonable cost
+            assert!(job_result.mana_spent > 0, "Job should have cost some mana");
+            assert!(
+                job_result.mana_spent <= 1000,
+                "Job cost should be reasonable"
+            );
+
+            println!("  ✅ Basic mana economics validation passed");
+
+            // Note: Full mana validation would include:
+            // - Checking actual balance changes
+            // - Verifying refunds for failed jobs
+            // - Validating transaction history
+
+            println!("✅ Mana economics validation completed");
+        }
+
+        /// Validate DAG integrity and receipt anchoring
+        async fn validate_dag_integrity(&self, job_result: &JobResult) {
+            println!("🔗 Validating DAG integrity and receipt anchoring...");
+
+            let receipt_cid = job_result
+                .receipt_cid
+                .as_ref()
+                .expect("No receipt CID to validate");
+
+            // Query DAG for receipt
+            let submitter_node = &self.nodes[0];
+            let dag_response = self
+                .client
+                .get(&format!("{}/dag/get/{}", submitter_node.url, receipt_cid))
+                .header("X-API-Key", &submitter_node.api_key)
+                .send()
+                .await
+                .expect("Failed to query DAG");
+
+            assert_eq!(dag_response.status(), 200, "Receipt not found in DAG");
+
+            let receipt_data: Value = dag_response
+                .json()
+                .await
+                .expect("Failed to parse receipt data");
+
+            // Validate receipt structure
+            assert!(receipt_data["job_id"].is_string(), "Receipt missing job_id");
+            assert!(
+                receipt_data["executor"].is_string(),
+                "Receipt missing executor"
+            );
+            assert!(
+                receipt_data["signature"].is_string(),
+                "Receipt missing signature"
+            );
+            assert!(receipt_data["result"].is_object(), "Receipt missing result");
+
+            println!("  ✅ Receipt found in DAG with CID: {}", receipt_cid);
+
+            // Validate receipt signature
+            let signature_valid = receipt_data["signature_valid"].as_bool().unwrap_or(false);
+            assert!(signature_valid, "Receipt signature is invalid");
+
+            println!("  ✅ Receipt signature validated");
+
+            // Check DAG consistency across nodes
+            for node in &self.nodes {
+                let node_dag_response = self
+                    .client
+                    .get(&format!("{}/dag/get/{}", node.url, receipt_cid))
+                    .header("X-API-Key", &node.api_key)
+                    .send()
                     .await;
-                
-                if let Ok(response) = status_response {
-                    if response.status() == 200 {
-                        let job_status: Value = response.json().await
-                            .expect("Failed to parse job status");
-                        
-                        match job_status["status"].as_str().unwrap_or("unknown") {
-                            "Completed" => current_completed += 1,
-                            "Failed" | "Cancelled" => current_failed += 1,
-                            _ => {} // Still in progress
+
+                if node_dag_response.is_ok() && node_dag_response.as_ref().unwrap().status() == 200
+                {
+                    println!("  ✅ Receipt replicated to {}", node.name);
+                }
+            }
+
+            println!("✅ DAG integrity validated");
+        }
+
+        /// Execute load test with multiple jobs
+        async fn execute_load_test(&self) {
+            println!("🚀 Executing load test with multiple jobs...");
+
+            const NUM_JOBS: usize = 5;
+            const CONCURRENT_JOBS: usize = 3;
+
+            let mut job_handles = Vec::new();
+            let submitter_node = &self.nodes[0];
+
+            // Submit multiple jobs concurrently
+            for i in 0..NUM_JOBS {
+                let client = self.client.clone();
+                let url = submitter_node.url.clone();
+                let api_key = submitter_node.api_key.clone();
+                let test_id = format!("{}-load-{}", self.test_id, i);
+
+                let handle = tokio::spawn(async move {
+                    // Use Echo jobs for load testing (proven to work)
+                    let spec = icn_mesh::JobSpec {
+                        kind: icn_mesh::JobKind::Echo {
+                            payload: format!("Load test job #{} - {}", i, test_id),
+                        },
+                        ..Default::default()
+                    };
+                    let job_request = json!({
+                        "manifest_cid": format!("cidv1-load-test-{}", test_id),
+                        "spec_bytes": general_purpose::STANDARD.encode(bincode::serialize(&spec).unwrap()),
+                        "spec_json": null,
+                        "cost_mana": 100
+                    });
+
+                    let submit_response = client
+                        .post(&format!("{}/mesh/submit", url))
+                        .header("Content-Type", "application/json")
+                        .header("X-API-Key", &api_key)
+                        .json(&job_request)
+                        .send()
+                        .await
+                        .expect("Failed to submit load test job");
+
+                    if submit_response.status() == 202 {
+                        let submit_result: Value = submit_response
+                            .json()
+                            .await
+                            .expect("Failed to parse submit response");
+                        submit_result["job_id"].as_str().unwrap().to_string()
+                    } else {
+                        panic!("Failed to submit load test job {}", i);
+                    }
+                });
+
+                job_handles.push(handle);
+
+                // Stagger submissions to avoid overwhelming the system
+                if job_handles.len() >= CONCURRENT_JOBS {
+                    sleep(Duration::from_millis(500)).await;
+                }
+            }
+
+            // Wait for all jobs to be submitted
+            let mut job_ids = Vec::new();
+            for handle in job_handles {
+                let job_id = handle.await.expect("Failed to submit job");
+                job_ids.push(job_id);
+            }
+
+            println!("  ✅ {} jobs submitted successfully", job_ids.len());
+
+            // Monitor job completions
+            const LOAD_TEST_TIMEOUT: Duration = Duration::from_secs(180);
+            let start_wait = Instant::now();
+            let mut completed_jobs = 0;
+            let mut failed_jobs = 0;
+
+            while start_wait.elapsed() < LOAD_TEST_TIMEOUT
+                && completed_jobs + failed_jobs < job_ids.len()
+            {
+                let mut current_completed = 0;
+                let mut current_failed = 0;
+
+                for job_id in &job_ids {
+                    let status_response = self
+                        .client
+                        .get(&format!("{}/mesh/jobs/{}", submitter_node.url, job_id))
+                        .header("X-API-Key", &submitter_node.api_key)
+                        .send()
+                        .await;
+
+                    if let Ok(response) = status_response {
+                        if response.status() == 200 {
+                            let job_status: Value =
+                                response.json().await.expect("Failed to parse job status");
+
+                            match job_status["status"].as_str().unwrap_or("unknown") {
+                                "Completed" => current_completed += 1,
+                                "Failed" | "Cancelled" => current_failed += 1,
+                                _ => {} // Still in progress
+                            }
+                        }
+                    }
+                }
+
+                if current_completed != completed_jobs || current_failed != failed_jobs {
+                    completed_jobs = current_completed;
+                    failed_jobs = current_failed;
+                    println!(
+                        "  📊 Load test progress: {} completed, {} failed, {} pending",
+                        completed_jobs,
+                        failed_jobs,
+                        job_ids.len() - completed_jobs - failed_jobs
+                    );
+                }
+
+                sleep(Duration::from_secs(5)).await;
+            }
+
+            let success_rate = completed_jobs as f64 / job_ids.len() as f64;
+            println!(
+                "  📈 Load test completed: {:.1}% success rate ({}/{} jobs)",
+                success_rate * 100.0,
+                completed_jobs,
+                job_ids.len()
+            );
+
+            // Validate acceptable success rate
+            assert!(
+                success_rate >= 0.8,
+                "Load test success rate too low: {:.1}%",
+                success_rate * 100.0
+            );
+
+            println!("✅ Load test completed successfully");
+        }
+
+        /// Validate performance metrics
+        async fn validate_performance_metrics(&self) {
+            println!("📊 Validating performance metrics...");
+
+            let prometheus_url = "http://localhost:9090";
+            let end_time = chrono::Utc::now().timestamp();
+            let _start_time = end_time - 300; // Last 5 minutes
+
+            // Query key performance metrics (using actual metric names)
+            let metrics_queries = vec![
+                ("mesh_pending_jobs", "mesh_pending_jobs"),
+                ("network_peer_count", "network_peer_count"),
+                ("node_uptime", "node_uptime_seconds"),
+                ("governance_proposals", "governance_submit_proposal_calls"),
+                ("dag_operations", "dag_put_calls"),
+            ];
+
+            let mut performance_report = HashMap::new();
+
+            for (metric_name, query) in metrics_queries {
+                let response = self
+                    .client
+                    .get(&format!("{}/api/v1/query", prometheus_url))
+                    .query(&[("query", query)])
+                    .send()
+                    .await
+                    .expect(&format!("Failed to query metric: {}", metric_name));
+
+                if response.status() == 200 {
+                    let query_result: Value = response
+                        .json()
+                        .await
+                        .expect("Failed to parse metrics response");
+
+                    if let Some(data) = query_result["data"]["result"].as_array() {
+                        if !data.is_empty() {
+                            let value = data[0]["value"][1].as_str().unwrap_or("0");
+                            performance_report.insert(metric_name.to_string(), value.to_string());
+                            println!("  📈 {}: {}", metric_name, value);
                         }
                     }
                 }
             }
-            
-            if current_completed != completed_jobs || current_failed != failed_jobs {
-                completed_jobs = current_completed;
-                failed_jobs = current_failed;
-                println!("  📊 Load test progress: {} completed, {} failed, {} pending", 
-                         completed_jobs, failed_jobs, job_ids.len() - completed_jobs - failed_jobs);
+
+            // Validate performance thresholds
+            if let Some(peer_count) = performance_report.get("network_peer_count") {
+                let peers: f64 = peer_count.parse().unwrap_or(0.0);
+                assert!(peers >= 2.0, "Should have at least 2 peers connected");
             }
-            
-            sleep(Duration::from_secs(5)).await;
+
+            if let Some(uptime) = performance_report.get("node_uptime") {
+                let uptime_val: f64 = uptime.parse().unwrap_or(0.0);
+                assert!(uptime_val > 0.0, "Node uptime should be positive");
+            }
+
+            println!("✅ Performance metrics validated");
         }
-        
-        let success_rate = completed_jobs as f64 / job_ids.len() as f64;
-        println!("  📈 Load test completed: {:.1}% success rate ({}/{} jobs)", 
-                 success_rate * 100.0, completed_jobs, job_ids.len());
-        
-        // Validate acceptable success rate
-        assert!(success_rate >= 0.8, "Load test success rate too low: {:.1}%", success_rate * 100.0);
-        
-        println!("✅ Load test completed successfully");
-    }
-    
-    /// Validate performance metrics
-    async fn validate_performance_metrics(&self) {
-        println!("📊 Validating performance metrics...");
-        
-        let prometheus_url = "http://localhost:9090";
-        let end_time = chrono::Utc::now().timestamp();
-        let _start_time = end_time - 300; // Last 5 minutes
-        
-        // Query key performance metrics (using actual metric names)
-        let metrics_queries = vec![
-            ("mesh_pending_jobs", "mesh_pending_jobs"),
-            ("network_peer_count", "network_peer_count"),
-            ("node_uptime", "node_uptime_seconds"),
-            ("governance_proposals", "governance_submit_proposal_calls"),
-            ("dag_operations", "dag_put_calls"),
-        ];
-        
-        let mut performance_report = HashMap::new();
-        
-        for (metric_name, query) in metrics_queries {
-            let response = self.client
-                .get(&format!("{}/api/v1/query", prometheus_url))
-                .query(&[("query", query)])
+
+        /// Get mana balance for a node
+        async fn get_mana_balance(&self, node_url: &str, api_key: &str) -> u64 {
+            // First get the node's DID from /keys endpoint
+            let keys_response = self
+                .client
+                .get(&format!("{}/keys", node_url))
+                .header("X-API-Key", api_key)
                 .send()
                 .await
-                .expect(&format!("Failed to query metric: {}", metric_name));
-            
-            if response.status() == 200 {
-                let query_result: Value = response.json().await
-                    .expect("Failed to parse metrics response");
-                
-                if let Some(data) = query_result["data"]["result"].as_array() {
-                    if !data.is_empty() {
-                        let value = data[0]["value"][1].as_str().unwrap_or("0");
-                        performance_report.insert(metric_name.to_string(), value.to_string());
-                        println!("  📈 {}: {}", metric_name, value);
-                    }
-                }
+                .expect("Failed to get node keys");
+
+            let status = keys_response.status();
+            println!("  🔍 Keys response status: {}", status);
+
+            // Check if the response is successful
+            if !status.is_success() {
+                let error_text = keys_response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "Failed to read error response".to_string());
+                panic!(
+                    "Keys endpoint failed with status {}: {}",
+                    status, error_text
+                );
+            }
+
+            // Check if response body is empty
+            let response_text = keys_response
+                .text()
+                .await
+                .expect("Failed to read keys response as text");
+
+            println!("  🔍 Keys raw response: '{}'", response_text);
+
+            if response_text.trim().is_empty() {
+                panic!("Keys endpoint returned empty response");
+            }
+
+            // Parse the JSON
+            let keys_data: Value = serde_json::from_str(&response_text)
+                .expect("Failed to parse keys response as JSON");
+
+            let node_did = keys_data["did"]
+                .as_str()
+                .expect("Node DID not found in keys response");
+
+            println!("  🔍 Node DID: {}", node_did);
+
+            // Now get the mana balance using the correct endpoint
+            let response = self
+                .client
+                .get(&format!("{}/account/{}/mana", node_url, node_did))
+                .header("X-API-Key", api_key)
+                .send()
+                .await
+                .expect("Failed to get mana balance");
+
+            let balance_data: Value = response.json().await.expect("Failed to parse mana balance");
+
+            balance_data["balance"].as_u64().unwrap_or(0)
+        }
+
+        /// Get mana transaction history
+        async fn get_mana_transactions(&self, _node_url: &str, _api_key: &str) -> Vec<Value> {
+            // Note: ICN node doesn't currently expose a mana transactions endpoint
+            // This is a placeholder implementation that returns an empty list
+            // In a real implementation, this would query a dedicated endpoint
+            println!("  ⚠️  Mana transactions endpoint not yet implemented in ICN node, returning empty list");
+            vec![]
+        }
+    }
+
+    impl Drop for E2ETestHarness {
+        fn drop(&mut self) {
+            // Clean up federation if we started it
+            if std::env::var("ICN_DEVNET_RUNNING").is_err() {
+                let _ = Command::new("docker-compose")
+                    .args(&[
+                        "-f",
+                        "icn-devnet/docker-compose.yml",
+                        "down",
+                        "--volumes",
+                        "--remove-orphans",
+                    ])
+                    .current_dir("..") // Go up one level from tests/ to project root
+                    .status();
             }
         }
-        
-        // Validate performance thresholds
-        if let Some(peer_count) = performance_report.get("network_peer_count") {
-            let peers: f64 = peer_count.parse().unwrap_or(0.0);
-            assert!(peers >= 2.0, "Should have at least 2 peers connected");
-        }
-        
-        if let Some(uptime) = performance_report.get("node_uptime") {
-            let uptime_val: f64 = uptime.parse().unwrap_or(0.0);
-            assert!(uptime_val > 0.0, "Node uptime should be positive");
-        }
-        
-        println!("✅ Performance metrics validated");
     }
-    
-    /// Get mana balance for a node
-    async fn get_mana_balance(&self, node_url: &str, api_key: &str) -> u64 {
-        // First get the node's DID from /keys endpoint
-        let keys_response = self.client
-            .get(&format!("{}/keys", node_url))
-            .header("X-API-Key", api_key)
-            .send()
-            .await
-            .expect("Failed to get node keys");
-        
-        let status = keys_response.status();
-        println!("  🔍 Keys response status: {}", status);
-        
-        // Check if the response is successful
-        if !status.is_success() {
-            let error_text = keys_response.text().await
-                .unwrap_or_else(|_| "Failed to read error response".to_string());
-            panic!("Keys endpoint failed with status {}: {}", status, error_text);
-        }
-        
-        // Check if response body is empty
-        let response_text = keys_response.text().await
-            .expect("Failed to read keys response as text");
-        
-        println!("  🔍 Keys raw response: '{}'", response_text);
-        
-        if response_text.trim().is_empty() {
-            panic!("Keys endpoint returned empty response");
-        }
-        
-        // Parse the JSON
-        let keys_data: Value = serde_json::from_str(&response_text)
-            .expect("Failed to parse keys response as JSON");
-        
-        let node_did = keys_data["did"].as_str()
-            .expect("Node DID not found in keys response");
-        
-        println!("  🔍 Node DID: {}", node_did);
-        
-        // Now get the mana balance using the correct endpoint
-        let response = self.client
-            .get(&format!("{}/account/{}/mana", node_url, node_did))
-            .header("X-API-Key", api_key)
-            .send()
-            .await
-            .expect("Failed to get mana balance");
-        
-        let balance_data: Value = response.json().await
-            .expect("Failed to parse mana balance");
-        
-        balance_data["balance"].as_u64().unwrap_or(0)
-    }
-    
-    /// Get mana transaction history
-    async fn get_mana_transactions(&self, _node_url: &str, _api_key: &str) -> Vec<Value> {
-        // Note: ICN node doesn't currently expose a mana transactions endpoint
-        // This is a placeholder implementation that returns an empty list
-        // In a real implementation, this would query a dedicated endpoint
-        println!("  ⚠️  Mana transactions endpoint not yet implemented in ICN node, returning empty list");
-        vec![]
-    }
-}
-
-impl Drop for E2ETestHarness {
-    fn drop(&mut self) {
-        // Clean up federation if we started it
-        if std::env::var("ICN_DEVNET_RUNNING").is_err() {
-            let _ = Command::new("docker-compose")
-                .args(&[
-                    "-f", "icn-devnet/docker-compose.yml",
-                    "down", "--volumes", "--remove-orphans"
-                ])
-                .current_dir("..") // Go up one level from tests/ to project root
-                .status();
-        }
-    }
-} 
 } // End of comprehensive_e2e_test module
 
 #[cfg(not(feature = "enable-libp2p"))]
@@ -838,4 +959,4 @@ impl Drop for E2ETestHarness {
 async fn comprehensive_e2e_test_stub() {
     println!("❌ Comprehensive E2E test requires the 'enable-libp2p' feature.");
     println!("Run with: cargo test --features enable-libp2p");
-} 
+}

--- a/tests/integration/reputation_persistence.rs
+++ b/tests/integration/reputation_persistence.rs
@@ -44,14 +44,14 @@ mod reputation_persistence {
             job_id: job_id.clone(),
             executor_did: did_a.clone(),
             price_mana: 10,
-            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            resources: Resources { cpu_cores: 1, memory_mb: 10, storage_mb: 0 },
             signature: SignatureBytes(Vec::new()),
         };
         let bid_b = MeshJobBid {
             job_id: job_id.clone(),
             executor_did: did_b.clone(),
             price_mana: 10,
-            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            resources: Resources { cpu_cores: 1, memory_mb: 10, storage_mb: 0 },
             signature: SignatureBytes(Vec::new()),
         };
 
@@ -188,14 +188,14 @@ mod reputation_persistence_sqlite {
             job_id: job_id.clone(),
             executor_did: did_a.clone(),
             price_mana: 10,
-            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            resources: Resources { cpu_cores: 1, memory_mb: 10, storage_mb: 0 },
             signature: SignatureBytes(Vec::new()),
         };
         let bid_b = MeshJobBid {
             job_id: job_id.clone(),
             executor_did: did_b.clone(),
             price_mana: 10,
-            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            resources: Resources { cpu_cores: 1, memory_mb: 10, storage_mb: 0 },
             signature: SignatureBytes(Vec::new()),
         };
 
@@ -294,14 +294,14 @@ mod reputation_persistence_rocks {
             job_id: job_id.clone(),
             executor_did: did_a.clone(),
             price_mana: 10,
-            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            resources: Resources { cpu_cores: 1, memory_mb: 10, storage_mb: 0 },
             signature: SignatureBytes(Vec::new()),
         };
         let bid_b = MeshJobBid {
             job_id: job_id.clone(),
             executor_did: did_b.clone(),
             price_mana: 10,
-            resources: Resources { cpu_cores: 1, memory_mb: 10 },
+            resources: Resources { cpu_cores: 1, memory_mb: 10, storage_mb: 0 },
             signature: SignatureBytes(Vec::new()),
         };
 

--- a/tests/integration/simple_verification.rs
+++ b/tests/integration/simple_verification.rs
@@ -1,49 +1,62 @@
 #[cfg(feature = "enable-libp2p")]
 mod simple_verification_test {
-    use icn_runtime::RuntimeContext;
-    use icn_common::{Did, DagBlock, Cid};
-    use icn_mesh::{JobSpec, JobKind, Resources};
     use bincode;
+    use icn_common::{Cid, DagBlock, Did};
+    use icn_mesh::{JobKind, JobSpec, Resources};
+    use icn_runtime::RuntimeContext;
     use std::time::Duration;
     use tokio::time::sleep;
 
     #[tokio::test]
     async fn simple_icn_core_verification() {
         println!("🚀 ICN Core Simple Verification Test");
-        
+
         // Test 1: Create runtime context
         println!("📋 Test 1: Creating RuntimeContext...");
         let test_did = Did::new("key", "test_node");
         let rt_ctx = RuntimeContext::new_testing(test_did.clone(), Some(1000))
             .expect("Failed to create test RuntimeContext");
-        
+
         // Test 2: Verify mana management
         println!("📋 Test 2: Testing mana management...");
-        let initial_balance = rt_ctx.get_mana(&test_did).await
+        let initial_balance = rt_ctx
+            .get_mana(&test_did)
+            .await
             .expect("Failed to get initial mana balance");
         assert_eq!(initial_balance, 1000, "Initial mana balance should be 1000");
-        
+
         // Spend some mana
-        rt_ctx.spend_mana(&test_did, 100).await
+        rt_ctx
+            .spend_mana(&test_did, 100)
+            .await
             .expect("Failed to spend mana");
-        
-        let balance_after_spend = rt_ctx.get_mana(&test_did).await
+
+        let balance_after_spend = rt_ctx
+            .get_mana(&test_did)
+            .await
             .expect("Failed to get balance after spend");
-        assert_eq!(balance_after_spend, 900, "Balance should be 900 after spending 100");
-        
+        assert_eq!(
+            balance_after_spend, 900,
+            "Balance should be 900 after spending 100"
+        );
+
         // Credit some mana back
-        rt_ctx.credit_mana(&test_did, 50).await
+        rt_ctx
+            .credit_mana(&test_did, 50)
+            .await
             .expect("Failed to credit mana");
-        
-        let final_balance = rt_ctx.get_mana(&test_did).await
+
+        let final_balance = rt_ctx
+            .get_mana(&test_did)
+            .await
             .expect("Failed to get final balance");
         assert_eq!(final_balance, 950, "Final balance should be 950");
-        
+
         // Test 3: Verify DAG store
         println!("📋 Test 3: Testing DAG store...");
         let test_data = b"Hello ICN World!";
         let test_cid = Cid::new_v1_sha256(0x55, test_data);
-        
+
         let dag_block = DagBlock {
             cid: test_cid.clone(),
             data: test_data.to_vec(),
@@ -53,52 +66,61 @@ mod simple_verification_test {
             signature: None,
             scope: None,
         };
-        
+
         let mut dag_store = rt_ctx.dag_store.lock().await;
         let put_result = dag_store.put(&dag_block).await;
         assert!(put_result.is_ok(), "DAG put should succeed");
-        
+
         let get_result = dag_store.get(&test_cid).await;
         assert!(get_result.is_ok(), "DAG get should succeed");
-        
+
         if let Ok(Some(retrieved_block)) = get_result {
-            assert_eq!(retrieved_block.data, test_data, "Retrieved data should match stored data");
+            assert_eq!(
+                retrieved_block.data, test_data,
+                "Retrieved data should match stored data"
+            );
         }
         drop(dag_store);
-        
+
         // Test 4: Submit a simple mesh job using the new API
         println!("📋 Test 4: Testing mesh job submission...");
         let manifest_cid = Cid::new_v1_sha256(0x55, b"test_manifest");
         let spec = icn_mesh::JobSpec {
-            kind: icn_mesh::JobKind::Echo { payload: "Simple verification test job".into() },
+            kind: icn_mesh::JobKind::Echo {
+                payload: "Simple verification test job".into(),
+            },
             inputs: vec![],
             outputs: vec!["result".into()],
-            required_resources: icn_mesh::Resources { cpu_cores: 1, memory_mb: 128 },
+            required_resources: icn_mesh::Resources {
+                cpu_cores: 1,
+                memory_mb: 128,
+                storage_mb: 0,
+            },
         };
         let spec_bytes = bincode::serialize(&spec).unwrap();
         let submit_result = rt_ctx
             .handle_submit_job(manifest_cid, spec_bytes, 100)
             .await;
         assert!(submit_result.is_ok(), "Job submission should succeed");
-        
+
         if let Ok(job_id) = submit_result {
             println!("✅ Job submitted with ID: {}", job_id);
-            
+
             // Wait a bit and check job status
             sleep(Duration::from_secs(1)).await;
-            
+
             let job_status = rt_ctx.get_job_status(&job_id).await;
             assert!(job_status.is_ok(), "Should be able to get job status");
-            
+
             if let Ok(status) = job_status {
                 println!("📊 Job status: {:?}", status);
             }
         }
-        
+
         println!("✅ ICN Core Simple Verification Complete!");
         println!("🎉 All core functionality verified:");
         println!("   ✓ RuntimeContext creation");
-        println!("   ✓ Mana management (spend/credit/balance)");  
+        println!("   ✓ Mana management (spend/credit/balance)");
         println!("   ✓ DAG store (put/get)");
         println!("   ✓ Mesh job submission");
     }
@@ -109,4 +131,4 @@ mod simple_verification_test {
 async fn simple_verification_stub() {
     println!("❌ Simple verification test requires the 'enable-libp2p' feature.");
     println!("Run with: cargo test --features enable-libp2p");
-} 
+}


### PR DESCRIPTION
## Summary
- add `storage_mb` to mesh `Resources`
- propagate storage requirements in job announcements and bids
- update runtime and mesh tests for new field

## Testing
- `cargo fmt --all`
- *(tests and clippy did not run due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68757d65d0c08324819724bf3927a83d