### PR TITLE
Enhance governance plugin system

### DIFF
--- a/crates/icn-governance/tests/callback.rs
+++ b/crates/icn-governance/tests/callback.rs
@@ -13,7 +13,7 @@ fn callback_runs_on_execute() {
     let executed = Arc::new(AtomicBool::new(false));
     let mut gov = GovernanceModule::new();
     let flag = executed.clone();
-    gov.set_callback(move |_p| {
+    gov.set_callback(move |_p: &icn_governance::Proposal| {
         flag.store(true, Ordering::SeqCst);
         Ok(())
     });

--- a/crates/icn-governance/tests/execution.rs
+++ b/crates/icn-governance/tests/execution.rs
@@ -87,3 +87,44 @@ fn execute_remove_member_proposal() {
     let prop = gov.get_proposal(&pid).unwrap().unwrap();
     assert_eq!(prop.status, ProposalStatus::Executed);
 }
+
+#[test]
+fn execute_runs_all_callbacks() {
+    use std::sync::{atomic::{AtomicUsize, Ordering}, Arc};
+
+    let mut gov = GovernanceModule::new();
+    gov.add_member(Did::from_str("did:example:alice").unwrap());
+    gov.add_member(Did::from_str("did:example:bob").unwrap());
+    gov.set_quorum(2);
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let c1 = counter.clone();
+    gov.set_callback(move |_p: &icn_governance::Proposal| {
+        c1.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+    let c2 = counter.clone();
+    gov.set_callback(move |_p: &icn_governance::Proposal| {
+        c2.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+
+    let pid = gov
+        .submit_proposal(ProposalSubmission {
+            proposer: Did::from_str("did:example:alice").unwrap(),
+            proposal_type: ProposalType::GenericText("hi".into()),
+            description: "hook".into(),
+            duration_secs: 1,
+            quorum: None,
+            threshold: None,
+            content_cid: None,
+        })
+        .unwrap();
+    gov.open_voting(&pid).unwrap();
+    gov.cast_vote(Did::from_str("did:example:alice").unwrap(), &pid, VoteOption::Yes).unwrap();
+    gov.cast_vote(Did::from_str("did:example:bob").unwrap(), &pid, VoteOption::Yes).unwrap();
+    let (status, _) = gov.close_voting_period(&pid).unwrap();
+    assert_eq!(status, ProposalStatus::Accepted);
+    gov.execute_proposal(&pid).unwrap();
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}

--- a/crates/icn-governance/tests/resolution.rs
+++ b/crates/icn-governance/tests/resolution.rs
@@ -16,7 +16,7 @@ fn execute_resolution_proposal() {
     let pause_f = paused.clone();
     let freeze_f = frozen.clone();
     let mut gov = GovernanceModule::new();
-    gov.set_callback(move |p| {
+    gov.set_callback(move |p: &icn_governance::Proposal| {
         if let ProposalType::Resolution(res) = &p.proposal_type {
             for a in &res.actions {
                 match a {

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -892,7 +892,7 @@ pub async fn app_router_with_options(
         let frozen_set = app_state.frozen_reputations.clone();
         let handle = tokio::runtime::Handle::current();
         let mut gov = gov_mod.lock().await;
-        gov.set_callback(move |proposal| {
+        gov.set_callback(move |proposal: &icn_governance::Proposal| {
             if let icn_governance::ProposalType::SystemParameterChange(param, value) =
                 &proposal.proposal_type
             {
@@ -1101,7 +1101,7 @@ pub async fn app_router_from_context(
         let frozen_set = app_state.frozen_reputations.clone();
         let handle = tokio::runtime::Handle::current();
         let mut gov = gov_mod.lock().await;
-        gov.set_callback(move |proposal| {
+        gov.set_callback(move |proposal: &icn_governance::Proposal| {
             if let icn_governance::ProposalType::SystemParameterChange(param, value) =
                 &proposal.proposal_type
             {
@@ -1474,7 +1474,7 @@ pub async fn run_node() -> Result<(), Box<dyn std::error::Error>> {
         let frozen_set = app_state.frozen_reputations.clone();
         let handle = tokio::runtime::Handle::current();
         let mut gov = gov_mod.lock().await;
-        gov.set_callback(move |proposal| {
+        gov.set_callback(move |proposal: &icn_governance::Proposal| {
             if let icn_governance::ProposalType::SystemParameterChange(param, value) =
                 &proposal.proposal_type
             {

--- a/crates/icn-node/tests/network_selection.rs
+++ b/crates/icn-node/tests/network_selection.rs
@@ -15,8 +15,7 @@ async fn enable_p2p_uses_libp2p() {
     #[cfg(feature = "enable-libp2p")]
     {
         use icn_network::NetworkService;
-        assert!(svc
-            .as_any()
+        assert!(NetworkService::as_any(&*svc)
             .is::<icn_network::libp2p_service::Libp2pNetworkService>());
     }
 }
@@ -33,6 +32,6 @@ async fn test_mode_forces_stub() {
     let svc = build_network_service(&cfg).await.unwrap();
     {
         use icn_network::NetworkService;
-        assert!(svc.as_any().is::<icn_network::StubNetworkService>());
+        assert!(NetworkService::as_any(&*svc).is::<icn_network::StubNetworkService>());
     }
 }


### PR DESCRIPTION
## Summary
- add `ProposalCallback` trait to allow multiple proposal hooks
- keep hooks in `GovernanceModule` and run them on execution
- update node callbacks and tests for new trait API
- test multiple callbacks execution

## Testing
- `cargo test -p icn-governance`

------
https://chatgpt.com/codex/tasks/task_e_687aee0e2c6083248f0e7f317142a1f3