### PR TITLE
[icn-governance] add deliberation status

### DIFF
--- a/crates/icn-governance/tests/pending.rs
+++ b/crates/icn-governance/tests/pending.rs
@@ -5,7 +5,7 @@ use icn_governance::{
 use std::str::FromStr;
 
 #[test]
-fn open_voting_transitions_from_pending() {
+fn open_voting_transitions_from_deliberation() {
     let mut gov = GovernanceModule::new();
     let pid = gov
         .submit_proposal(ProposalSubmission {
@@ -19,7 +19,7 @@ fn open_voting_transitions_from_pending() {
         })
         .unwrap();
     let prop = gov.get_proposal(&pid).unwrap().unwrap();
-    assert_eq!(prop.status, ProposalStatus::Pending);
+    assert_eq!(prop.status, ProposalStatus::Deliberation);
 
     gov.open_voting(&pid).unwrap();
     let prop = gov.get_proposal(&pid).unwrap().unwrap();

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -179,6 +179,14 @@ vote. Operators may enforce mandatory proofs by creating the
 - **Iterative Refinement**: Continuous improvement cycle
 - **Historical Analysis**: Learn from past decisions
 
+### **Proposal Status Flow**
+The `ProposalStatus` enum tracks each stage:
+1. `Deliberation` – proposal submitted and discussed
+2. `VotingOpen` – ballots may be cast
+3. `Accepted` or `Rejected` – outcome after tallying
+4. `Executed` – approved actions applied
+5. `Failed` – execution could not complete
+
 ---
 
 ## 🤝 **Participation Models**


### PR DESCRIPTION
## Summary
- introduce `Deliberation` phase to `ProposalStatus`
- enforce `Deliberation -> VotingOpen` transition rules
- update tests for new lifecycle
- document proposal status flow in governance docs

## Testing
- `cargo test -p icn-governance`
- `cargo fmt --all -- --check`
- `cargo clippy -p icn-governance --all-targets --all-features -- -D warnings` *(fails: unused imports in dependency crates)*

------
https://chatgpt.com/codex/tasks/task_e_687aee0c735083248d21b9faefd945ee