### PR TITLE
Add mutual aid registry and reputation tokens

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -46,6 +46,7 @@ pub mod dag_trait;
 pub mod federation_trait;
 pub mod governance_trait;
 pub mod identity_trait;
+pub mod mutual_aid_trait;
 /// Prometheus metrics helpers
 pub mod metrics;
 use crate::governance_trait::{

--- a/crates/icn-api/src/mutual_aid_trait.rs
+++ b/crates/icn-api/src/mutual_aid_trait.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+use icn_common::CommonError;
+use icn_dag::mutual_aid::AidResource;
+
+#[async_trait]
+pub trait MutualAidApi {
+    async fn list_resources(&self) -> Result<Vec<AidResource>, CommonError>;
+    async fn register_resource(&self, resource: AidResource) -> Result<(), CommonError>;
+}

--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -155,6 +155,11 @@ enum Commands {
         #[clap(subcommand)]
         command: FederationCommands,
     },
+    /// Mutual aid resource registry
+    Aid {
+        #[clap(subcommand)]
+        command: AidCommands,
+    },
     /// Emergency response coordination
     Emergency {
         #[clap(subcommand)]
@@ -343,6 +348,17 @@ enum EmergencyCommands {
     Request {
         #[clap(help = "Aid request JSON or '-' for stdin")]
         request_json_or_stdin: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum AidCommands {
+    /// List available aid resources
+    List,
+    /// Register a new aid resource
+    Register {
+        #[clap(help = "Aid resource JSON or '-' for stdin")]
+        resource_json_or_stdin: String,
     },
 }
 
@@ -542,6 +558,12 @@ async fn run_command(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
             FederationCommands::ListPeers => handle_fed_list_peers(cli, client).await?,
             FederationCommands::Status => handle_fed_status(cli, client).await?,
             FederationCommands::Sync => handle_fed_sync(cli, client).await?,
+        },
+        Commands::Aid { command } => match command {
+            AidCommands::List => handle_aid_list(cli, client).await?,
+            AidCommands::Register { resource_json_or_stdin } => {
+                handle_aid_register(cli, client, resource_json_or_stdin).await?
+            }
         },
         Commands::Emergency { command } => match command {
             EmergencyCommands::List => handle_emergency_list(cli, client).await?,
@@ -1433,6 +1455,31 @@ async fn handle_emergency_request(
     let _: serde_json::Value =
         post_request(&cli.api_url, client, "/emergency/request", &body).await?;
     println!("Aid request submitted");
+    Ok(())
+}
+
+async fn handle_aid_list(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
+    let v: serde_json::Value = get_request(&cli.api_url, client, "/aid/resources").await?;
+    println!("{}", serde_json::to_string_pretty(&v)?);
+    Ok(())
+}
+
+async fn handle_aid_register(
+    cli: &Cli,
+    client: &Client,
+    resource_json_or_stdin: &str,
+) -> Result<(), anyhow::Error> {
+    let content = if resource_json_or_stdin == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        resource_json_or_stdin.to_string()
+    };
+    let body: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| anyhow::anyhow!("Invalid aid resource JSON: {}", e))?;
+    let _: serde_json::Value = post_request(&cli.api_url, client, "/aid/resource", &body).await?;
+    println!("Aid resource registered");
     Ok(())
 }
 

--- a/crates/icn-dag/src/mutual_aid.rs
+++ b/crates/icn-dag/src/mutual_aid.rs
@@ -1,4 +1,7 @@
-use icn_common::Did;
+use icn_common::{
+    compute_merkle_cid, CommonError, DagBlock, Did, SystemTimeProvider, TimeProvider,
+};
+use crate::StorageService;
 use serde::{Deserialize, Serialize};
 
 /// Record describing a resource available for mutual aid.
@@ -15,4 +18,58 @@ pub struct AidResource {
     /// Arbitrary classification tags.
     #[serde(default)]
     pub tags: Vec<String>,
+}
+
+/// Registry service storing [`AidResource`] records in a DAG store.
+pub struct MutualAidRegistry<S: StorageService<DagBlock>> {
+    store: S,
+}
+
+impl<S: StorageService<DagBlock>> MutualAidRegistry<S> {
+    /// Create a new registry using the provided store.
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+
+    /// Register a new aid resource and return its CID.
+    pub fn register(
+        &mut self,
+        resource: &AidResource,
+        author: &Did,
+    ) -> Result<String, CommonError> {
+        let data = serde_json::to_vec(resource).map_err(|e| {
+            CommonError::SerializationError(format!("aid resource: {}", e))
+        })?;
+        let ts = SystemTimeProvider.unix_seconds();
+        let cid = compute_merkle_cid(0x71, &data, &[], ts, author, &None, &None);
+        let block = DagBlock {
+            cid: cid.clone(),
+            data,
+            links: vec![],
+            timestamp: ts,
+            author_did: author.clone(),
+            signature: None,
+            scope: None,
+        };
+        self.store.put(&block)?;
+        Ok(cid.to_string())
+    }
+
+    /// List all registered resources.
+    pub fn list(&self) -> Result<Vec<AidResource>, CommonError> {
+        let blocks = self.store.list_blocks()?;
+        Ok(blocks
+            .into_iter()
+            .filter_map(|b| serde_json::from_slice::<AidResource>(&b.data).ok())
+            .collect())
+    }
+
+    /// Find resources that contain the specified tag.
+    pub fn find_by_tag(&self, tag: &str) -> Result<Vec<AidResource>, CommonError> {
+        Ok(self
+            .list()?
+            .into_iter()
+            .filter(|r| r.tags.iter().any(|t| t == tag))
+            .collect())
+    }
 }

--- a/crates/icn-economics/src/reputation_tokens.rs
+++ b/crates/icn-economics/src/reputation_tokens.rs
@@ -1,0 +1,47 @@
+use crate::{burn_tokens, mint_tokens_with_reputation, ManaLedger, NodeScope, ResourceLedger, ResourceRepositoryAdapter};
+use icn_common::{CommonError, Did};
+
+/// Resource class identifier for reputation reward tokens.
+pub const REPUTATION_CLASS: &str = "reputation_reward";
+
+/// Grant non-transferable reputation tokens to a recipient.
+pub fn grant_reputation_tokens<L: ResourceLedger, M: ManaLedger>(
+    repo: &ResourceRepositoryAdapter<L>,
+    mana_ledger: &M,
+    reputation_store: &dyn icn_reputation::ReputationStore,
+    issuer: &Did,
+    recipient: &Did,
+    amount: u64,
+    scope: Option<NodeScope>,
+) -> Result<(), CommonError> {
+    mint_tokens_with_reputation(
+        repo,
+        mana_ledger,
+        reputation_store,
+        issuer,
+        REPUTATION_CLASS,
+        amount,
+        recipient,
+        scope,
+    )
+}
+
+/// Consume reputation tokens from the owner's balance.
+pub fn use_reputation_tokens<L: ResourceLedger, M: ManaLedger>(
+    repo: &ResourceRepositoryAdapter<L>,
+    mana_ledger: &M,
+    issuer: &Did,
+    owner: &Did,
+    amount: u64,
+    scope: Option<NodeScope>,
+) -> Result<(), CommonError> {
+    burn_tokens(
+        repo,
+        mana_ledger,
+        issuer,
+        REPUTATION_CLASS,
+        amount,
+        owner,
+        scope,
+    )
+}

--- a/crates/icn-mesh/src/aid.rs
+++ b/crates/icn-mesh/src/aid.rs
@@ -1,6 +1,9 @@
 use crate::JobSpec;
 use icn_common::Did;
 use serde::{Deserialize, Serialize};
+use icn_dag::mutual_aid::MutualAidRegistry;
+use icn_common::DagBlock;
+use icn_dag::StorageService;
 
 /// Request for community aid.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -37,4 +40,22 @@ pub fn match_aid_requests<'a>(
         }
     }
     matches
+}
+
+/// Pull open aid requests from a [`MutualAidRegistry`] and match them with templates.
+pub fn match_registry_requests<'a, S: StorageService<DagBlock>>(
+    registry: &MutualAidRegistry<S>,
+    templates: &'a [AidJobTemplate],
+) -> Result<Vec<(AidRequest, &'a AidJobTemplate)>, icn_common::CommonError> {
+    let requests = registry.list()?;
+    let mut matches = Vec::new();
+    for req in &requests {
+        for tmpl in templates {
+            if tmpl.tags.iter().any(|t| req.tags.contains(t)) {
+                matches.push((req.clone(), tmpl));
+                break;
+            }
+        }
+    }
+    Ok(matches)
 }


### PR DESCRIPTION
## Summary
- link reputation to non-transferable token grants
- store mutual aid resources in the DAG
- match templates with requests from the registry
- expose mutual aid registry API traits
- manage aid resources via CLI

## Testing
- `cargo check -p icn-dag`
- `cargo check -p icn-economics`
- `cargo check -p icn-mesh`
- `cargo check -p icn-api`
- `cargo check -p icn-cli` *(fails: could not compile `icn-network`)*

------
https://chatgpt.com/codex/tasks/task_e_687585351ea4832489d3d3d812a6b2ff