### PR TITLE
Add governance onboarding templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ More detailed information can be found in the `README.md` file within each crate
 * [Resource Tokens](docs/resource_tokens.md) – token classes and mana integration
 * [CCL Language Reference](docs/CCL_LANGUAGE_REFERENCE.md) – full syntax guide
 * [CCL Examples](icn-ccl/examples/) – governance contract templates
+* [Governance Onboarding Guide](docs/governance_onboarding.md) – using templates
 * [Contract Creation Guide](docs/howto-create-contract.md) – compile and submit CCL jobs
 
 ### **Development Resources**

--- a/docs/ICN_FEATURE_OVERVIEW.md
+++ b/docs/ICN_FEATURE_OVERVIEW.md
@@ -402,11 +402,12 @@ ICN enables autonomous federated systems that support cooperative coordination w
 
 ### **For Cooperatives**
 1. Review the [Governance Framework](governance-framework.md)
-2. Understand [Economic Models](economics-models.md)
-3. Explore [Cooperative Infrastructure Features](#11-🤝-cooperative-infrastructure-new)
-4. Plan your [Federation Strategy](federation-strategy.md)
-5. Join our [Cooperative Pilot Program](mailto:pilot@intercooperative.network)
-6. Connect with the [Cooperative Working Group](https://github.com/InterCooperative/icn-core/discussions/categories/cooperative-infrastructure)
+2. Follow the [Governance Onboarding Guide](governance_onboarding.md)
+3. Understand [Economic Models](economics-models.md)
+4. Explore [Cooperative Infrastructure Features](#11-🤝-cooperative-infrastructure-new)
+5. Plan your [Federation Strategy](federation-strategy.md)
+6. Join our [Cooperative Pilot Program](mailto:pilot@intercooperative.network)
+7. Connect with the [Cooperative Working Group](https://github.com/InterCooperative/icn-core/discussions/categories/cooperative-infrastructure)
 
 ### **For Researchers**
 1. Read our [Academic Papers](academic-papers.md)

--- a/docs/governance-pattern-library.md
+++ b/docs/governance-pattern-library.md
@@ -10,6 +10,6 @@ The `icn-templates` crate collects reusable CCL snippets for common cooperative 
 - `rotating_council.ccl`
 - `rotating_assembly.ccl`
 
-Each constant is exported from `icn-templates` for programmatic access. The same files are available under [`icn-ccl/examples/`](../icn-ccl/examples/) for quick inspection.
+Each constant is exported from `icn-templates` for programmatic access. The same files are available under [`icn-ccl/examples/governance_templates/`](../icn-ccl/examples/governance_templates/) for quick inspection.
 
 Use these patterns with the formation wizard or your own tooling to bootstrap new cooperatives.

--- a/docs/governance_onboarding.md
+++ b/docs/governance_onboarding.md
@@ -1,0 +1,40 @@
+# Cooperative Governance Onboarding
+
+This short guide walks cooperatives through setting up their first CCL-based governance policy using the provided templates.
+
+## 1. Review the Templates
+
+Browse [`icn-ccl/examples/governance_templates/`](../icn-ccl/examples/governance_templates/) for common patterns:
+
+- `simple_voting.ccl` – minimal majority voting
+- `treasury_rules.ccl` – example spending policy
+- `rotating_stewards.ccl` – single steward rotates each cycle
+- `rotating_council.ccl` – council membership rotates
+- `rotating_assembly.ccl` – meeting chair rotates among members
+
+Copy the template that best matches your cooperative structure and customize member identifiers or parameters as needed.
+
+## 2. Compile the Contract
+
+Use `icn-cli` to compile your CCL file to WASM:
+
+```bash
+icn-cli ccl compile my_policy.ccl -o my_policy.wasm
+```
+
+## 3. Upload and Propose
+
+1. Upload the compiled module to your node's DAG service:
+   ```bash
+   curl -X POST http://localhost:5001/dag/put \
+     --data-binary '@my_policy.wasm'
+   ```
+2. Generate a job spec and submit the proposal:
+   ```bash
+   generate_ccl_job_spec --wasm-cid <cid> --output policy_job.json
+   curl -X POST http://localhost:5001/governance/propose \
+     -H 'Content-Type: application/json' \
+     -d @policy_job.json
+   ```
+
+For additional patterns see [governance-pattern-library.md](governance-pattern-library.md).

--- a/docs/howto-create-contract.md
+++ b/docs/howto-create-contract.md
@@ -1,6 +1,6 @@
 # Creating and Running a CCL Contract
 
-This quick guide walks through writing a simple Cooperative Contract Language (CCL) file, compiling it with `icn-cli`, uploading the compiled module to a node, and submitting a job that executes the contract. The examples under [`icn-ccl/examples/`](../icn-ccl/examples/) provide additional templates you can adapt.
+This quick guide walks through writing a simple Cooperative Contract Language (CCL) file, compiling it with `icn-cli`, uploading the compiled module to a node, and submitting a job that executes the contract. The examples under [`icn-ccl/examples/governance_templates/`](../icn-ccl/examples/governance_templates/) provide additional templates you can adapt.
 
 ## 1. Write the contract
 
@@ -13,7 +13,7 @@ fn run() -> Integer {
 }
 ```
 
-Browse the [examples directory](../icn-ccl/examples/) for more realistic contracts such as `cooperative_housing_maintenance.ccl` or `childcare_cooperative_schedule.ccl`.
+Browse the [examples directory](../icn-ccl/examples/governance_templates/) for more realistic contracts such as `cooperative_housing_maintenance.ccl` or `childcare_cooperative_schedule.ccl`.
 
 ## 2. Compile the contract
 

--- a/docs/rotating_governance_templates.md
+++ b/docs/rotating_governance_templates.md
@@ -10,7 +10,7 @@ Three example contracts illustrate common cooperative structures where leadershi
 - **Rotating Council** – small council membership rotates through a list of members.
 - **Rotating Assembly** – meeting chair rotates among all members.
 
-The source files live under [`icn-ccl/examples/`](../icn-ccl/examples/) and are mirrored in the `icn-templates` crate for programmatic use.
+The source files live under [`icn-ccl/examples/governance_templates/`](../icn-ccl/examples/governance_templates/) and are mirrored in the `icn-templates` crate for programmatic use.
 
 ## Using the Templates
 

--- a/icn-ccl/examples/governance_templates/rotating_assembly.ccl
+++ b/icn-ccl/examples/governance_templates/rotating_assembly.ccl
@@ -1,0 +1,12 @@
+// Rotating assembly template
+// Returns the meeting chair for a given cycle
+fn assembly_chair(cycle: Integer, members: Array<Integer>) -> Integer {
+    let count = array_len(members);
+    let index = cycle % count;
+    return members[index];
+}
+
+fn run() -> Integer {
+    let members = [1, 2, 3, 4];
+    return assembly_chair(0, members);
+}

--- a/icn-ccl/examples/governance_templates/rotating_council.ccl
+++ b/icn-ccl/examples/governance_templates/rotating_council.ccl
@@ -1,0 +1,19 @@
+// Rotating council template
+// Selects a council subset based on cycle index
+fn select_council(cycle: Integer, members: Array<Integer>, seats: Integer) -> Array<Integer> {
+    let count = array_len(members);
+    let i = 0;
+    let council = [];
+    while i < seats {
+        let idx = (cycle + i) % count;
+        array_push(council, members[idx]);
+        let i = i + 1;
+    }
+    return council;
+}
+
+fn run() -> Integer {
+    let members = [1, 2, 3, 4];
+    let council = select_council(0, members, 2);
+    return array_len(council);
+}

--- a/icn-ccl/examples/governance_templates/rotating_stewards.ccl
+++ b/icn-ccl/examples/governance_templates/rotating_stewards.ccl
@@ -1,0 +1,12 @@
+// Rotating steward template
+// Cycles through a list of steward member IDs
+fn next_steward(cycle: Integer, stewards: Array<Integer>) -> Integer {
+    let count = array_len(stewards);
+    let index = cycle % count;
+    return stewards[index];
+}
+
+fn run() -> Integer {
+    let stewards = [1, 2, 3];
+    return next_steward(0, stewards);
+}

--- a/icn-ccl/examples/governance_templates/simple_voting.ccl
+++ b/icn-ccl/examples/governance_templates/simple_voting.ccl
@@ -1,0 +1,4 @@
+// Simple majority voting procedure
+fn vote_yes(count: Integer) -> Integer { return count + 1; }
+fn vote_no(count: Integer) -> Integer { return count; }
+fn run() -> Integer { return vote_yes(0); }

--- a/icn-ccl/examples/governance_templates/treasury_rules.ccl
+++ b/icn-ccl/examples/governance_templates/treasury_rules.ccl
@@ -1,0 +1,4 @@
+// Example treasury withdrawal policy
+fn request_funds(amount: Mana) -> Mana { return amount; }
+fn approve(amount: Mana) -> Mana { return amount; }
+fn run() -> Mana { return approve(request_funds(10)); }


### PR DESCRIPTION
## Summary
- add governance template files under `icn-ccl/examples/governance_templates`
- document governance onboarding with a new guide
- link to governance onboarding in README and feature overview
- update docs referencing example path

## Testing
- `cargo test --workspace --quiet` *(fails: could not compile `icn-network`)*

------
https://chatgpt.com/codex/tasks/task_e_68757d76759483249c0e4267acdb66dc