### PR TITLE
Add federation CLI and devnet automation

### DIFF
--- a/crates/icn-cli/Cargo.toml
+++ b/crates/icn-cli/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = "1.0"
 base64 = "0.21"
 bincode = "1"
 
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/icn-cli/README.md
+++ b/crates/icn-cli/README.md
@@ -30,6 +30,36 @@ The `icn-cli` is the primary tool for users to interact with an ICN node from th
     *   `icn-cli federation list-peers`: List peers known to the node.
     *   `icn-cli federation status`: Display federation status including peer count.
     *   `icn-cli federation sync`: Synchronize federation state with peers.
+
+### Federation Examples (with `icn-devnet`)
+
+```bash
+# Initialize the federation on the bootstrap node
+cargo run -p icn-cli -- \
+  --api-url http://localhost:5001 \
+  --api-key devnet-a-key \
+  federation init
+
+# Join additional nodes to the federation
+cargo run -p icn-cli -- \
+  --api-url http://localhost:5002 \
+  --api-key devnet-b-key \
+  federation join http://localhost:5001
+
+cargo run -p icn-cli -- \
+  --api-url http://localhost:5003 \
+  --api-key devnet-c-key \
+  federation join http://localhost:5001
+
+# Synchronize federation state
+cargo run -p icn-cli -- \
+  --api-url http://localhost:5001 \
+  --api-key devnet-a-key \
+  federation sync
+```
+
+`icn-devnet/launch_federation.sh` runs these commands automatically when the
+containers start so the federation is ready for testing.
 *   **Identity Operations:**
     *   `icn-cli identity generate-proof <PROOF_REQUEST_JSON>`: Produce a zero-knowledge proof from the supplied request JSON.
     *   `icn-cli identity verify-proof <PROOF_JSON>`: Verify a proof and print whether it is valid.

--- a/crates/icn-network/src/lib.rs
+++ b/crates/icn-network/src/lib.rs
@@ -1705,7 +1705,8 @@ pub mod libp2p_service {
                         })?;
                     rx.await.map_err(|e| {
                         MeshNetworkError::Libp2p(format!("Connect response failed: {}", e))
-                    })
+                    })?;
+                    Ok(())
                 }
             })
             .await

--- a/icn-devnet/launch_federation.sh
+++ b/icn-devnet/launch_federation.sh
@@ -159,6 +159,27 @@ wait_for_network_convergence() {
     done
 }
 
+# Configure federation using icn-cli
+setup_federation_cli() {
+    log "Setting up federation with icn-cli..."
+    cargo run -p icn-cli -- \
+        --api-url "$NODE_A_URL" \
+        --api-key "$NODE_A_API_KEY" \
+        federation init >/dev/null
+    cargo run -p icn-cli -- \
+        --api-url "$NODE_B_URL" \
+        --api-key "$NODE_B_API_KEY" \
+        federation join "$NODE_A_URL" >/dev/null
+    cargo run -p icn-cli -- \
+        --api-url "$NODE_C_URL" \
+        --api-key "$NODE_C_API_KEY" \
+        federation join "$NODE_A_URL" >/dev/null
+    cargo run -p icn-cli -- \
+        --api-url "$NODE_A_URL" \
+        --api-key "$NODE_A_API_KEY" \
+        federation sync >/dev/null
+}
+
 # Test basic node functionality and job submission
 test_mesh_job_execution() {
     log "Testing basic node functionality and job submission..."
@@ -272,6 +293,8 @@ main() {
     
     # Wait for network convergence
     wait_for_network_convergence
+
+    setup_federation_cli
 
     if [ "$START_ONLY" = true ]; then
         success "Federation started (start-only mode)"


### PR DESCRIPTION
## Summary
- extend `icn-cli` with `--api-key` option and forward headers
- expose federation `init`, `join`, and `sync` commands
- document federation examples in CLI README
- wire up federation setup in devnet launch script
- fix network connect_peer return

## Testing
- `cargo check -p icn-cli`
- `cargo test -p icn-cli --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68757d7132888324aaff87256ede11b7