### PR TITLE
Add docs for advanced sync, voting, and tools

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -86,6 +86,8 @@
 #### **Networking & Computation (78% Complete)**
 - **[crates/icn-network/README.md](crates/icn-network/README.md)** - P2P networking with libp2p
 - **[crates/icn-mesh/README.md](crates/icn-mesh/README.md)** - Distributed job execution
+- **[docs/synchronization/CRDT_SYNC.md](docs/synchronization/CRDT_SYNC.md)** - Real-time CRDT sync
+- **[docs/federation/DAG_SYNC_PROTOCOL.md](docs/federation/DAG_SYNC_PROTOCOL.md)** - Federation DAG sync protocol
 
 #### **Developer Tools & SDKs (90% Complete)**
 - **[crates/icn-cli/README.md](crates/icn-cli/README.md)** - Command-line interface
@@ -93,6 +95,7 @@
 - **[crates/icn-sdk/README.md](crates/icn-sdk/README.md)** - High-level Rust SDK
 - **[crates/icn-templates/README.md](crates/icn-templates/README.md)** - Template management
 - **[crates/job-audit/README.md](crates/job-audit/README.md)** - Job auditing
+- **[docs/developer_tools/CCL_LSP.md](docs/developer_tools/CCL_LSP.md)** - CCL language server
 
 ---
 
@@ -110,6 +113,7 @@
 - **[packages/ui-kit/README.md](packages/ui-kit/README.md)** - Cross-platform component library
 - **[packages/ts-sdk/README.md](packages/ts-sdk/README.md)** - TypeScript SDK
 - **[packages/ccl-visual-editor/README.md](packages/ccl-visual-editor/README.md)** - Visual contract editor
+- **[docs/i18n/README.md](docs/i18n/README.md)** - Internationalization guide
 
 ---
 
@@ -125,6 +129,7 @@
 - **[docs/ccl/ccl_wasm_tasks.md](docs/ccl/ccl_wasm_tasks.md)** - CCL WASM backend implementation
 - **[docs/ccl/ccl_visual_editor_plan.md](docs/ccl/ccl_visual_editor_plan.md)** - Visual editor plan
 - **[docs/CCL_INTEGRATION_SUMMARY.md](docs/CCL_INTEGRATION_SUMMARY.md)** - CCL integration status
+- **[docs/governance/ADVANCED_VOTING.md](docs/governance/ADVANCED_VOTING.md)** - Ranked choice and quadratic voting
 
 ---
 
@@ -153,6 +158,7 @@
 
 ### **Security & Validation**
 - **[docs/SECURITY.md](docs/SECURITY.md)** - Security patterns and validation
