### PR TITLE
[identity] add delegated credential chain

### DIFF
--- a/crates/icn-governance/src/lib.rs
+++ b/crates/icn-governance/src/lib.rs
@@ -31,8 +31,8 @@ use serde::{Deserialize, Serialize};
 pub mod federation_governance;
 pub mod metrics;
 pub mod scoped_policy;
+pub mod budgeting;
 
-};
 pub use budgeting::{apply_budget_allocation, BudgetProposal};
 
 /// Trait for governance execution hooks.

--- a/crates/icn-identity/README.md
+++ b/crates/icn-identity/README.md
@@ -59,6 +59,34 @@ Zero-knowledge revocation proofs allow verifiers to check that a credential rema
 2. The holder includes this proof when presenting the credential or a credential proof.
 3. Verifiers call `verify_revocation` using their configured `ZkRevocationVerifier`. A successful result confirms the credential is not revoked.
 
+## Delegated Credentials
+
+Delegated credentials allow one DID to delegate authority to another. A chain
+of such credentials proves transitive delegation from the original issuer to the
+final holder.
+
+```rust
+use icn_identity::{
+    delegated_credential::{DelegatedCredential, verify_delegation_chain},
+    generate_ed25519_keypair, did_key_from_verifying_key, KeyDidResolver,
+};
+use icn_common::Did;
+use std::str::FromStr;
+
+let (sk_a, vk_a) = generate_ed25519_keypair();
+let did_a = Did::from_str(&did_key_from_verifying_key(&vk_a)).unwrap();
+let (sk_b, vk_b) = generate_ed25519_keypair();
+let did_b = Did::from_str(&did_key_from_verifying_key(&vk_b)).unwrap();
+let (sk_c, vk_c) = generate_ed25519_keypair();
+let did_c = Did::from_str(&did_key_from_verifying_key(&vk_c)).unwrap();
+
+let d1 = DelegatedCredential::new(did_a.clone(), did_b.clone(), &sk_a);
+let d2 = DelegatedCredential::new(did_b.clone(), did_c.clone(), &sk_b);
+
+let resolver = KeyDidResolver;
+verify_delegation_chain(&did_a, &[d1, d2], &resolver).unwrap();
+```
+
 ## Contributing
 
 Contributions are welcome! Please see the main [CONTRIBUTING.md](../../CONTRIBUTING.md) in the root of the `icn-core` repository for guidelines.

--- a/crates/icn-identity/src/delegated_credential.rs
+++ b/crates/icn-identity/src/delegated_credential.rs
@@ -1,0 +1,69 @@
+use crate::{sign_message, verify_signature, DidResolver, SignatureBytes};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use icn_common::{CommonError, Did};
+use serde::{Deserialize, Serialize};
+
+/// Credential indicating the issuer has delegated authority to the delegatee.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DelegatedCredential {
+    /// DID of the delegator.
+    pub issuer: Did,
+    /// DID receiving the delegated authority.
+    pub delegatee: Did,
+    /// Signature from the issuer over the issuer and delegatee DIDs.
+    pub signature: SignatureBytes,
+}
+
+impl DelegatedCredential {
+    /// Create and sign a new delegated credential.
+    pub fn new(issuer: Did, delegatee: Did, key: &SigningKey) -> Self {
+        let mut bytes = issuer.to_string().into_bytes();
+        bytes.extend_from_slice(delegatee.to_string().as_bytes());
+        let sig = sign_message(key, &bytes);
+        Self {
+            issuer,
+            delegatee,
+            signature: SignatureBytes::from_ed_signature(sig),
+        }
+    }
+
+    /// Verify this credential against the provided verifying key.
+    pub fn verify(&self, key: &VerifyingKey) -> Result<(), CommonError> {
+        let mut bytes = self.issuer.to_string().into_bytes();
+        bytes.extend_from_slice(self.delegatee.to_string().as_bytes());
+        let ed = self.signature.to_ed_signature()?;
+        if verify_signature(key, &bytes, &ed) {
+            Ok(())
+        } else {
+            Err(CommonError::IdentityError(
+                "delegation signature invalid".into(),
+            ))
+        }
+    }
+}
+
+/// Verify a chain of delegated credentials starting from `root_issuer`.
+///
+/// Each credential must be issued by the previous delegate and be
+/// signed correctly. The function returns the DID of the final delegate
+/// in the chain if all signatures verify.
+pub fn verify_delegation_chain(
+    root_issuer: &Did,
+    chain: &[DelegatedCredential],
+    resolver: &dyn DidResolver,
+) -> Result<Did, CommonError> {
+    let mut current_did = root_issuer.clone();
+    let mut current_key = resolver.resolve(&current_did)?;
+
+    for cred in chain {
+        if cred.issuer != current_did {
+            return Err(CommonError::IdentityError(
+                "issuer mismatch in delegation chain".into(),
+            ));
+        }
+        cred.verify(&current_key)?;
+        current_did = cred.delegatee.clone();
+        current_key = resolver.resolve(&current_did)?;
+    }
+    Ok(current_did)
+}

--- a/crates/icn-identity/src/lib.rs
+++ b/crates/icn-identity/src/lib.rs
@@ -59,6 +59,8 @@ pub use trust_verification::{
     TrustVerificationEngine, TrustVerificationConfig, TrustVerificationResult, ChallengeResolution,
 };
 pub mod metrics;
+pub mod delegated_credential;
+pub use delegated_credential::{DelegatedCredential, verify_delegation_chain};
 
 // --- Core Cryptographic Operations & DID:key generation ---
 

--- a/crates/icn-identity/tests/delegation_chain.rs
+++ b/crates/icn-identity/tests/delegation_chain.rs
@@ -1,0 +1,25 @@
+use icn_common::Did;
+use icn_identity::{
+    delegated_credential::{verify_delegation_chain, DelegatedCredential},
+    did_key_from_verifying_key, generate_ed25519_keypair, KeyDidResolver,
+};
+use std::str::FromStr;
+
+#[test]
+fn delegation_chain_a_b_c() {
+    let (sk_a, vk_a) = generate_ed25519_keypair();
+    let did_a = Did::from_str(&did_key_from_verifying_key(&vk_a)).unwrap();
+
+    let (sk_b, vk_b) = generate_ed25519_keypair();
+    let did_b = Did::from_str(&did_key_from_verifying_key(&vk_b)).unwrap();
+
+    let (sk_c, vk_c) = generate_ed25519_keypair();
+    let did_c = Did::from_str(&did_key_from_verifying_key(&vk_c)).unwrap();
+
+    let d1 = DelegatedCredential::new(did_a.clone(), did_b.clone(), &sk_a);
+    let d2 = DelegatedCredential::new(did_b.clone(), did_c.clone(), &sk_b);
+
+    let resolver = KeyDidResolver;
+    let result = verify_delegation_chain(&did_a, &[d1, d2], &resolver).unwrap();
+    assert_eq!(result, did_c);
+}


### PR DESCRIPTION
## Summary
- support delegated credentials for authority chaining
- verify delegation chains via DID signatures
- document delegated credential flow
- test credential chain verification

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused imports, mismatched types, and other warnings)*
- `cargo test --all-features --workspace` *(fails: could not compile `icn-dag` and `icn-ccl`)*
- `cargo test -p icn-ccl` *(fails: could not compile `icn-ccl` tests)*
- `just test-ccl-contracts` *(fails: recipe not found)*
- `just test-covm-execution` *(fails: recipe not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b00455cd88324886e1e619d3bfd69