### PR TITLE
[ccl] add module import support

### DIFF
--- a/icn-ccl/src/lib.rs
+++ b/icn-ccl/src/lib.rs
@@ -62,17 +62,31 @@ pub fn compile_ccl_source_to_wasm(source: &str) -> Result<(Vec<u8>, ContractMeta
 pub fn compile_ccl_file_to_wasm(
     path: &std::path::Path,
 ) -> Result<(Vec<u8>, ContractMetadata), CclError> {
-    use std::fs;
+    use sha2::{Digest, Sha256};
+    use icn_common::{compute_merkle_cid, Did};
 
-    let source_code = fs::read_to_string(path).map_err(|e| {
-        CclError::IoError(format!(
-            "Failed to read source file {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
+    let ast_node = parser::parse_ccl_file(path)?;
 
-    compile_ccl_source_to_wasm(&source_code)
+    let mut semantic_analyzer = semantic_analyzer::SemanticAnalyzer::new();
+    semantic_analyzer.analyze(&ast_node)?;
+
+    let optimizer = optimizer::Optimizer::new();
+    let optimized_ast = optimizer.optimize(ast_node)?;
+
+    let mut backend = wasm_backend::WasmBackend::new();
+    let (wasm, mut meta) = backend.compile_to_wasm(&optimized_ast)?;
+
+    let ts = 0u64;
+    let author = Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
+    meta.cid = cid.to_string();
+
+    let source_code = std::fs::read_to_string(path)?;
+    let digest = Sha256::digest(source_code.as_bytes());
+    meta.source_hash = format!("sha256:{:x}", digest);
+
+    Ok((wasm, meta))
 }
 
 // Re-export CLI helper functions for easier access by icn-cli

--- a/icn-ccl/tests/contracts/module_import/helper.ccl
+++ b/icn-ccl/tests/contracts/module_import/helper.ccl
@@ -1,0 +1,1 @@
+fn add(a: Integer, b: Integer) -> Integer { return a + b; }

--- a/icn-ccl/tests/contracts/module_import/main.ccl
+++ b/icn-ccl/tests/contracts/module_import/main.ccl
@@ -1,0 +1,2 @@
+import "helper.ccl" as helper;
+fn run() -> Integer { return helper_add(2, 3); }

--- a/icn-ccl/tests/module_import.rs
+++ b/icn-ccl/tests/module_import.rs
@@ -1,0 +1,54 @@
+use icn_ccl::compile_ccl_file_to_wasm;
+use icn_runtime::context::RuntimeContext;
+use icn_runtime::executor::{JobExecutor, WasmExecutor, WasmExecutorConfig};
+use icn_common::{Cid, DagBlock};
+use icn_identity::{did_key_from_verifying_key, generate_ed25519_keypair, SignatureBytes};
+use icn_mesh::{ActualMeshJob, JobId, JobSpec};
+use std::str::FromStr;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn compile_and_run_with_import() {
+    let dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/contracts/module_import");
+    let main = dir.join("main.ccl");
+    let (wasm, _) = compile_ccl_file_to_wasm(&main).expect("compile file");
+
+    let ctx = RuntimeContext::new_with_stubs_and_mana("did:key:zImport", 10).unwrap();
+    let ts = 0u64;
+    let author = icn_common::Did::new("key", "tester");
+    let sig_opt = None;
+    let cid = icn_common::compute_merkle_cid(0x71, &wasm, &[], ts, &author, &sig_opt, &None);
+    let block = DagBlock {
+        cid: cid.clone(),
+        data: wasm.clone(),
+        links: vec![],
+        timestamp: ts,
+        author_did: author,
+        signature: sig_opt,
+        scope: None,
+    };
+    {
+        let mut store = ctx.dag_store.lock().await;
+        store.put(&block).unwrap();
+    }
+    let cid = block.cid.clone();
+
+    let (sk, vk) = generate_ed25519_keypair();
+    let node_did = icn_common::Did::from_str(&did_key_from_verifying_key(&vk)).unwrap();
+
+    let job = ActualMeshJob {
+        id: JobId(Cid::new_v1_sha256(0x55, b"jobimp")),
+        manifest_cid: cid,
+        spec: JobSpec::default(),
+        creator_did: node_did.clone(),
+        cost_mana: 0,
+        max_execution_wait_ms: None,
+        signature: SignatureBytes(vec![]),
+    };
+
+    let signer = std::sync::Arc::new(icn_runtime::context::StubSigner::new_with_keys(sk, vk));
+    let exec = WasmExecutor::new(ctx.clone(), signer, WasmExecutorConfig::default());
+    let receipt = exec.execute_job(&job).await.unwrap();
+    assert_eq!(receipt.executor_did, node_did);
+    let expected_cid = Cid::new_v1_sha256(0x55, &5i64.to_le_bytes());
+    assert_eq!(receipt.result_cid, expected_cid);
+}


### PR DESCRIPTION
## Summary
- implement recursive module loading for `import` statements
- prefix imported items using alias
- compile CCL files using the new loader
- add test and fixtures demonstrating multi-file compilation

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt diff)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed to finish)*
- `cargo test --all-features --workspace` *(failed to finish)*
- `cargo test -p icn-ccl` *(failed to finish)*
- `just test-ccl-contracts` *(command not found)*
- `just test-covm-execution` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aec1d8dc48324b6b4da39e7debec7