+- **[docs/security/ZKP_INTEGRATION.md](docs/security/ZKP_INTEGRATION.md)** - Zero-knowledge proof flows
 - **[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** - Comprehensive troubleshooting
 
 ---

--- a/docs/developer_tools/CCL_LSP.md
+++ b/docs/developer_tools/CCL_LSP.md
@@ -1,0 +1,27 @@
+# CCL Language Server Protocol
+
+> **⚠️ Development Status**: The CCL LSP is functional but under active development. Expect breaking changes.
+
+This document describes how to use the Cooperative Contract Language (CCL) language server, its architecture, and tips for debugging contract development.
+
+## Usage
+
+Run the language server from the `icn-ccl` crate:
+
+```bash
+cargo run -p icn-ccl --bin ccl_lsp
+```
+
+Configure your editor to connect to the server on the provided port. The server offers syntax highlighting, diagnostics, and contract completion suggestions.
+
+## Architecture Overview
+
+The LSP communicates with the CCL compiler to parse and analyze source files. Diagnostics are generated from the semantic analyzer and returned through standard LSP messages. See `icn-ccl/src/lsp/` for implementation details.
+
+## Debugging Tips
+
+* Run the server with `RUST_LOG=debug` to see internal messages.
+* Use the `--stdio` flag to connect via standard input/output.
+* If diagnostics seem incorrect, run `cargo test -p icn-ccl tests/test_developer_tooling.rs` to verify expected behavior.
+
+Development contributions are welcome as we stabilize the tooling.

--- a/docs/federation/DAG_SYNC_PROTOCOL.md
+++ b/docs/federation/DAG_SYNC_PROTOCOL.md
@@ -1,0 +1,13 @@
+# Federation DAG Synchronization Protocol
+
+> **⚠️ Development Status**: The federation DAG sync process is evolving and may change in future releases.
+
+Federated nodes exchange content-addressed updates using a directed acyclic graph (DAG) store. Each node maintains a local DAG and periodically syncs with peers.
+
+## Sync Process
+
+1. **Exchange Heads** – Peers share the latest known DAG heads.
+2. **Request Missing Blocks** – Nodes request blocks absent from their local store.
+3. **Conflict Resolution** – Divergent histories are merged using deterministic rules defined in `crates/icn-dag/src/conflict_resolution.rs`.
+
+This protocol allows autonomous communities to collaborate while keeping local control of data.

--- a/docs/governance/ADVANCED_VOTING.md
+++ b/docs/governance/ADVANCED_VOTING.md
@@ -1,0 +1,17 @@
+# Advanced Voting Mechanisms
+
+> **⚠️ Development Status**: Experimental implementations for advanced voting are available. Interfaces may change.
+
+This guide outlines advanced governance voting systems supported by ICN Core.
+
+## Ranked Choice Voting
+
+Voters rank proposals by preference. The tallying algorithm iteratively eliminates the lowest-ranked option until a majority winner emerges. See `icn-governance/src/ranked_choice.rs` for implementation details.
+
+## Quadratic Voting
+
+Participants allocate voting credits quadratically to express intensity of preference. This mechanism reduces the influence of large stakeholders and encourages consensus.
+
+## Other Mechanisms
+
+Additional strategies such as approval voting and score voting can be implemented via CCL contracts. Experimentation is encouraged to determine what best fits your cooperative.

--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -1,0 +1,17 @@
+# Internationalization Guide
+
+> **⚠️ Development Status**: Localization support is in the early stages. Expect limited language coverage.
+
+This guide explains how to enable multiple languages in ICN Core applications and how we approach accessibility.
+
+## Setup
+
+Localization files live under `apps/*/locales/`. Add new language JSON files following the existing format. Update the `i18n` configuration in each frontend app to register the new locale.
+
+## Accessibility
+
+* Ensure UI components have appropriate ARIA labels.
+* Test color contrast and keyboard navigation.
+* Provide alternative text for all images.
+
+Community contributions are welcome to expand language support and improve accessibility practices.

--- a/docs/security/ZKP_INTEGRATION.md
+++ b/docs/security/ZKP_INTEGRATION.md
@@ -1,0 +1,19 @@
+# Zero-Knowledge Proof Integration
+
+> **⚠️ Development Status**: Zero-knowledge workflows are prototype quality. Use in test environments only.
+
+ICN Core integrates zero-knowledge proofs (ZKPs) for privacy-preserving authentication and data validation.
+
+## Proof Flow
+
+1. A proving client generates a proof using the circuits in `crates/icn-zk/`.
+2. The proof is submitted to the runtime for verification.
+3. Verified proofs grant access or validate transactions without revealing sensitive data.
+
+## Security Considerations
+
+* Audit circuits carefully for side-channel leaks.
+* Ensure trusted setup parameters are distributed securely.
+* Monitor verification costs to prevent denial-of-service vectors.
+
+Production deployment will require extensive security review and benchmarking.

--- a/docs/synchronization/CRDT_SYNC.md
+++ b/docs/synchronization/CRDT_SYNC.md
@@ -1,0 +1,15 @@
+# CRDT Synchronization
+
+> **⚠️ Development Status**: These notes describe real-time synchronization plans. Implementations are experimental.
+
+ICN Core uses Conflict-free Replicated Data Types (CRDTs) to synchronize state across federation nodes. Gossip-based protocols exchange CRDT updates to eventually reach convergence.
+
+## Real-Time Sync Protocols
+
+1. **Gossip Broadcast** – Nodes periodically broadcast deltas to peers using libp2p gossipsub.
+2. **State Vector Exchange** – Peers compare vector clocks to request missing operations.
+3. **Compression** – Batch multiple operations into a single message for efficiency.
+
+The CRDT modules live in `crates/icn-crdt/` and integrate with the DAG store for persistence.
+
+Further improvements will focus on reducing bandwidth and handling network partitions gracefully.


### PR DESCRIPTION
## Summary
- document CCL LSP usage and debugging
- document CRDT sync protocols
- document advanced voting mechanisms
- document DAG federation sync
- document ZKP integration
- add i18n guide
- link new docs from DOCUMENTATION_INDEX

## Testing
- `just docs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688312efb0b083248da59c8b1f761fc2