### PR TITLE
Add runtime validation for production services

### DIFF
--- a/crates/icn-runtime/src/context/signers.rs
+++ b/crates/icn-runtime/src/context/signers.rs
@@ -31,6 +31,7 @@ pub trait Signer: Send + Sync + std::fmt::Debug {
     fn public_key_bytes(&self) -> Vec<u8>;
     fn did(&self) -> Did;
     fn verifying_key_ref(&self) -> &VerifyingKey;
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 /// Helper function to create DID from verifying key
@@ -111,6 +112,10 @@ impl Signer for StubSigner {
 
     fn verifying_key_ref(&self) -> &VerifyingKey {
         &self.pk
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 
@@ -273,6 +278,10 @@ impl Signer for Ed25519Signer {
 
     fn verifying_key_ref(&self) -> &VerifyingKey {
         &self.pk
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
 }
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -306,7 +306,9 @@ pub fn create_test_job() -> MeshJob {
 
 // Test context
 pub async fn create_test_context() -> RuntimeContext {
-    RuntimeContext::new_for_test().await
+    use icn_runtime::RuntimeContext;
+    let did = icn_common::Did::new("key", "test_node");
+    RuntimeContext::new_for_testing(did, Some(1000)).unwrap()
 }
 
 // Mock implementations

--- a/docs/PRODUCTION_SECURITY_GUIDE.md
+++ b/docs/PRODUCTION_SECURITY_GUIDE.md
@@ -24,11 +24,20 @@ ICN implements multiple layers of security:
 ICN has migrated from development `StubSigner` to production-grade `Ed25519Signer` with memory protection:
 
 ```rust
-// Production deployment (automatic)
-let runtime_context = RuntimeContext::new_with_real_libp2p(config).await?;
+// Production deployment
+let runtime_context = RuntimeContext::new_for_production(
+    node_did,
+    network_service,
+    signer,
+    Arc::new(icn_identity::KeyDidResolver),
+    dag_store,
+    mana_ledger,
+    reputation_store,
+    None,
+)?;
 
-// Development/testing (manual)
-let runtime_context = RuntimeContext::new_with_stub_signer(config).await?;
+// Development or testing
+let runtime_context = RuntimeContext::new_for_testing(node_did, Some(1000))?;
 ```
 
 ### **Ed25519Signer Features**


### PR DESCRIPTION
## Summary
- extend `Signer` trait with `as_any` and implement for signers
- validate signer and DAG store types in `RuntimeContext::validate_production_services`
- update docs for new `new_for_production`/`new_for_testing` pattern

## Testing
- `cargo check -p icn-runtime`

------
https://chatgpt.com/codex/tasks/task_e_687594c218bc83249a75ce40b86a6e80