### PR TITLE
[docs] add governance reward templates

### DIFF
--- a/crates/icn-governance/README.md
+++ b/crates/icn-governance/README.md
@@ -39,6 +39,8 @@ When built with the `federation` feature, this crate exposes
 Reusable CCL snippets for rewarding contributors live in `templates/`. Examples:
 - `reward_member.ccl` — grant scoped tokens to a specific member.
 - `community_bonus.ccl` — distribute a bonus to all members.
+- `dao_reward_issuance.ccl` — issue DAO reward tokens to members.
+- `contributor_recognition.ccl` — mint a recognition badge for a contributor.
 
 
 ## Contributing

--- a/crates/icn-governance/templates/contributor_recognition.ccl
+++ b/crates/icn-governance/templates/contributor_recognition.ccl
@@ -1,0 +1,13 @@
+// Proposal template: mint a recognition badge for a contributor
+class RecognitionBadge {
+    transferable: false
+}
+
+fn recognize(member: Did) -> Integer {
+    mint("RecognitionBadge", 1, member);
+    return 0;
+}
+
+fn run() -> Integer {
+    return recognize(member);
+}

--- a/crates/icn-governance/templates/dao_reward_issuance.ccl
+++ b/crates/icn-governance/templates/dao_reward_issuance.ccl
@@ -1,0 +1,13 @@
+// Proposal template: issue reward tokens to DAO members
+class DaoReward {
+    transferable: true
+}
+
+fn issue(member: Did, amount: Integer) -> Integer {
+    mint("DaoReward", amount, member);
+    return amount;
+}
+
+fn run() -> Integer {
+    return issue(member, 1);
+}

--- a/docs/developer_incentives.md
+++ b/docs/developer_incentives.md
@@ -1,0 +1,17 @@
+# Developer Incentives
+
+This guide explains how to reward open source contributors using the governance templates shipped with `icn-core`.
+
+## Usage
+
+1. Pick a template under `crates/icn-governance/templates/`:
+   - `dao_reward_issuance.ccl` issues transferable DAO reward tokens.
+   - `contributor_recognition.ccl` mints a non-transferable recognition badge.
+2. Compile the chosen template:
+   ```bash
+   icn-cli ccl compile dao_reward_issuance.ccl
+   ```
+3. Submit a proposal referencing the compiled module via your governance tooling.
+4. Once approved, the runtime executes the policy and distributes tokens.
+
+Modify these templates or mana costs to match your cooperative's incentive policy.

--- a/docs/reputation_integration.md
+++ b/docs/reputation_integration.md
@@ -15,3 +15,11 @@ Relevant code:
 When minting scoped tokens, issuers pay mana. The `price_by_reputation` helper reduces this cost based on the issuer's reputation, enabling trusted contributors to create resources more cheaply.
 
 The new `mint_tokens_with_reputation` function demonstrates this linkage.
+
+## Converting Reputation to Mana or Tokens
+
+Governance policies can directly convert reputation scores into usable mana or
+resource tokens. Community members with higher reputation may receive extra
+credit via `credit_by_reputation` or earn bonus tokens when contracts call
+`mint_tokens_with_reputation`. This allows cooperatives to reward trusted
+contributors without relying on speculative markets.


### PR DESCRIPTION
## Summary
- add DAO reward issuance and contributor recognition templates
- document new templates in `icn-governance` README
- explain reputation conversion in `reputation_integration.md`
- provide usage instructions in `developer_incentives.md`

## Testing
- `cargo fmt --all -- --check` *(fails: diff output)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(interrupted)*
- `cargo test --all-features --workspace` *(interrupted)*
- `cargo test -p icn-ccl` *(interrupted)*
- `just test-ccl-contracts` *(fails: recipe not found)*
- `just test-covm-execution` *(fails: recipe not found)*

------
https://chatgpt.com/codex/tasks/task_e_68757d7726e083248d1d56e682b9a273