### PR TITLE
Add governance standard macros and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The project has achieved a significant milestone with a production-ready foundat
 - **Identity Management**: DID-based identity with verifiable credentials
 - **Reputation System**: Contribution tracking and trust metrics with persistence
 - **Federation Sync**: Cross-federation governance synchronization
+- **Governance Helpers**: Reusable quorum, delegation, and council rotation macros in `examples/governance_templates`
 
 ### **✅ Distributed Computing**
 - **Mesh Job Execution**: WASM-sandboxed distributed computation
@@ -471,6 +472,7 @@ More detailed information can be found in the `README.md` file within each crate
 * [Resource Tokens](docs/resource_tokens.md) – token classes and mana integration
 * [CCL Language Reference](docs/CCL_LANGUAGE_REFERENCE.md) – full syntax guide
 * [CCL Examples](icn-ccl/examples/) – governance contract templates
+* [Governance Templates](examples/governance_templates/) – reusable macros and sample policies
 * [Governance Onboarding Guide](docs/governance_onboarding.md) – using templates
 * [Contract Creation Guide](docs/howto-create-contract.md) – compile and submit CCL jobs
 

--- a/examples/governance_templates/council_rotation.ccl
+++ b/examples/governance_templates/council_rotation.ccl
@@ -1,0 +1,19 @@
+// Governance helper: rotate a council subset
+fn select_council(cycle: Integer, members: Array<Integer>, seats: Integer) -> Array<Integer> {
+    let count = array_len(members);
+    let i = 0;
+    let council = [];
+    while i < seats {
+        let idx = (cycle + i) % count;
+        array_push(council, members[idx]);
+        let i = i + 1;
+    }
+    return council;
+}
+
+// Example using the council rotation helper
+fn run() -> Integer {
+    let members = [1, 2, 3, 4];
+    let council = select_council(1, members, 2);
+    return array_len(council);
+}

--- a/examples/governance_templates/delegated_vote.ccl
+++ b/examples/governance_templates/delegated_vote.ccl
@@ -1,0 +1,13 @@
+// Governance helper: tally direct and delegated votes
+fn conduct_delegated_vote(direct_votes: Integer, delegated_votes: Integer, delegation_weight: Integer) -> Integer {
+    let weighted_delegated = (delegated_votes * delegation_weight) / 100;
+    return direct_votes + weighted_delegated;
+}
+
+// Example using the delegated voting helper
+fn run() -> Integer {
+    let direct = 5;
+    let delegated = 3;
+    let weight = 50; // 50% of delegated votes count
+    return conduct_delegated_vote(direct, delegated, weight);
+}

--- a/examples/governance_templates/quorum_check.ccl
+++ b/examples/governance_templates/quorum_check.ccl
@@ -1,0 +1,12 @@
+// Governance helper: check if quorum is met
+fn is_quorum_met(participant_count: Integer, total_members: Integer, quorum_percent: Integer) -> Bool {
+    let required = (total_members * quorum_percent) / 100;
+    return participant_count >= required;
+}
+
+// Example using the quorum helper
+fn run() -> Bool {
+    let participants = 30;
+    let total_members = 50;
+    return is_quorum_met(participants, total_members, 60);
+}

