### PR TITLE
Enable governance tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run tests
         run: cargo test --all-features --workspace --exclude icn-integration-tests
 
+      - name: Run governance tests (production config)
+        run: cargo test -p icn-governance
+
       - name: Run icn-cli integration tests
         run: cargo test --all-features -p icn-cli
 


### PR DESCRIPTION
## Summary
- ensure governance integration tests run on every pull request

## Testing
- `cargo test -p icn-governance`

------
https://chatgpt.com/codex/tasks/task_e_687594ce45288324bfd762869b3c7d48