### PR TITLE
Add sync status endpoint and fork resolution

### DIFF
--- a/configs/federation_quorum_supermajority.toml
+++ b/configs/federation_quorum_supermajority.toml
@@ -1,0 +1,4 @@
+# Federation supermajority quorum configuration (4 of 5 nodes)
+[governance.proposals]
+min_quorum = 0.8
+passing_threshold = 0.66

--- a/configs/quorum_supermajority.toml
+++ b/configs/quorum_supermajority.toml
@@ -1,0 +1,4 @@
+# Supermajority quorum configuration (4 of 5 nodes)
+[governance.proposals]
+min_quorum = 0.8
+passing_threshold = 0.66

--- a/crates/icn-dag/src/lib.rs
+++ b/crates/icn-dag/src/lib.rs
@@ -88,11 +88,12 @@ pub fn choose_canonical_root(mut candidates: Vec<(Cid, u64)>) -> Option<Cid> {
     if candidates.is_empty() {
         return None;
     }
-    candidates.sort_by(|a, b| match a.1.cmp(&b.1) {
+    // Sort by height descending, then lexicographically ascending
+    candidates.sort_by(|a, b| match b.1.cmp(&a.1) {
         std::cmp::Ordering::Equal => a.0.to_string().cmp(&b.0.to_string()),
         other => other,
     });
-    candidates.last().map(|(cid, _)| cid.clone())
+    candidates.first().map(|(cid, _)| cid.clone())
 }
 
 // --- Storage Service Trait ---

--- a/crates/icn-dag/tests/root.rs
+++ b/crates/icn-dag/tests/root.rs
@@ -31,3 +31,23 @@ fn root_deterministic() {
     let root2 = compute_dag_root(&[parent.cid.clone()]);
     assert_eq!(root1, root2);
 }
+
+#[test]
+fn canonical_root_prefers_highest_height() {
+    let a = icn_common::Cid::new_v1_dummy(0x71, 0x12, b"A");
+    let b = icn_common::Cid::new_v1_dummy(0x71, 0x12, b"B");
+    let chosen = icn_dag::choose_canonical_root(vec![(a.clone(), 1), (b.clone(), 2)]).unwrap();
+    assert_eq!(chosen, b);
+}
+
+#[test]
+fn canonical_root_tiebreaks_lexicographically() {
+    let a = icn_common::Cid::new_v1_dummy(0x71, 0x12, b"A");
+    let b = icn_common::Cid::new_v1_dummy(0x71, 0x12, b"B");
+    let chosen = icn_dag::choose_canonical_root(vec![(b.clone(), 1), (a.clone(), 1)]).unwrap();
+    if a.to_string() < b.to_string() {
+        assert_eq!(chosen, a);
+    } else {
+        assert_eq!(chosen, b);
+    }
+}

--- a/crates/icn-network/tests/proposal_gossip.rs
+++ b/crates/icn-network/tests/proposal_gossip.rs
@@ -1,0 +1,68 @@
+use icn_network::{gossip_proposal_with_retry, NetworkService, MeshNetworkError, PeerId, StubNetworkService};
+use icn_protocol::{GossipMessage, MessagePayload, ProtocolMessage};
+use icn_common::Did;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use async_trait::async_trait;
+use tokio::sync::mpsc::Receiver;
+
+#[derive(Debug)]
+struct FlakyService {
+    inner: StubNetworkService,
+    attempts: Arc<Mutex<u32>>,
+    fail_for: u32,
+}
+
+impl FlakyService {
+    fn new(fail_for: u32) -> Self {
+        Self { inner: StubNetworkService::default(), attempts: Arc::new(Mutex::new(0)), fail_for }
+    }
+}
+
+#[async_trait]
+impl NetworkService for FlakyService {
+    async fn discover_peers(&self, t: Option<String>) -> Result<Vec<PeerId>, MeshNetworkError> {
+        self.inner.discover_peers(t).await
+    }
+    async fn send_message(&self, p: &PeerId, m: ProtocolMessage) -> Result<(), MeshNetworkError> {
+        self.inner.send_message(p, m).await
+    }
+    async fn broadcast_message(&self, m: ProtocolMessage) -> Result<(), MeshNetworkError> {
+        let mut count = self.attempts.lock().unwrap();
+        *count += 1;
+        if *count <= self.fail_for {
+            return Err(MeshNetworkError::Libp2p("temporary failure".into()));
+        }
+        self.inner.broadcast_message(m).await
+    }
+    async fn subscribe(&self) -> Result<Receiver<ProtocolMessage>, MeshNetworkError> {
+        self.inner.subscribe().await
+    }
+    async fn get_network_stats(&self) -> Result<icn_network::NetworkStats, MeshNetworkError> {
+        self.inner.get_network_stats().await
+    }
+    async fn store_record(&self, k: String, v: Vec<u8>) -> Result<(), MeshNetworkError> {
+        self.inner.store_record(k, v).await
+    }
+    async fn get_record(&self, k: String) -> Result<Option<Vec<u8>>, MeshNetworkError> {
+        self.inner.get_record(k).await
+    }
+    #[cfg(feature = "libp2p")]
+    async fn connect_peer(&self, addr: libp2p::Multiaddr) -> Result<(), MeshNetworkError> {
+        self.inner.connect_peer(addr).await
+    }
+    fn as_any(&self) -> &dyn std::any::Any { self }
+}
+
+#[tokio::test]
+async fn proposal_gossip_retries() {
+    let service = FlakyService::new(2);
+    let msg = ProtocolMessage::new(
+        MessagePayload::GossipMessage(GossipMessage { topic: "proposal".into(), payload: vec![], ttl: 1 }),
+        Did::from_str("did:key:abc").unwrap(),
+        None,
+    );
+    gossip_proposal_with_retry(&service, msg).await.unwrap();
+    let attempts = *service.attempts.lock().unwrap();
+    assert!(attempts > 2);
+}

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -866,6 +866,7 @@ pub async fn app_router_with_options(
             .route("/dag/meta", post(dag_meta_handler))
             .route("/dag/root", get(dag_root_handler))
             .route("/dag/status", get(dag_status_handler))
+            .route("/sync/status", get(sync_status_handler))
             .route("/dag/pin", post(dag_pin_handler))
             .route("/dag/unpin", post(dag_unpin_handler))
             .route("/dag/prune", post(dag_prune_handler))
@@ -1039,6 +1040,7 @@ pub async fn app_router_from_context(
         .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/root", get(dag_root_handler))
         .route("/dag/status", get(dag_status_handler))
+        .route("/sync/status", get(sync_status_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1353,6 +1355,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         .route("/dag/meta", post(dag_meta_handler))
         .route("/dag/root", get(dag_root_handler))
         .route("/dag/status", get(dag_status_handler))
+        .route("/sync/status", get(sync_status_handler))
         .route("/dag/pin", post(dag_pin_handler))
         .route("/dag/unpin", post(dag_unpin_handler))
         .route("/dag/prune", post(dag_prune_handler))
@@ -1813,6 +1816,18 @@ async fn dag_status_handler(State(state): State<AppState>) -> impl IntoResponse 
         Ok(status) => (StatusCode::OK, Json(status)).into_response(),
         Err(e) => map_rust_error_to_json_response(
             format!("DAG status error: {e}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .into_response(),
+    }
+}
+
+/// GET /sync/status – Report DAG synchronization status (alias).
+async fn sync_status_handler(State(state): State<AppState>) -> impl IntoResponse {
+    match state.runtime_context.get_dag_sync_status().await {
+        Ok(status) => (StatusCode::OK, Json(status)).into_response(),
+        Err(e) => map_rust_error_to_json_response(
+            format!("Sync status error: {e}"),
             StatusCode::INTERNAL_SERVER_ERROR,
         )
         .into_response(),

--- a/tests/integration/dag_sync.rs
+++ b/tests/integration/dag_sync.rs
@@ -19,7 +19,7 @@ async fn dag_sync_status_consistency() {
         let mut all_synced = true;
         for url in [NODE_A_URL, NODE_B_URL, NODE_C_URL] {
             let resp = client
-                .get(&format!("{}/dag/status", url))
+                .get(&format!("{}/sync/status", url))
                 .send()
                 .await
                 .expect("dag sync");

--- a/tests/integration/federation.rs
+++ b/tests/integration/federation.rs
@@ -81,7 +81,7 @@ async fn test_federation_node_health() {
         assert!(info["version"].is_string());
 
         let dag_resp = client
-            .get(&format!("{}/dag/status", url))
+            .get(&format!("{}/sync/status", url))
             .send()
             .await
             .expect("dag status");


### PR DESCRIPTION
## Summary
- add `/sync/status` to node API for runtime DAG sync state
- implement deterministic fork resolution in `icn-dag`
- provide quorum config templates
- test proposal gossip retry logic

## Testing
- `cargo test -p icn-dag choose_canonical_root -- --nocapture` *(fails: build requires rocksdb)*

------
https://chatgpt.com/codex/tasks/task_e_6875c9119b248324b0c1e9b43b85be31