### PR TITLE
Add DAG sync status endpoint

### DIFF
--- a/crates/icn-api/src/lib.rs
+++ b/crates/icn-api/src/lib.rs
@@ -474,9 +474,10 @@ where
     async fn get_dag_sync_status(&self) -> Result<DagSyncStatus, CommonError> {
         let store = self.store.lock().await;
         let root = icn_dag::current_root(&*store).await?;
+        let in_sync = root.is_some();
         Ok(DagSyncStatus {
             current_root: root,
-            in_sync: true,
+            in_sync,
         })
     }
 }

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -856,7 +856,7 @@ pub async fn app_router_with_options(
             .route("/dag/get", post(dag_get_handler)) // These will use RT context's DAG store
             .route("/dag/meta", post(dag_meta_handler))
             .route("/dag/root", get(dag_root_handler))
-            .route("/dag/sync", get(dag_sync_status_handler))
+            .route("/dag/status", get(dag_status_handler))
             .route("/dag/pin", post(dag_pin_handler))
             .route("/dag/unpin", post(dag_unpin_handler))
             .route("/dag/prune", post(dag_prune_handler))
@@ -1029,7 +1029,7 @@ pub async fn app_router_from_context(
         .route("/dag/get", post(dag_get_handler))
         .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/root", get(dag_root_handler))
-        .route("/dag/sync", get(dag_sync_status_handler))
+        .route("/dag/status", get(dag_status_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1343,7 +1343,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         .route("/dag/get", post(dag_get_handler))
         .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/root", get(dag_root_handler))
-        .route("/dag/sync", get(dag_sync_status_handler))
+        .route("/dag/status", get(dag_status_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1811,12 +1811,12 @@ async fn dag_root_handler(State(state): State<AppState>) -> impl IntoResponse {
     }
 }
 
-/// GET /dag/sync – Report DAG synchronization status.
-async fn dag_sync_status_handler(State(state): State<AppState>) -> impl IntoResponse {
+/// GET /dag/status – Report DAG synchronization status.
+async fn dag_status_handler(State(state): State<AppState>) -> impl IntoResponse {
     match state.runtime_context.get_dag_sync_status().await {
         Ok(status) => (StatusCode::OK, Json(status)).into_response(),
         Err(e) => map_rust_error_to_json_response(
-            format!("DAG sync error: {e}"),
+            format!("DAG status error: {e}"),
             StatusCode::INTERNAL_SERVER_ERROR,
         )
         .into_response(),

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -1539,9 +1539,10 @@ impl RuntimeContext {
         let root = icn_dag::current_root(&*store).await.map_err(|e| {
             HostAbiError::DagOperationFailed(format!("Failed to get DAG root: {}", e))
         })?;
+        let in_sync = root.is_some();
         Ok(icn_common::DagSyncStatus {
             current_root: root,
-            in_sync: true,
+            in_sync,
         })
     }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -43,6 +43,7 @@ curl -X GET https://localhost:8080/info \
 | POST | `/dag/pin` | Pin a block to prevent pruning | Yes |
 | POST | `/dag/unpin` | Remove a pin from a block | Yes |
 | POST | `/dag/prune` | Garbage collect unpinned blocks | Yes |
+| GET | `/dag/status` | Current DAG root and sync state | Optional |
 
 ### Example DAG Operations
 ```bash
@@ -76,6 +77,10 @@ curl -X POST https://localhost:8080/dag/unpin \
   -H "Content-Type: application/json" \
   -H "x-api-key: your-api-key" \
   -d '{"cid": "your-cid-string"}'
+
+# Check DAG synchronization status
+curl -X GET https://localhost:8080/dag/status \
+  -H "x-api-key: your-api-key"
 ```
 
 ## Transaction Endpoints

--- a/tests/integration/dag_sync.rs
+++ b/tests/integration/dag_sync.rs
@@ -18,7 +18,7 @@ async fn dag_sync_status_consistency() {
         let mut roots = Vec::new();
         for url in [NODE_A_URL, NODE_B_URL, NODE_C_URL] {
             let resp = client
-                .get(&format!("{}/dag/sync", url))
+                .get(&format!("{}/dag/status", url))
                 .send()
                 .await
                 .expect("dag sync");

--- a/tests/integration/federation.rs
+++ b/tests/integration/federation.rs
@@ -80,6 +80,13 @@ async fn test_federation_node_health() {
         assert!(info["name"].is_string());
         assert!(info["version"].is_string());
 
+        let dag_resp = client
+            .get(&format!("{}/dag/status", url))
+            .send()
+            .await
+            .expect("dag status");
+        assert!(dag_resp.status().is_success());
+
         println!("    ✅ {} is healthy", name);
     }
 


### PR DESCRIPTION
## Summary
- add `/dag/status` HTTP endpoint
- compute DAG sync info in runtime & DAG API
- update federation health checks
- document the new endpoint

## Testing
- `cargo test --all-features --workspace` *(fails: could not compile `icn-node`)*

------
https://chatgpt.com/codex/tasks/task_e_687585ca3e808324aa079d3a5f4954dc