### PR TITLE
[job-audit] add audit tool crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "tests",
     "crates/icn-sdk",
     "crates/icn-zk",
+    "crates/job-audit",
 ]
 resolver = "2"
 

--- a/crates/job-audit/Cargo.toml
+++ b/crates/job-audit/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "job-audit"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+icn-common = { path = "../icn-common" }
+icn-identity = { path = "../icn-identity" }
+icn-dag = { path = "../icn-dag", features = ["async"] }
+icn-mesh = { path = "../icn-mesh" }
+icn-runtime = { path = "../icn-runtime", features = ["async"] }
+clap = { version = "4.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/job-audit/src/main.rs
+++ b/crates/job-audit/src/main.rs
@@ -1,0 +1,109 @@
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand};
+use icn_common::{parse_cid_from_string, Cid, Did};
+use icn_identity::{generate_ed25519_keypair, ExecutionReceipt};
+use icn_runtime::context::{DagStoreMutexType, RuntimeContext, StubSigner};
+use icn_runtime::executor::{JobExecutor, SimpleExecutor};
+use icn_runtime::context::mana::SimpleManaLedger;
+use icn_dag::TokioFileDagStore;
+use icn_mesh::{ActualMeshJob, JobId};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::str::FromStr;
+
+#[derive(Parser)]
+#[command(author, version, about = "ICN Job Audit Utility")]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Audit a job by JobId
+    Audit {
+        /// JobId CID string
+        job_id: String,
+        /// Path to DAG directory
+        #[clap(long, default_value = "./dag")] 
+        dag: PathBuf,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Audit { job_id, dag } => audit_job(&job_id, dag).await?,
+    }
+    Ok(())
+}
+
+async fn audit_job(job_id_str: &str, dag_path: PathBuf) -> Result<()> {
+    let cid = parse_cid_from_string(job_id_str)?;
+    let job_id = JobId(cid.clone());
+
+    let dag_store = TokioFileDagStore::new(dag_path)?;
+    let dag_store: Arc<DagStoreMutexType<_>> = Arc::new(DagStoreMutexType::new(dag_store));
+
+    let tmp = tempfile::NamedTempFile::new()?;
+    let ledger = SimpleManaLedger::new(tmp.path().to_path_buf());
+
+    let signer = Arc::new(StubSigner::new());
+    let ctx = RuntimeContext::new_development(
+        Did::from_str("did:key:zAudit")?,
+        signer.clone(),
+        ledger,
+        None,
+        Some(dag_store.clone() as Arc<DagStoreMutexType<_>>),
+    )?;
+
+    let lifecycle = ctx
+        .get_job_status(&job_id)
+        .await?
+        .ok_or_else(|| anyhow!("Job not found"))?;
+    let receipt = lifecycle
+        .receipt
+        .ok_or_else(|| anyhow!("No receipt for job"))?;
+
+    let exec_receipt = ExecutionReceipt {
+        job_id: receipt.job_id.0.clone(),
+        executor_did: receipt.executor_did.clone(),
+        result_cid: receipt.result_cid.clone(),
+        cpu_ms: receipt.cpu_ms,
+        success: receipt.success,
+        sig: receipt.signature.clone(),
+    };
+
+    exec_receipt.verify_with_resolver(&icn_identity::KeyDidResolver)?;
+
+    let spec = lifecycle.job.decode_spec()?;
+    let actual_job = ActualMeshJob {
+        id: lifecycle.job.id.clone(),
+        manifest_cid: lifecycle.job.manifest_cid.clone(),
+        spec,
+        creator_did: lifecycle.job.submitter_did.clone(),
+        cost_mana: lifecycle.job.cost_mana,
+        max_execution_wait_ms: None,
+        signature: icn_identity::SignatureBytes(vec![]),
+    };
+
+    let (sk, _) = generate_ed25519_keypair();
+    let executor = SimpleExecutor::with_context(receipt.executor_did.clone(), sk, ctx.clone());
+    let replay = executor.execute_job(&actual_job).await?;
+
+    let outputs_match = replay.result_cid == exec_receipt.result_cid;
+    let cpu_diff = if replay.cpu_ms > exec_receipt.cpu_ms {
+        replay.cpu_ms - exec_receipt.cpu_ms
+    } else {
+        exec_receipt.cpu_ms - replay.cpu_ms
+    };
+    println!("Job Audit Report");
+    println!("Job: {}", job_id_str);
+    println!("Signature valid: true");
+    println!("Output match: {}", outputs_match);
+    println!("CPU ms recorded: {} | replayed: {} (diff {})", exec_receipt.cpu_ms, replay.cpu_ms, cpu_diff);
+    println!("Success flag: {}", exec_receipt.success);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add new `job-audit` binary crate
- allow auditing job receipts against DAG data

## Testing
- `cargo fmt --all -- --check` *(fails: unexpected closing delimiter)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused import)*
- `cargo test --all-features --workspace` *(terminated)*
- `cargo test -p icn-ccl` *(runs build, warnings, then terminated)*
- `just test-ccl-contracts` *(fails: command not found)*
- `just test-covm-execution` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0467fc748324b4f7971532fdcfec