### PR TITLE
Add federation deployment and load test scripts

### DIFF
--- a/docs/ten_node_results.md
+++ b/docs/ten_node_results.md
@@ -36,3 +36,16 @@ failed to start daemon: Error initializing network controller: failed to registe
 ```
 
 As a result, the federation containers never launched and no jobs were submitted. No peer counts or completion times were recorded.
+
+## ❗ Codex Attempt (April 2026)
+
+We executed `scripts/load_test.sh --jobs 5` inside the provided environment. Job
+submissions returned immediately, but the node at `http://localhost:5001` was not
+reachable:
+
+```
+curl: (7) Failed to connect to localhost port 5001: Connection refused
+```
+
+Prometheus was also unavailable so no metrics were captured. The test produced no
+valid results.

--- a/icn-devnet/README.md
+++ b/icn-devnet/README.md
@@ -109,6 +109,31 @@ scripts/run_10node_devnet.sh
 This exposes Prometheus at `http://localhost:9090` and Grafana at
 `http://localhost:3000`.
 
+## Large Federation Deployment
+
+To experiment with more than ten nodes, use `scripts/deploy_large_federation.sh`.
+Specify the desired node count with `--nodes`:
+
+```bash
+# Launch a 15 node federation
+./scripts/deploy_large_federation.sh --nodes 15
+```
+
+The script generates a temporary compose file and starts the requested nodes
+alongside Prometheus and Grafana.
+
+## Load Testing
+
+Once the federation is running you can submit a burst of jobs using
+`scripts/load_test.sh`:
+
+```bash
+./scripts/load_test.sh --jobs 100 --metrics-output results.json
+```
+
+The script sends concurrent job submissions and optionally writes Prometheus
+metrics to the specified output file.
+
 ## 🏗️ Architecture
 
 ### Network Topology

--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# load_test.sh
+# Submit a large number of jobs concurrently against a running node.
+
+CONCURRENT_JOBS=100
+NODE_URL="http://localhost:5001"
+API_KEY="${API_KEY:-devnet-a-key}"
+JOB_FILE="${JOB_FILE:-$(dirname "$0")/../icn-devnet/job_test.json}"
+METRICS_OUTPUT="load_test_results.json"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --jobs)
+      CONCURRENT_JOBS="$2"; shift 2;;
+    --node-url)
+      NODE_URL="$2"; shift 2;;
+    --metrics-output)
+      METRICS_OUTPUT="$2"; shift 2;;
+    *) echo "Usage: $0 [--jobs N] [--node-url URL] [--metrics-output FILE]"; exit 1;;
+  esac
+done
+
+submit_job() {
+  curl -s -X POST "$NODE_URL/mesh/submit" \
+    -H 'Content-Type: application/json' \
+    -H "X-API-Key: $API_KEY" \
+    -d "$(cat "$JOB_FILE")" >/dev/null || true
+}
+
+start_time=$(date +%s)
+for i in $(seq 1 "$CONCURRENT_JOBS"); do
+  submit_job &
+done
+wait
+end_time=$(date +%s)
+
+echo "Submitted $CONCURRENT_JOBS jobs in $((end_time - start_time)) seconds"
+
+METRICS_URL="http://localhost:9090/api/v1/query?query=icn_jobs_completed_total"
+if curl -sf "$METRICS_URL" >/dev/null; then
+  curl -s "$METRICS_URL" > "$METRICS_OUTPUT"
+  echo "Metrics written to $METRICS_OUTPUT"
+fi
+


### PR DESCRIPTION
## Summary
- make `deploy_large_federation.sh` accept `--nodes` for arbitrary federation size
- add `load_test.sh` helper for concurrent job submission
- document new scripts in icn-devnet README
- record failed load test attempt in `ten_node_results.md`

## Testing
- `just format` *(fails: Recipe `format` failed)*
- `just test` *(failed to compile icn-network tests)*

------
https://chatgpt.com/codex/tasks/task_e_6875c90d10c88324adfba35f2c12a241