### PR TITLE
[runtime] add environment constructors

### DIFF
--- a/ICN_IMPLEMENTATION_STATUS_MATRIX.md
+++ b/ICN_IMPLEMENTATION_STATUS_MATRIX.md
@@ -182,9 +182,9 @@ The main problem is that some contexts default to stub services instead of produ
 
 | Method | Services Used | Purpose | Status |
 |--------|---------------|---------|--------|
-| **`new_for_production()`** | All production services | Production deployments | ❌ Needs implementation |
-| **`new_for_testing()`** | All stub services | Testing only | ❌ Needs implementation |
-| **`new_for_development()`** | Mixed services | Development work | ❌ Needs implementation |
+| **`new_for_production()`** | All production services | Production deployments | ✅ Implemented |
+| **`new_for_testing()`** | All stub services | Testing only | ✅ Implemented |
+| **`new_for_development()`** | Mixed services | Development work | ✅ Implemented |
 
 ### **Service Selection Matrix**
 

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -664,7 +664,7 @@ pub async fn app_router_with_options(
         #[cfg(feature = "enable-libp2p")]
         {
             // For production/development with real networking
-            RuntimeContext::new_development(
+            RuntimeContext::new_for_development(
                 node_did.clone(),
                 _signer.clone(),
                 mana_ledger,
@@ -676,7 +676,7 @@ pub async fn app_router_with_options(
         #[cfg(not(feature = "enable-libp2p"))]
         {
             // For testing without networking - use stub services
-            RuntimeContext::new_testing(node_did.clone(), Some(1000))
+            RuntimeContext::new_for_testing(node_did.clone(), Some(1000))
                 .expect("Failed to create testing RuntimeContext")
         }
     };
@@ -1146,10 +1146,10 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg_attr(not(feature = "persist-sled"), allow(unused_mut))]
     let mut rt_ctx = if config.test_mode {
-        RuntimeContext::new_testing(node_did.clone(), Some(1000))
+        RuntimeContext::new_for_testing(node_did.clone(), Some(1000))
             .expect("Failed to create RuntimeContext for testing")
     } else {
-        RuntimeContext::new(
+        RuntimeContext::new_for_production(
             node_did.clone(),
             network_service,
             signer.clone(),

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -283,6 +283,54 @@ impl RuntimeContext {
         Ok(ctx)
     }
 
+    /// Create a RuntimeContext configured for production deployments.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_for_production(
+        current_identity: Did,
+        network_service: Arc<dyn icn_network::NetworkService>,
+        signer: Arc<dyn Signer>,
+        did_resolver: Arc<dyn icn_identity::DidResolver>,
+        dag_store: Arc<DagStoreMutexType<DagStorageService>>,
+        mana_ledger: SimpleManaLedger,
+        reputation_store: Arc<dyn icn_reputation::ReputationStore>,
+        policy_enforcer: Option<Arc<dyn icn_governance::scoped_policy::ScopedPolicyEnforcer>>,
+    ) -> Result<Arc<Self>, CommonError> {
+        Self::new(
+            current_identity,
+            network_service,
+            signer,
+            did_resolver,
+            dag_store,
+            mana_ledger,
+            reputation_store,
+            policy_enforcer,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_for_development(
+        current_identity: Did,
+        signer: Arc<dyn Signer>,
+        mana_ledger: SimpleManaLedger,
+        network_service: Option<Arc<dyn icn_network::NetworkService>>,
+        dag_store: Option<Arc<DagStoreMutexType<DagStorageService>>>,
+    ) -> Result<Arc<Self>, CommonError> {
+        Self::new_development(
+            current_identity,
+            signer,
+            mana_ledger,
+            network_service,
+            dag_store,
+        )
+    }
+
+    pub fn new_for_testing(
+        current_identity: Did,
+        initial_mana: Option<u64>,
+    ) -> Result<Arc<Self>, CommonError> {
+        Self::new_testing(current_identity, initial_mana)
+    }
+
     /// Create a new context with ledger path (convenience method for tests).
     ///
     /// **⚠️ DEPRECATED**: This method uses stub services and should not be used in production.


### PR DESCRIPTION
## Summary
- implement `new_for_production`, `new_for_testing`, and `new_for_development`
- use new constructors in `icn-node`
- document constructor availability in status matrix

## Testing
- `cargo fmt --check`

------
https://chatgpt.com/codex/tasks/task_e_68757d6931708324ae3d885f2ccfea60