### PR TITLE
Add stability test for ABI host indices

### DIFF
--- a/crates/icn-runtime/tests/abi_constants.rs
+++ b/crates/icn-runtime/tests/abi_constants.rs
@@ -1,0 +1,19 @@
+use icn_runtime::abi::*;
+
+#[test]
+fn abi_constants_are_stable() {
+    assert_eq!(ABI_HOST_ACCOUNT_GET_MANA, 10);
+    assert_eq!(ABI_HOST_ACCOUNT_SPEND_MANA, 11);
+    assert_eq!(ABI_HOST_ACCOUNT_CREDIT_MANA, 12);
+    assert_eq!(ABI_HOST_SUBMIT_MESH_JOB, 16);
+    assert_eq!(ABI_HOST_GET_PENDING_MESH_JOBS, 22);
+    assert_eq!(ABI_HOST_ANCHOR_RECEIPT, 23);
+    assert_eq!(ABI_HOST_GET_REPUTATION, 24);
+    assert_eq!(ABI_HOST_VERIFY_ZK_PROOF, 25);
+    assert_eq!(ABI_HOST_GENERATE_ZK_PROOF, 26);
+    assert_eq!(ABI_HOST_CREATE_GOVERNANCE_PROPOSAL, 17);
+    assert_eq!(ABI_HOST_OPEN_GOVERNANCE_VOTING, 18);
+    assert_eq!(ABI_HOST_CAST_GOVERNANCE_VOTE, 19);
+    assert_eq!(ABI_HOST_CLOSE_VOTING_AND_VERIFY, 20);
+    assert_eq!(ABI_HOST_EXECUTE_GOVERNANCE_PROPOSAL, 21);
+}


### PR DESCRIPTION
## Summary
- add `abi_constants.rs` to verify ABI_HOST_* constants

## Testing
- `cargo test -p icn-runtime --test abi_constants -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68787a393b588324ad12bd5996fafb00