### PR TITLE
[ccl] add delegation support

### DIFF
--- a/icn-ccl/ccl-lib/assembly_governance.ccl
+++ b/icn-ccl/ccl-lib/assembly_governance.ccl
@@ -24,6 +24,9 @@ struct Delegate {
     weight: Integer
 }
 
+// Stored delegation records
+state delegations: Array<Delegate> = [];
+
 // Core assembly functions
 fn create_assembly_proposal(
     proposer: Did,
@@ -68,7 +71,9 @@ fn delegate_voting_power(
         scope: scope,
         weight: weight
     };
-    
+
+    array_push(delegations, delegation);
+
     return true;
 }
 
@@ -99,9 +104,16 @@ fn vote_on_assembly_proposal(
 }
 
 fn calculate_voting_weight(voter: Did) -> Integer {
-    let base_weight = host_get_reputation();
-    // TODO: Add delegated voting power calculation
-    return base_weight;
+    let total = host_get_reputation();
+    let i = 0;
+    while i < array_len(delegations) {
+        let del = delegations[i];
+        if del.delegate == voter && del.weight <= DELEGATION_LIMIT {
+            total = total + del.weight;
+        }
+        i = i + 1;
+    }
+    return total;
 }
 
 fn finalize_assembly_proposal(proposal: AssemblyProposal) -> Bool {

--- a/icn-ccl/tests/assembly_delegation.rs
+++ b/icn-ccl/tests/assembly_delegation.rs
@@ -1,0 +1,28 @@
+use icn_ccl::compile_ccl_file_to_wasm;
+use wasmtime::{Engine, Linker, Module, Store};
+use std::path::PathBuf;
+
+fn run_contract(path: &str) -> i32 {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path);
+    let (wasm, _) = compile_ccl_file_to_wasm(&path).expect("compile");
+    let engine = Engine::default();
+    let module = Module::new(&engine, &wasm).expect("module");
+    let mut linker = Linker::new(&engine);
+    linker.func_wrap("icn", "host_account_get_mana", || -> i64 { 0 }).unwrap();
+    linker.func_wrap("icn", "host_get_reputation", || -> i64 { 1 }).unwrap();
+    linker.func_wrap("icn", "host_submit_mesh_job", |_: i32, _: i32| {}).unwrap();
+    linker.func_wrap("icn", "host_anchor_receipt", |_: i32, _: i32| {}).unwrap();
+    linker.func_wrap("icn", "host_get_current_time", || -> i64 { 0 }).unwrap();
+    let mut store = Store::new(&engine, ());
+    let instance = linker.instantiate(&mut store, &module).expect("inst");
+    let run = instance.get_typed_func::<(), i32>(&mut store, "run").unwrap();
+    run.call(&mut store, ()).expect("run")
+}
+
+#[test]
+fn delegation_increases_votes() {
+    let with_del = run_contract("tests/contracts/assembly_delegation.ccl");
+    let without_del = run_contract("tests/contracts/assembly_no_delegation.ccl");
+    assert_eq!(with_del, 2);
+    assert_eq!(without_del, 1);
+}

--- a/icn-ccl/tests/contracts/assembly_delegation.ccl
+++ b/icn-ccl/tests/contracts/assembly_delegation.ccl
@@ -1,0 +1,8 @@
+import "../../ccl-lib/assembly_governance.ccl" as Assembly;
+
+fn run() -> Integer {
+    let prop = Assembly.create_assembly_proposal(did:example:alice, "Delegation Test", 10);
+    Assembly.delegate_voting_power(did:example:alice, did:example:bob, "gen", 1);
+    let voted = Assembly.vote_on_assembly_proposal(prop, did:example:bob, "yes");
+    return voted.yes_votes;
+}

--- a/icn-ccl/tests/contracts/assembly_no_delegation.ccl
+++ b/icn-ccl/tests/contracts/assembly_no_delegation.ccl
@@ -1,0 +1,7 @@
+import "../../ccl-lib/assembly_governance.ccl" as Assembly;
+
+fn run() -> Integer {
+    let prop = Assembly.create_assembly_proposal(did:example:alice, "No Delegation", 10);
+    let voted = Assembly.vote_on_assembly_proposal(prop, did:example:bob, "yes");
+    return voted.yes_votes;
+}


### PR DESCRIPTION
## Summary
- persist `Delegate` entries in `assembly_governance.ccl`
- count delegated weights in `calculate_voting_weight`
- add contract examples exercising delegation logic
- add unit test demonstrating weight increase from delegation

## Testing
- `cargo fmt --all -- --check` *(fails: file `icn-ccl/test_all_cooperative_contracts.rs` does not exist)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*
- `cargo test -p icn-ccl --test assembly_delegation -- --nocapture` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_687d54769f248324a1f52866e5448abf