--- a/icn-ccl/src/governance_std.rs
+++ b/icn-ccl/src/governance_std.rs
@@ -1,0 +1,23 @@
+use std::collections::HashMap;
+
+/// Standard macros for cooperative governance patterns.
+pub fn governance_macros() -> HashMap<String, String> {
+    let mut m = HashMap::new();
+
+    m.insert(
+        "is_quorum_met".to_string(),
+        "fn is_quorum_met(participant_count: Integer, total_members: Integer, quorum_percent: Integer) -> Bool {\n    let required = (total_members * quorum_percent) / 100;\n    return participant_count >= required;\n}".to_string(),
+    );
+
+    m.insert(
+        "conduct_delegated_vote".to_string(),
+        "fn conduct_delegated_vote(\n    direct_votes: Integer,\n    delegated_votes: Integer,\n    delegation_weight: Integer\n) -> Integer {\n    let weighted_delegated = (delegated_votes * delegation_weight) / 100;\n    return direct_votes + weighted_delegated;\n}".to_string(),
+    );
+
+    m.insert(
+        "select_council".to_string(),
+        "fn select_council(cycle: Integer, members: Array<Integer>, seats: Integer) -> Array<Integer> {\n    let count = array_len(members);\n    let i = 0;\n    let council = [];\n    while i < seats {\n        let idx = (cycle + i) % count;\n        array_push(council, members[idx]);\n        let i = i + 1;\n    }\n    return council;\n}".to_string(),
+    );
+
+    m
+}

--- a/icn-ccl/src/lib.rs
+++ b/icn-ccl/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parser;
 pub mod semantic_analyzer;
 pub mod wasm_backend; // Expose functions for CLI layer
 pub mod stdlib;
+pub mod governance_std;
 
 pub use error::CclError;
 pub use metadata::ContractMetadata;

--- a/icn-ccl/src/stdlib.rs
+++ b/icn-ccl/src/stdlib.rs
@@ -5,6 +5,7 @@
 
 use crate::ast::{ExpressionNode, TypeAnnotationNode, PolicyStatementNode};
 use crate::error::CclError;
+use crate::governance_std;
 use std::collections::HashMap;
 
 /// Standard constants available in CCL
@@ -23,6 +24,7 @@ impl StandardLibrary {
         // Add standard constants
         stdlib.add_constants();
         stdlib.add_macros();
+        stdlib.add_governance_helpers();
         
         stdlib
     }
@@ -232,13 +234,6 @@ impl StandardLibrary {
             }".to_string()
         );
         
-        self.macros.insert(
-            "is_quorum_met".to_string(),
-            "fn is_quorum_met(participants: Integer, total_members: Integer, quorum_percent: Integer) -> Bool {
-                let required = (total_members * quorum_percent) / 100;
-                return participants >= required;
-            }".to_string()
-        );
         
         self.macros.insert(
             "calculate_quadratic_cost".to_string(),
@@ -438,13 +433,6 @@ impl StandardLibrary {
             }".to_string()
         );
 
-        self.macros.insert(
-            "is_quorum_met".to_string(),
-            "fn is_quorum_met(participant_count: Integer, total_members: Integer, quorum_percent: Integer) -> Bool {
-                let required = (total_members * quorum_percent) / 100;
-                return participant_count >= required;
-            }".to_string()
-        );
     }
     
     /// Get a constant value by name
@@ -500,18 +488,9 @@ impl StandardLibrary {
     
     /// Add governance helper functions for common patterns
     pub fn add_governance_helpers(&mut self) {
-        // Multi-round voting with delegation
-        self.macros.insert(
-            "conduct_delegated_vote".to_string(),
-            "fn conduct_delegated_vote(
-                direct_votes: Integer, 
-                delegated_votes: Integer, 
-                delegation_weight: Integer
-            ) -> Integer {
-                let weighted_delegated = (delegated_votes * delegation_weight) / 100;
-                return direct_votes + weighted_delegated;
-            }".to_string()
-        );
+        for (name, body) in governance_std::governance_macros() {
+            self.macros.insert(name, body);
+        }
         
         // Consensus building with graduated penalties
         self.macros.insert(


### PR DESCRIPTION
## Summary
- add governance standard macros in `governance_std`
- expose new helpers in the README
- provide example templates demonstrating quorum checks, delegated voting and council rotation

## Testing
- `cargo test -p icn-ccl --no-run` *(failed: could not compile icn-ccl tests)*

------
https://chatgpt.com/codex/tasks/task_e_687aec1da9288324b096cbb8eaf609af