### PR TITLE
[api] add proof generation and verify endpoints

### DIFF
--- a/crates/icn-api/src/identity_trait.rs
+++ b/crates/icn-api/src/identity_trait.rs
@@ -59,6 +59,24 @@ pub struct BatchVerificationResponse {
     pub results: Vec<bool>,
 }
 
+/// Request to generate a credential proof on the node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateProofRequest {
+    pub issuer: Did,
+    pub holder: Did,
+    pub claim_type: String,
+    pub schema: Cid,
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_inputs: Option<serde_json::Value>,
+}
+
+/// Response containing the generated proof.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProofResponse {
+    pub proof: ZkCredentialProof,
+}
+
 #[async_trait]
 pub trait IdentityApi {
     async fn issue_credential(
@@ -98,5 +116,17 @@ pub trait IdentityApi {
     async fn verify_revocation_proof(
         &self,
         proof: ZkRevocationProof,
+    ) -> Result<VerificationResponse, CommonError>;
+
+    /// Generate a zero-knowledge credential proof.
+    async fn generate_zk_proof(
+        &self,
+        request: GenerateProofRequest,
+    ) -> Result<ProofResponse, CommonError>;
+
+    /// Verify a credential proof using the runtime.
+    async fn verify_zk_proof(
+        &self,
+        proof: ZkCredentialProof,
     ) -> Result<VerificationResponse, CommonError>;
 }

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -838,6 +838,8 @@ pub async fn app_router_with_options(
             .route("/keys", get(keys_handler))
             .route("/reputation/{did}", get(reputation_handler))
             .route("/identity/verify", post(zk_verify_handler))
+            .route("/identity/generate-proof", post(zk_generate_handler))
+            .route("/identity/verify-proof", post(zk_verify_handler))
             .route("/identity/verify/revocation", post(zk_verify_revocation_handler))
             .route("/identity/verify/batch", post(zk_verify_batch_handler))
             .route(
@@ -3011,6 +3013,17 @@ async fn reputation_handler(
             map_rust_error_to_json_response(format!("Invalid DID: {e}"), StatusCode::BAD_REQUEST)
                 .into_response()
         }
+    }
+}
+
+// POST /identity/generate-proof - generate a credential proof
+async fn zk_generate_handler(
+    State(state): State<AppState>,
+    Json(req): Json<icn_api::identity_trait::GenerateProofRequest>,
+) -> impl IntoResponse {
+    match icn_runtime::generate_zk_proof(&state.runtime_context, &req).await {
+        Ok(proof) => (StatusCode::OK, Json(proof)).into_response(),
+        Err(e) => map_rust_error_to_json_response(e, StatusCode::BAD_REQUEST).into_response(),
     }
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -244,6 +244,43 @@ curl -X GET https://localhost:8080/federation/peers \
 | GET | `/circuits/{slug}/{version}` | Fetch circuit verifying key | Yes |
 | GET | `/circuits/{slug}` | List available circuit versions | Yes |
 
+## Credential Proof Endpoints
+
+| Method | Path | Description | Auth Required |
+|--------|------|-------------|---------------|
+| POST | `/identity/generate-proof` | Generate a zero-knowledge credential proof | Yes |
+| POST | `/identity/verify-proof` | Verify a credential proof | Yes |
+
+### Example Proof Generation
+```bash
+curl -X POST https://localhost:8080/identity/generate-proof \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{"issuer":"did:key:issuer","holder":"did:key:holder","claim_type":"age_over_18","schema":"bafyschema","backend":"groth16","public_inputs":{"birth_year":2000,"current_year":2020}}'
+```
+Response `200 OK`
+```json
+{
+  "issuer": "did:key:issuer",
+  "holder": "did:key:holder",
+  "claim_type": "age_over_18",
+  "proof": "...",
+  "schema": "bafyschema",
+  "backend": "groth16"
+}
+```
+
+### Example Proof Verification
+```bash
+curl -X POST https://localhost:8080/identity/verify-proof \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{"issuer":"did:key:issuer","holder":"did:key:holder","claim_type":"age_over_18","proof":"0xdead","schema":"bafyschema","backend":"groth16"}'
+```
+Response `200 OK`
+```json
+{ "verified": true }
+```
 ## Example Requests & Responses
 
 ### GET `/info`


### PR DESCRIPTION
## Summary
- support ZK proof creation/verification in `icn-api`
- expose runtime helpers and node routes
- add CLI subcommands for remote proof ops
- document credential proof endpoints

## Testing
- `cargo fmt --all -- --check` *(fails: produced diff)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to compile icn-runtime)*
- `cargo test --all-features --workspace` *(failed to compile icn-runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6875c912e5e08324aa5b494bd3a5a423