### PR TITLE
Add expiration checks for credentials

### DIFF
--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -3384,6 +3384,7 @@ async fn credential_issue_handler(
         claims.clone(),
         Some(req.schema),
     );
+    cred.expires_at = Some(req.expiration);
 
     for (k, v) in claims {
         let mut bytes = req.issuer.to_string().into_bytes();

--- a/tests/integration/credential_disclosure.rs
+++ b/tests/integration/credential_disclosure.rs
@@ -45,7 +45,7 @@ async fn credential_disclose_route() {
         holder: Did::new("key", "holder"),
         attributes: attrs,
         schema: Cid::new_v1_sha256(0x55, b"schema"),
-        expiration: 1,
+        expiration: chrono::Utc::now().timestamp() as u64 + 60,
     };
 
     let resp = client.post(&issue_url).json(&req).send().await.unwrap();
@@ -63,6 +63,60 @@ async fn credential_disclose_route() {
     assert!(disc_resp.credential.claims.contains_key("role"));
     assert!(!disc_resp.credential.claims.contains_key("age"));
     assert_eq!(disc_resp.proof.disclosed_fields, vec!["age".to_string()]);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn disclosure_fails_when_expired() {
+    std::fs::write("fixtures/mana_ledger.tmp", "{\"balances\":{}}").unwrap();
+    let (router, ctx) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(std::path::PathBuf::from("fixtures/mana_ledger.tmp")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    let node_did = ctx.current_identity.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+    sleep(Duration::from_millis(100)).await;
+
+    let client = Client::new();
+    let issue_url = format!("http://{}/identity/credentials/issue", addr);
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert("role".to_string(), "tester".to_string());
+    let req = IssueCredentialRequest {
+        issuer: node_did.clone(),
+        holder: Did::new("key", "holder"),
+        attributes: attrs,
+        schema: Cid::new_v1_sha256(0x55, b"schema"),
+        expiration: chrono::Utc::now().timestamp() as u64 - 1,
+    };
+
+    let resp = client.post(&issue_url).json(&req).send().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let cred_resp: CredentialResponse = resp.json().await.unwrap();
+
+    let disclose_url = format!("http://{}/identity/credentials/disclose", addr);
+    let disc_req = DisclosureRequest {
+        credential: cred_resp.credential,
+        fields: vec!["role".to_string()],
+    };
+    let resp = client.post(&disclose_url).json(&disc_req).send().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
     server.abort();
 }

--- a/tests/integration/credential_issuance.rs
+++ b/tests/integration/credential_issuance.rs
@@ -45,7 +45,7 @@ async fn credential_issue_route() {
         holder: Did::new("key", "holder"),
         attributes: attrs,
         schema: Cid::new_v1_sha256(0x55, b"schema"),
-        expiration: 1,
+        expiration: chrono::Utc::now().timestamp() as u64 + 60,
     };
 
     let resp = client.post(&url).json(&req).send().await.unwrap();
@@ -88,6 +88,60 @@ async fn credential_issue_route() {
 
     let resp = client.get(&get_url).send().await.unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn expired_credential_rejected() {
+    std::fs::write("fixtures/mana_ledger.tmp", "{\"balances\":{}}").unwrap();
+    let (router, ctx) = app_router_with_options(
+        None,
+        None,
+        None,
+        None,
+        Some(std::path::PathBuf::from("fixtures/mana_ledger.tmp")),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+    let node_did = ctx.current_identity.clone();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = task::spawn(async move {
+        axum::serve(listener, router.into_make_service())
+            .await
+            .unwrap();
+    });
+    sleep(Duration::from_millis(100)).await;
+    let client = Client::new();
+    let issue_url = format!("http://{}/identity/credentials/issue", addr);
+
+    let mut attrs = BTreeMap::new();
+    attrs.insert("role".to_string(), "tester".to_string());
+    let req = IssueCredentialRequest {
+        issuer: node_did.clone(),
+        holder: Did::new("key", "holder"),
+        attributes: attrs,
+        schema: Cid::new_v1_sha256(0x55, b"schema"),
+        expiration: chrono::Utc::now().timestamp() as u64 - 1,
+    };
+
+    let resp = client.post(&issue_url).json(&req).send().await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let cred_resp: CredentialResponse = resp.json().await.unwrap();
+
+    let verify_url = format!("http://{}/identity/credentials/verify", addr);
+    let resp = client
+        .post(&verify_url)
+        .json(&cred_resp.credential)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 
     server.abort();
 }

--- a/tests/integration/credential_trusted_issuers.rs
+++ b/tests/integration/credential_trusted_issuers.rs
@@ -43,6 +43,7 @@ async fn verify_trusted_and_untrusted_issuers() {
     let mut claims = HashMap::new();
     claims.insert("role".to_string(), "tester".to_string());
     let mut cred = Credential::new(trusted_did.clone(), Did::new("key", "holder"), claims, Some(Cid::new_v1_sha256(0x55, b"schema")));
+    cred.expires_at = Some(chrono::Utc::now().timestamp() as u64 + 60);
     cred.sign_claims(&sk_trusted);
     let resp = client.post(&url).json(&cred).send().await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
@@ -53,6 +54,7 @@ async fn verify_trusted_and_untrusted_issuers() {
     let mut claims2 = HashMap::new();
     claims2.insert("role".to_string(), "tester".to_string());
     let mut cred2 = Credential::new(untrusted_did, Did::new("key", "holder"), claims2, Some(Cid::new_v1_sha256(0x55, b"schema")));
+    cred2.expires_at = Some(chrono::Utc::now().timestamp() as u64 + 60);
     cred2.sign_claims(&sk_untrusted);
     let resp = client.post(&url).json(&cred2).send().await.unwrap();
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);


### PR DESCRIPTION
## Summary
- extend `Credential` and `DisclosedCredential` with `expires_at`
- invalidate verification and disclosure when expired
- store expiration in issued credentials
- update tests for new expiry behaviour and add failure cases

## Testing
- `cargo test -p icn-identity` *(fails: groth16_proof_roundtrip, trust_verification, zk proof tests)*
- `cargo test -p icn-integration-tests --test credential_issuance` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_687b0044b1108324a8c49568a81b05cb