### PR TITLE
Add federation discovery via network

### DIFF
--- a/crates/icn-cli/src/main.rs
+++ b/crates/icn-cli/src/main.rs
@@ -524,6 +524,9 @@ enum FederationCommands {
     /// Synchronize federation state
     #[clap(name = "sync")]
     Sync,
+    /// Discover federations on the network
+    #[clap(name = "discover")]
+    Discover,
     /// Federation trust management commands
     Trust {
         #[clap(subcommand)]
@@ -1046,6 +1049,7 @@ async fn run_command(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
             FederationCommands::ListPeers => handle_fed_list_peers(cli, client).await?,
             FederationCommands::Status => handle_fed_status(cli, client).await?,
             FederationCommands::Sync => handle_fed_sync(cli, client).await?,
+            FederationCommands::Discover => handle_fed_discover(cli, client).await?,
             FederationCommands::Trust { command } => match command {
                 FederationTrustCommands::Configure { federation_id, policy_json_or_stdin } => {
                     handle_fed_trust_configure(cli, client, federation_id, policy_json_or_stdin).await?
@@ -1775,6 +1779,13 @@ async fn handle_fed_init(cli: &Cli, client: &Client) -> Result<(), anyhow::Error
 async fn handle_fed_sync(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
     let resp: serde_json::Value =
         post_request(&cli.api_url, client, "/federation/sync", &(), cli.api_key.as_deref()).await?;
+    println!("{}", serde_json::to_string_pretty(&resp)?);
+    Ok(())
+}
+
+async fn handle_fed_discover(cli: &Cli, client: &Client) -> Result<(), anyhow::Error> {
+    let resp: serde_json::Value =
+        get_request(&cli.api_url, client, "/federation/discover", cli.api_key.as_deref()).await?;
     println!("{}", serde_json::to_string_pretty(&resp)?);
     Ok(())
 }

--- a/crates/icn-network/tests/federation_discover.rs
+++ b/crates/icn-network/tests/federation_discover.rs
@@ -1,0 +1,50 @@
+#![allow(unused_imports, clippy::clone_on_copy, clippy::uninlined_format_args)]
+
+#[cfg(feature = "libp2p")]
+mod federation_discover {
+    use icn_common::Did;
+    use icn_network::libp2p_service::{Libp2pNetworkService, NetworkConfig};
+    use icn_network::{NetworkService, FEDERATION_INFO_PREFIX};
+    use icn_protocol::FederationInfo;
+    use tokio::time::{sleep, Duration};
+
+    #[tokio::test]
+    async fn federation_discover_two_nodes() {
+        let node_a = Libp2pNetworkService::new(NetworkConfig::default())
+            .await
+            .expect("node a start");
+        sleep(Duration::from_secs(1)).await;
+        let addr = node_a
+            .listening_addresses()
+            .into_iter()
+            .next()
+            .expect("node a addr");
+        let peer_a = node_a.local_peer_id().clone();
+
+        let mut config_b = NetworkConfig::default();
+        config_b.bootstrap_peers = vec![(peer_a, addr.clone())];
+        let node_b = Libp2pNetworkService::new(config_b)
+            .await
+            .expect("node b start");
+
+        sleep(Duration::from_secs(2)).await;
+
+        let info = FederationInfo {
+            federation_id: "fed1".to_string(),
+            members: vec![Did::new("key", "member1")],
+        };
+        let key = format!("{}fed1", FEDERATION_INFO_PREFIX);
+        node_a
+            .store_record(key, bincode::serialize(&info).unwrap())
+            .await
+            .unwrap();
+
+        sleep(Duration::from_secs(2)).await;
+
+        let discovered = node_b.discover_federations().await.unwrap();
+        assert!(discovered.iter().any(|f| f.federation_id == "fed1"));
+
+        node_a.shutdown().await.unwrap();
+        node_b.shutdown().await.unwrap();
+    }
+}

--- a/crates/icn-protocol/src/lib.rs
+++ b/crates/icn-protocol/src/lib.rs
@@ -69,6 +69,10 @@ pub enum MessagePayload {
     FederationJoinResponse(FederationJoinResponseMessage),
     /// Request federation state synchronization
     FederationSyncRequest(FederationSyncRequestMessage),
+    /// Request list of known federations
+    FederationDiscoverRequest(FederationDiscoverRequestMessage),
+    /// Response containing discovered federations
+    FederationDiscoverResponse(FederationDiscoverResponseMessage),
 
     // === Network Management ===
     /// Generic gossip message for flexible communication
@@ -398,6 +402,26 @@ pub enum SyncDataType {
     Reputation,
 }
 
+/// Request a list of known federations from a peer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationDiscoverRequestMessage;
+
+/// Information about a federation for discovery purposes
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationInfo {
+    /// Identifier of the federation
+    pub federation_id: String,
+    /// Known members within the federation
+    pub members: Vec<Did>,
+}
+
+/// Response containing federations advertised by a peer
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationDiscoverResponseMessage {
+    /// Federations known to the responding peer
+    pub federations: Vec<FederationInfo>,
+}
+
 // === Network Management Messages ===
 
 /// Generic gossip message for flexible communication
@@ -484,6 +508,8 @@ impl MessagePayload {
             MessagePayload::FederationJoinRequest(_) => "FederationJoinRequest",
             MessagePayload::FederationJoinResponse(_) => "FederationJoinResponse",
             MessagePayload::FederationSyncRequest(_) => "FederationSyncRequest",
+            MessagePayload::FederationDiscoverRequest(_) => "FederationDiscoverRequest",
+            MessagePayload::FederationDiscoverResponse(_) => "FederationDiscoverResponse",
             MessagePayload::GossipMessage(_) => "GossipMessage",
             MessagePayload::HeartbeatMessage(_) => "HeartbeatMessage",
             MessagePayload::PeerDiscoveryMessage(_) => "PeerDiscoveryMessage",


### PR DESCRIPTION
## Summary
- extend protocol with federation discovery request/response
- track federation info in libp2p network service using Kademlia
- expose `discover_federations` on `NetworkService`
- add CLI command `federation discover`
- test federation discovery between two libp2p nodes

## Testing
- `cargo check -p icn-network --features libp2p`

------
https://chatgpt.com/codex/tasks/task_e_687ad135fb5883249da573fa531ab712