### PR TITLE
[ccl] improve semantic analysis

### DIFF
--- a/icn-ccl/tests/semantic_tests.rs
+++ b/icn-ccl/tests/semantic_tests.rs
@@ -89,3 +89,44 @@ fn test_for_loop_semantics() {
     let res = analyze_ok(src);
     assert!(res.is_ok());
 }
+
+#[test]
+fn test_standalone_struct_usage() {
+    let src = r#"
+        struct Point { x: Integer, y: Integer }
+        fn run() -> Integer {
+            let p = Point { x: 1, y: 2 };
+            return p.x;
+        }
+    "#;
+    let res = analyze_ok(src);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_struct_member_not_found() {
+    let src = "struct P { x: Integer } fn bad() -> Integer { let p = P { x: 1 }; return p.y; }";
+    let res = analyze_ok(src);
+    assert!(matches!(res, Err(CclError::SemanticError(_))));
+}
+
+#[test]
+fn test_const_declaration() {
+    let src = "const ANSWER: Integer = 42; fn run() -> Integer { return ANSWER; }";
+    let res = analyze_ok(src);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_match_pattern_type_error() {
+    let src = "fn run() -> Integer { let v = 1; match v { true => 0, _ => 1 } }";
+    let res = analyze_ok(src);
+    assert!(matches!(res, Err(CclError::TypeMismatchError { .. })));
+}
+
+#[test]
+fn test_enum_definition_usage() {
+    let src = "enum Color { Red, Blue } fn run() -> Integer { let c = Color::Red; match c { Color::Red => 1, _ => 0 } }";
+    let res = analyze_ok(src);
+    assert!(res.is_ok());
+}


### PR DESCRIPTION
## Summary
- validate standalone structs, enums and constants in the semantic analyzer
- perform struct field checks and member lookup
- add pattern type checking logic for `match` statements
- expand semantic analyzer tests for new cases

## Testing
- `cargo fmt --all -- --check` *(fails: file does not exist)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused import, E0502)*
- `cargo test --all-features --workspace` *(fails: missing test binaries)*

------
https://chatgpt.com/codex/tasks/task_e_687d546ed1888324a41bddb77ee0e427