### PR TITLE
Anchor parameter updates in runtime

### DIFF
--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -80,6 +80,9 @@ closed via `host_close_governance_proposal_voting`, returning the final
 `host_execute_governance_proposal`, which broadcasts the updated proposal and
 rewards the proposer.
 
+Executing a `SystemParameterChange` proposal also anchors a `ParameterUpdate`
+record in the DAG so parameter history remains tamper-evident.
+
 ```rust,no_run
 use icn_runtime::{
     context::RuntimeContext,

--- a/crates/icn-runtime/src/context/mod.rs
+++ b/crates/icn-runtime/src/context/mod.rs
@@ -9,6 +9,7 @@ pub mod host_environment;
 pub mod mana;
 pub mod mesh_network;
 pub mod resource_ledger;
+pub mod parameter_update;
 pub mod runtime_context;
 pub mod service_config;
 pub mod signers;
@@ -27,8 +28,8 @@ pub use resource_ledger::{
     record_resource_event, ResourceAction, ResourceLedger, ResourceLedgerEntry,
 };
 pub use runtime_context::{
-    RuntimeContext, RuntimeContextParams, RuntimeContextBuilder, EnvironmentType, MeshNetworkServiceType, CreateProposalPayload, CastVotePayload, CloseProposalResult,
-    MANA_MAX_CAPACITY_KEY,
+    RuntimeContext, RuntimeContextParams, RuntimeContextBuilder, EnvironmentType, MeshNetworkServiceType,
+    CreateProposalPayload, CastVotePayload, CloseProposalResult, ParameterUpdate, MANA_MAX_CAPACITY_KEY,
 };
 pub use service_config::{ServiceConfig, ServiceConfigBuilder, ServiceEnvironment};
 pub use signers::{Ed25519Signer, HsmKeyStore, Signer, StubSigner};

--- a/crates/icn-runtime/src/context/parameter_update.rs
+++ b/crates/icn-runtime/src/context/parameter_update.rs
@@ -1,0 +1,11 @@
+use icn_common::Did;
+use serde::{Deserialize, Serialize};
+
+/// Recorded change to a runtime parameter anchored in the DAG.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParameterUpdate {
+    pub name: String,
+    pub value: String,
+    pub timestamp: u64,
+    pub signer: Did,
+}


### PR DESCRIPTION
## Summary
- add `ParameterUpdate` struct for auditing config changes
- persist parameter updates via new `RuntimeContext::anchor_parameter_update`
- store updates when proposals execute
- test that parameter changes write to the DAG
- document behavior in runtime README

## Testing
- `cargo test -p icn-runtime --lib`

------
https://chatgpt.com/codex/tasks/task_e_68787a25e59c8324af10a84d5691828b