### PR TITLE
Implement external governance ingestion

### DIFF
--- a/crates/icn-runtime/tests/integration/cross_node_governance.rs
+++ b/crates/icn-runtime/tests/integration/cross_node_governance.rs
@@ -68,8 +68,7 @@ mod cross_node_governance {
         })
         .await
         .expect("timeout waiting for proposal");
-        // TODO: Implement proper external proposal ingestion
-        // node_b.ingest_external_proposal(&proposal_bytes).await?;
+        node_b.ingest_external_proposal(&proposal_bytes).await?;
         let proposal: Proposal = bincode::deserialize(&proposal_bytes)?;
         {
             let gov = node_b.governance_module.lock().await;
@@ -93,8 +92,7 @@ mod cross_node_governance {
         })
         .await
         .expect("timeout waiting for vote");
-        // TODO: Implement proper external vote ingestion
-        // node_a.ingest_external_vote(&vote_bytes).await?;
+        node_a.ingest_external_vote(&vote_bytes).await?;
         {
             let gov = node_a.governance_module.lock().await;
             let pid = icn_governance::ProposalId(pid_str.clone());


### PR DESCRIPTION
## Summary
- add `ingest_external_proposal` and `ingest_external_vote` methods to `RuntimeContext`
- use the ingestion methods in the cross-node governance integration test

## Testing
- `just test` *(fails: could not compile `icn-network`)*

------
https://chatgpt.com/codex/tasks/task_e_68757d6848ac8324883db294d0b06c18