### PR TITLE
Add DAG status endpoint

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -836,7 +836,8 @@ pub async fn app_router_with_options(
             .route("/dag/get", post(dag_get_handler)) // These will use RT context's DAG store
             .route("/dag/meta", post(dag_meta_handler))
             .route("/dag/root", get(dag_root_handler))
-            .route("/dag/sync", get(dag_sync_status_handler))
+            .route("/dag/status", get(dag_status_handler))
+            .route("/dag/sync", get(dag_status_handler))
             .route("/dag/pin", post(dag_pin_handler))
             .route("/dag/unpin", post(dag_unpin_handler))
             .route("/dag/prune", post(dag_prune_handler))
@@ -993,7 +994,8 @@ pub async fn app_router_from_context(
         .route("/dag/get", post(dag_get_handler))
         .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/root", get(dag_root_handler))
-        .route("/dag/sync", get(dag_sync_status_handler))
+        .route("/dag/status", get(dag_status_handler))
+        .route("/dag/sync", get(dag_status_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1291,7 +1293,8 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         .route("/dag/get", post(dag_get_handler))
         .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/root", get(dag_root_handler))
-        .route("/dag/sync", get(dag_sync_status_handler))
+        .route("/dag/status", get(dag_status_handler))
+        .route("/dag/sync", get(dag_status_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1759,8 +1762,8 @@ async fn dag_root_handler(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
-/// GET /dag/sync – Report DAG synchronization status.
-async fn dag_sync_status_handler(State(state): State<AppState>) -> impl IntoResponse {
+/// GET /dag/status – Report DAG synchronization status.
+async fn dag_status_handler(State(state): State<AppState>) -> impl IntoResponse {
     match state.runtime_context.get_dag_sync_status().await {
         Ok(status) => (StatusCode::OK, Json(status)).into_response(),
         Err(e) => map_rust_error_to_json_response(

--- a/crates/icn-sdk/src/lib.rs
+++ b/crates/icn-sdk/src/lib.rs
@@ -795,6 +795,11 @@ impl IcnClient {
         self.get("/dag/root").await
     }
 
+    /// Get DAG synchronization status.
+    pub async fn dag_status(&self) -> Result<serde_json::Value, reqwest::Error> {
+        self.get("/dag/status").await
+    }
+
     // === Network Operations ===
 
     /// Get the local peer ID.

--- a/docs/API.md
+++ b/docs/API.md
@@ -40,6 +40,7 @@ curl -X GET https://localhost:8080/info \
 | POST | `/dag/put` | Store a content-addressed block | Yes |
 | POST | `/dag/get` | Retrieve a block by CID | Yes |
 | POST | `/dag/meta` | Retrieve metadata for a block | Yes |
+| GET  | `/dag/status` | Retrieve DAG synchronization status | Yes |
 | POST | `/dag/pin` | Pin a block to prevent pruning | Yes |
 | POST | `/dag/unpin` | Remove a pin from a block | Yes |
 | POST | `/dag/prune` | Garbage collect unpinned blocks | Yes |
@@ -64,6 +65,10 @@ curl -X POST https://localhost:8080/dag/meta \
   -H "Content-Type: application/json" \
   -H "x-api-key: your-api-key" \
   -d '{"cid": "your-cid-string"}'
+
+# Check DAG synchronization status
+curl -X GET https://localhost:8080/dag/status \
+  -H "x-api-key: your-api-key"
 
 # Pin a DAG block
 curl -X POST https://localhost:8080/dag/pin \

--- a/scripts/remote-utils.sh
+++ b/scripts/remote-utils.sh
@@ -780,10 +780,14 @@ verify_federation_health() {
     
     for node_name in "${!REMOTE_NODES[@]}"; do
         ((total_nodes++))
-        
+
         if ssh "icn-$node_name" "systemctl is-active icn-node" &>/dev/null; then
-            log "SUCCESS" "Node healthy: $node_name" "REMOTE"
-            ((healthy_nodes++))
+            if ssh "icn-$node_name" "curl -s -f http://localhost:8080/dag/status" &>/dev/null; then
+                log "SUCCESS" "Node healthy: $node_name" "REMOTE"
+                ((healthy_nodes++))
+            else
+                log "ERROR" "Node DAG check failed: $node_name" "REMOTE"
+            fi
         else
             log "ERROR" "Node unhealthy: $node_name" "REMOTE"
         fi

--- a/tests/integration/comprehensive_e2e.rs
+++ b/tests/integration/comprehensive_e2e.rs
@@ -257,6 +257,19 @@ impl E2ETestHarness {
             assert!(info["name"].is_string(), "Node {} missing name", node.name);
             assert!(info["version"].is_string(), "Node {} missing version", node.name);
             
+            // Check DAG synchronization status
+            let dag_resp = self.client
+                .get(&format!("{}/dag/status", node.url))
+                .header("X-API-Key", &node.api_key)
+                .send()
+                .await
+                .expect(&format!("Failed to fetch DAG status from {}", node.name));
+
+            assert!(dag_resp.status().is_success(), "Node {} DAG status", node.name);
+
+            let dag_status: Value = dag_resp.json().await.expect("dag json");
+            assert!(dag_status.get("current_root").is_some());
+
             println!("  ✅ {} is healthy", node.name);
         }
         

--- a/tests/integration/dag_sync.rs
+++ b/tests/integration/dag_sync.rs
@@ -18,7 +18,7 @@ async fn dag_sync_status_consistency() {
         let mut roots = Vec::new();
         for url in [NODE_A_URL, NODE_B_URL, NODE_C_URL] {
             let resp = client
-                .get(&format!("{}/dag/sync", url))
+                .get(&format!("{}/dag/status", url))
                 .send()
                 .await
                 .expect("dag sync");


### PR DESCRIPTION
## Summary
- expose `/dag/status` endpoint on the node
- add DAG status method in the SDK
- verify DAG health in federation scripts and tests
- document the new endpoint

## Testing
- `cargo test -p icn-common --lib`
- `cargo test -p icn-sdk --lib`
- *(failure)* `cargo test -p icn-node --lib`

------
https://chatgpt.com/codex/tasks/task_e_68757d6eab0483249031e504662f17f1