### PR TITLE
Initialize execution monitor and load node capabilities

### DIFF
--- a/crates/icn-node/src/config.rs
+++ b/crates/icn-node/src/config.rs
@@ -138,6 +138,10 @@ pub struct NodeConfig {
     pub key_rotation_days: u64,
     /// Peers this node has joined in a federation.
     pub federation_peers: Vec<String>,
+    /// Capabilities this node advertises for mesh execution.
+    pub executor_capabilities: Vec<String>,
+    /// Federations this node is a member of.
+    pub federations: Vec<String>,
 }
 
 pub(crate) fn default_ledger_backend() -> icn_runtime::context::LedgerBackend {
@@ -279,6 +283,8 @@ impl Default for NodeConfig {
             demo: false,
             key_rotation_days: 90,
             federation_peers: Vec::new(),
+            executor_capabilities: Vec::new(),
+            federations: Vec::new(),
         }
     }
 }

--- a/crates/icn-node/src/node.rs
+++ b/crates/icn-node/src/node.rs
@@ -976,6 +976,16 @@ pub async fn app_router_with_options(
     // Start the executor manager so this node can act as an executor
     rt_ctx.clone().spawn_mesh_executor_manager().await;
 
+    // Populate runtime parameters from node configuration
+    rt_ctx.parameters.insert(
+        "executor_capabilities".to_string(),
+        cfg.executor_capabilities.join(","),
+    );
+    rt_ctx.parameters.insert(
+        "executor_federations".to_string(),
+        cfg.federations.join(","),
+    );
+
     info!("ICN RuntimeContext initialized and JobManager + ExecutorManager spawned.");
 
     let config = Arc::new(TokioMutex::new(cfg.clone()));

--- a/crates/icn-runtime/src/context/runtime_context.rs
+++ b/crates/icn-runtime/src/context/runtime_context.rs
@@ -919,7 +919,7 @@ impl RuntimeContext {
     /// Create a new RuntimeContext from a service configuration.
     /// This is the preferred method as it ensures type-safe service mapping.
     pub fn from_service_config(config: ServiceConfig) -> Result<Arc<Self>, CommonError> {
-        // TODO: Initialize execution monitor logger
+        icn_runtime::execution_monitor::init_logger();
         // Validate the configuration before using it
         config.validate()?;
 
@@ -3715,8 +3715,16 @@ impl RuntimeContext {
                 memory_mb: available_memory,
                 storage_mb: 0,
             },
-            executor_capabilities: vec![], // TODO: Get from node config
-            executor_federations: vec![],  // TODO: Get from node federation
+            executor_capabilities: ctx
+                .parameters
+                .get("executor_capabilities")
+                .map(|v| v.value().split(',').map(|s| s.to_string()).collect())
+                .unwrap_or_default(),
+            executor_federations: ctx
+                .parameters
+                .get("executor_federations")
+                .map(|v| v.value().split(',').map(|s| s.to_string()).collect())
+                .unwrap_or_default(),
             executor_trust_scope: ctx
                 .parameters
                 .get("executor_trust_scope")
@@ -3880,8 +3888,16 @@ impl RuntimeContext {
                 memory_mb: available_memory,
                 storage_mb: 0,
             },
-            executor_capabilities: vec![], // TODO: Get from node config
-            executor_federations: vec![],  // TODO: Get from node federation
+            executor_capabilities: ctx
+                .parameters
+                .get("executor_capabilities")
+                .map(|v| v.value().split(',').map(|s| s.to_string()).collect())
+                .unwrap_or_default(),
+            executor_federations: ctx
+                .parameters
+                .get("executor_federations")
+                .map(|v| v.value().split(',').map(|s| s.to_string()).collect())
+                .unwrap_or_default(),
             executor_trust_scope: ctx
                 .parameters
                 .get("executor_trust_scope")
@@ -3951,7 +3967,7 @@ impl RuntimeContext {
         job: &ActualMeshJob,
         _agreed_cost: u64, // Marked as unused for now
     ) -> Result<icn_identity::ExecutionReceipt, HostAbiError> {
-        // TODO: Clear execution logs
+        icn_runtime::execution_monitor::clear_logs();
         let job_id = &job.id;
         let executor_did = ctx.current_identity.clone();
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -239,6 +239,13 @@ The InterCooperative Network (ICN) Core is designed as a modular, distributed sy
 
 **Dependencies**: All domain crates, WASM runtime
 
+**Runtime Initialization Steps**:
+1. `NodeConfig` is loaded and environment overrides are applied.
+2. A `ServiceConfig` is constructed with networking, storage and signing services.
+3. `RuntimeContext::from_service_config` initializes the execution monitor logger and builds the cross-component coordinator.
+4. Executor capabilities and federation memberships from `NodeConfig` populate runtime parameters.
+5. Job and executor managers are started to process work.
+
 ### Service Layer
 
 #### `icn-api`


### PR DESCRIPTION
## Summary
- hook up execution monitor logger during runtime startup
- clear execution logs before executing a job
- pull executor capabilities and federations from node config
- document runtime initialization steps

## Testing
- `cargo test -p icn-runtime` *(fails: could not compile `icn-network`)*

------
https://chatgpt.com/codex/tasks/task_e_687f0079adb0832496ca8fb3c3195fb5