### PR TITLE
Anchor parameter updates to DAG

### DIFF
--- a/crates/icn-runtime/README.md
+++ b/crates/icn-runtime/README.md
@@ -90,11 +90,16 @@ use icn_runtime::{
 async fn finalize_proposal(ctx: &RuntimeContext, pid: &str) -> Result<(), icn_runtime::HostAbiError> {
     let status = host_close_governance_proposal_voting(ctx, pid).await?;
     if status == "Accepted" {
-        host_execute_governance_proposal(ctx, pid).await?;
+host_execute_governance_proposal(ctx, pid).await?;
     }
     Ok(())
 }
 ```
+
+When a proposal updates a runtime parameter, the new value is persisted by
+anchoring a `ParameterUpdate` record to the DAG. These records include the
+parameter name, value, timestamp, and the DID of the signer so nodes can
+replay configuration history.
 
 ### Zero-Knowledge Proofs
 

--- a/crates/icn-runtime/src/context/mod.rs
+++ b/crates/icn-runtime/src/context/mod.rs
@@ -27,7 +27,7 @@ pub use resource_ledger::{
     record_resource_event, ResourceAction, ResourceLedger, ResourceLedgerEntry,
 };
 pub use runtime_context::{
-    RuntimeContext, RuntimeContextParams, RuntimeContextBuilder, EnvironmentType, MeshNetworkServiceType, CreateProposalPayload, CastVotePayload, CloseProposalResult,
+    RuntimeContext, RuntimeContextParams, RuntimeContextBuilder, EnvironmentType, MeshNetworkServiceType, CreateProposalPayload, CastVotePayload, CloseProposalResult, ParameterUpdate,
     MANA_MAX_CAPACITY_KEY,
 };
 pub use service_config::{ServiceConfig, ServiceConfigBuilder, ServiceEnvironment};


### PR DESCRIPTION
## Summary
- track runtime parameter changes with `ParameterUpdate`
- persist changes to DAG via `anchor_parameter_update`
- ensure `update_parameter` anchors updates
- document persistence of parameter updates
- add test verifying parameter change anchoring

## Testing
- `cargo test -p icn-runtime --test governance parameter_change_anchors_dag_entry --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6878870aadd483249e16ef057555880c