### PR TITLE
[monitoring] add runtime metrics and health endpoints

### DIFF
--- a/crates/icn-runtime/src/lib.rs
+++ b/crates/icn-runtime/src/lib.rs
@@ -44,8 +44,9 @@ pub use config::{
 };
 pub use context::{
     CastVotePayload, CloseProposalResult, ConcreteHostEnvironment, CreateProposalPayload,
-    DefaultMeshNetworkService, Ed25519Signer, HostEnvironment, JobAssignmentNotice,
-    MeshNetworkService, MeshNetworkServiceType, RuntimeContextBuilder, EnvironmentType, SimpleManaLedger, StubMeshNetworkService,
+    DefaultMeshNetworkService, Ed25519Signer, EnvironmentType, HostEnvironment,
+    JobAssignmentNotice, MeshNetworkService, MeshNetworkServiceType, RuntimeContextBuilder,
+    SimpleManaLedger, StubMeshNetworkService,
 };
 
 #[derive(Debug, Error)]
@@ -145,7 +146,8 @@ pub async fn host_submit_mesh_job(
     let cost_mana = job_to_submit.cost_mana;
 
     // Use the new DAG-integrated job submission method
-    let job_id = ctx.handle_submit_job(manifest_cid, spec_bytes, cost_mana)
+    let job_id = ctx
+        .handle_submit_job(manifest_cid, spec_bytes, cost_mana)
         .await?;
 
     // For backwards compatibility, also queue the job in the pending jobs channel
@@ -280,6 +282,7 @@ pub async fn host_account_credit_mana(
     account_id_str: &str,
     amount: u64,
 ) -> Result<(), HostAbiError> {
+    metrics::HOST_ACCOUNT_CREDIT_MANA_CALLS.inc();
     info!(
         "[host_account_credit_mana] called for account: {} amount: {}",
         account_id_str, amount
@@ -352,6 +355,7 @@ pub async fn host_anchor_receipt(
     receipt_json: &str,
     reputation_updater: &ReputationUpdater,
 ) -> Result<Cid, HostAbiError> {
+    metrics::HOST_ANCHOR_RECEIPT_CALLS.inc();
     debug!(
         "[host_anchor_receipt] Received receipt JSON: {}",
         receipt_json

--- a/crates/icn-runtime/src/metrics.rs
+++ b/crates/icn-runtime/src/metrics.rs
@@ -33,3 +33,12 @@ pub static WASM_MEMORY_GROWTH_DENIED: Lazy<Counter> = Lazy::new(Counter::default
 
 /// Counts denied table growth attempts inside the WASM resource limiter.
 pub static WASM_TABLE_GROWTH_DENIED: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Counts calls to `host_anchor_receipt`.
+pub static HOST_ANCHOR_RECEIPT_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Counts calls to `host_account_credit_mana`.
+pub static HOST_ACCOUNT_CREDIT_MANA_CALLS: Lazy<Counter> = Lazy::new(Counter::default);
+
+/// Tracks the number of known mana ledger accounts.
+pub static MANA_ACCOUNTS_GAUGE: Lazy<Gauge<i64>> = Lazy::new(Gauge::default);

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -88,6 +88,8 @@ Returns overall node health status:
 }
 ```
 
+Example JSON dashboards are available in [`monitoring/dashboards`](../monitoring/dashboards). Import these files into Grafana to visualize runtime metrics such as `runtime_receipts_anchored_total` and `mana_accounts`.
+
 **Status Codes:**
 - `200` - Node is healthy
 - `503` - Node is unhealthy

--- a/monitoring/dashboards/runtime_metrics.json
+++ b/monitoring/dashboards/runtime_metrics.json
@@ -1,0 +1,22 @@
+{
+  "uid": "runtime-metrics",
+  "title": "Runtime Metrics",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Receipts Anchored",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "runtime_receipts_anchored_total"}],
+      "gridPos": {"h":6,"w":12,"x":0,"y":0}
+    },
+    {
+      "type": "stat",
+      "title": "Mana Accounts",
+      "datasource": "Prometheus",
+      "targets": [{"expr": "mana_accounts"}],
+      "gridPos": {"h":4,"w":6,"x":0,"y":6}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- expose new runtime metrics counters and gauges
- wire up `/health` and `/ready` with runtime checks
- include sample Grafana dashboard
- document monitoring setup

## Testing
- `rustfmt --edition 2021 crates/icn-runtime/src/metrics.rs crates/icn-runtime/src/lib.rs crates/icn-runtime/src/context/runtime_context.rs crates/icn-api/src/metrics.rs`
- *(tests and clippy failed to run due to resource limits)*

------
https://chatgpt.com/codex/tasks/task_e_6875c90e9f788324b740648119e260a4